### PR TITLE
Copies the binary instead of linking for release

### DIFF
--- a/script/release-binary
+++ b/script/release-binary
@@ -38,7 +38,7 @@ gsutil stat "${DST}/${BINARY_NAME}" \
 # Build the binary
 bazel build -c dbg //src/envoy/mixer:envoy_tar
 BAZEL_TARGET="bazel-bin/src/envoy/mixer/envoy_tar.tar.gz"
-ln "${BAZEL_TARGET}" "${BINARY_NAME}"
+cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
 # Copy it to the bucket.


### PR DESCRIPTION
Jenkins slave have been change to use a cache for Bazel. bazel artifacst are now on a different device which makes hard link impossible.