### PR TITLE
Not call report if decodeHeaders is not called.

### DIFF
--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -242,6 +242,8 @@ class Instance : public Http::StreamFilter, public Http::AccessLog::Instance {
                    const HeaderMap* response_headers,
                    const AccessLog::RequestInfo& request_info) override {
     Log().debug("Called Mixer::Instance : {}", __func__);
+    // If decodeHaeders() is not called, not to call Mixer report.
+    if (!request_data_) return;
     // Make sure not to use any class members at the callback.
     // The class may be gone when it is called.
     // Log() is a static function so it is OK.


### PR DESCRIPTION
Somehow there are cases where decode() is not called, only encode() and log() are called.  Here is the log

[2017-03-07 18:19:59.283][5][info][main] [C7] new connection
[2017-03-07 18:19:59.296][5][debug][http] Called Mixer::Instance : Instance
[2017-03-07 18:19:59.296][5][debug][http] Called Mixer::Instance : setDecoderFilterCallbacks
[2017-03-07 18:19:59.296][5][debug][http] Called Mixer::Instance : setEncoderFilterCallbacks
[2017-03-07 18:19:59.296][5][debug][http] Called Mixer::Instance : encodeHeaders
[2017-03-07 18:19:59.296][5][debug][http] Called Mixer::Instance : log
