### PR TITLE
Disable cloud trace for envoy prototype.

### DIFF
--- a/src/envoy/prototype/server_config.pb.txt
+++ b/src/envoy/prototype/server_config.pb.txt
@@ -1,3 +1,6 @@
+cloud_tracing_config {
+  force_disable: true
+}
 mixer_options {
   mixer_server: "mixer_server"
 }


### PR DESCRIPTION
To prevent envoy crush if removing api_manager cluster from envoy-esp.conf.