### PR TITLE
Fix a bug in opaque config change and test it out

### DIFF
--- a/src/envoy/mixer/README.md
+++ b/src/envoy/mixer/README.md
@@ -46,14 +46,13 @@ This Proxy will use Envoy and talk to Mixer server.
 * Then issue HTTP request to proxy.
 
 ```
+  # request to server-side proxy
   curl http://localhost:9090/echo -d "hello world"
+  # request to client-side proxy that gets sent to server-side proxy
+  curl http://localhost:7070/echo -d "hello world"
 ```
 
 ## How to configurate HTTP filters
-
-This module has two HTTP filters:
-1. mixer filter: intercept all HTTP requests, call the mixer.
-2. forward_attribute filter: Forward attributes to the upstream istio/proxy.
 
 ### *mixer* filter:
 
@@ -65,7 +64,11 @@ This filter will intercept all HTTP requests and call Mixer. Here is its config:
       "name": "mixer",
       "config": {
          "mixer_server": "${MIXER_SERVER}",
-         "attributes" : {
+         "mixer_attributes" : {
+            "attribute_name1": "attribute_value1",
+            "attribute_name2": "attribute_value2"
+         },
+         "forward_attributes" : {
             "attribute_name1": "attribute_value1",
             "attribute_name2": "attribute_value2"
          }
@@ -74,26 +77,8 @@ This filter will intercept all HTTP requests and call Mixer. Here is its config:
 
 Notes:
 * mixer_server is required
-* attributes: these attributes will be send to the mixer
-
-### *forward_attribute* HTTP filter:
-
-This filer will forward attributes to the upstream istio/proxy.
-
-```
-   "filters": [
-      "type": "decoder",
-      "name": "forward_attribute",
-      "config": {
-         "attributes": {
-            "attribute_name1": "attribute_value1",
-            "attribute_name2": "attribute_value2"
- 	    }
-    }
-```
-
-Notes:
-* attributes: these attributes will be forwarded to the upstream istio/proxy.
+* mixer_attributes: these attributes will be send to the mixer
+* forward_attributes: these attributes will be forwarded to the upstream istio/proxy.
 
 
 

--- a/src/envoy/mixer/README.md
+++ b/src/envoy/mixer/README.md
@@ -60,7 +60,7 @@ This filter will intercept all HTTP requests and call Mixer. Here is its config:
 
 ```
    "filters": [
-      "type": "both",
+      "type": "decoder",
       "name": "mixer",
       "config": {
          "mixer_server": "${MIXER_SERVER}",

--- a/src/envoy/mixer/README.md
+++ b/src/envoy/mixer/README.md
@@ -80,5 +80,13 @@ Notes:
 * mixer_attributes: these attributes will be send to the mixer
 * forward_attributes: these attributes will be forwarded to the upstream istio/proxy.
 
+By default, mixer filter forwards attributes and does not invoke mixer server. You can customize this behavior per HTTP route by supplying an opaque config:
 
+```
+    "opaque_config": {
+      "mixer_control": "on",
+      "mixer_forward": "off"
+    }
+```
 
+This config reverts the behavior by sending requests to mixer server but not forwarding any attributes.

--- a/src/envoy/mixer/envoy.conf.template
+++ b/src/envoy/mixer/envoy.conf.template
@@ -19,7 +19,11 @@
                     {
                       "timeout_ms": 0,
                       "prefix": "/",
-                      "cluster": "service1"
+                      "cluster": "service1",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
                     }
                   ]
                 }
@@ -32,11 +36,11 @@
             ],
             "filters": [
               {
-                "type": "both",
+                "type": "decoder",
                 "name": "mixer",
                 "config": {
                   "mixer_server": "${MIXER_SERVER}",
-                  "attributes": {
+                  "mixer_attributes": {
                       "target.uid": "POD222",
                       "target.namespace": "XYZ222"
                   }
@@ -85,9 +89,10 @@
             "filters": [
               {
                 "type": "decoder",
-                "name": "forward_attribute",
+                "name": "mixer",
                 "config": {
-                   "attributes": {
+                   "mixer_server": "${MIXER_SERVER}",
+                   "forward_attributes": {
                       "source.uid": "POD11",
                       "source.namespace": "XYZ11"
                    }

--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -263,10 +263,8 @@ class Instance : public Http::StreamDecoderFilter,
       StreamDecoderFilterCallbacks& callbacks) override {
     Log().debug("Called Mixer::Instance : {}", __func__);
     decoder_callbacks_ = &callbacks;
-    if (!mixer_disabled()) {
-      decoder_callbacks_->addResetStreamCallback(
-          [this]() { state_ = Responded; });
-    }
+    decoder_callbacks_->addResetStreamCallback(
+        [this]() { state_ = Responded; });
   }
 
   void completeCheck(const Status& status) {


### PR DESCRIPTION
Note that we need to define `mixer_server` on the client side. We need to do a follow-up to make that config optional.