### PR TITLE
Allow for HTTP based function from Firebase rules

### DIFF
--- a/contrib/endpoints/src/api_manager/BUILD
+++ b/contrib/endpoints/src/api_manager/BUILD
@@ -118,6 +118,7 @@ cc_library(
         "//contrib/endpoints/src/api_manager/context",
         "//contrib/endpoints/src/api_manager/service_control",
         "//contrib/endpoints/src/api_manager/utils",
+        "//contrib/endpoints/src/api_manager/firebase_rules",
         "//external:cc_wkt_protos",
         "//external:cloud_trace",
         "//external:googletest_prod",
@@ -291,6 +292,8 @@ cc_test(
     deps = [
         ":api_manager",
         ":mock_api_manager_environment",
+        ":security_rules_proto",
+        "//external:cc_wkt_protos",
         "//external:googletest_main",
     ],
 )

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.h
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.h
@@ -65,6 +65,7 @@ class ServiceAccountToken {
     JWT_TOKEN_FOR_SERVICE_CONTROL = 0,
     JWT_TOKEN_FOR_CLOUD_TRACING,
     JWT_TOKEN_FOR_FIREBASE,
+    JWT_TOKEN_FOR_AUTHORIZATION_SERVICE,
     JWT_TOKEN_TYPE_MAX,
   };
   // Set audience.  Only calcualtes JWT token with specified audience.

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.h
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.h
@@ -65,6 +65,8 @@ class ServiceAccountToken {
     JWT_TOKEN_FOR_SERVICE_CONTROL = 0,
     JWT_TOKEN_FOR_CLOUD_TRACING,
     JWT_TOKEN_FOR_FIREBASE,
+
+    // JWT token for accessing the http endpoints defined in Firebase Rules.
     JWT_TOKEN_FOR_AUTHORIZATION_SERVICE,
     JWT_TOKEN_TYPE_MAX,
   };

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -28,17 +28,18 @@ namespace google {
 namespace api_manager {
 namespace {
 
-const char kFailedFirebaseReleaseFetch[] = "Failed to fetch Firebase Release";
-const char kFailedFirebaseTest[] = "Failed to execute Firebase Test";
-const char kInvalidResponse[] = "Invalid JSON response from Firebase Service";
-const char kV1[] = "/v1";
-const char kHttpGetMethod[] = "GET";
-const char kProjects[] = "/projects";
-const char kReleases[] = "/releases";
-const char kRulesetName[] = "rulesetName";
-const char kTestResults[] = "testResults";
-const char kContentType[] = "Content-Type";
-const char kApplication[] = "application/json";
+const std::string kFailedFirebaseReleaseFetch =
+    "Failed to fetch Firebase Release";
+const std::string kFailedFirebaseTest = "Failed to execute Firebase Test";
+const std::string kInvalidResponse =
+    "Invalid JSON response from Firebase Service";
+const std::string kV1 = "/v1";
+const std::string kHttpGetMethod = "GET";
+const std::string kProjects = "/projects";
+const std::string kReleases = "/releases";
+const std::string kRulesetName = "rulesetName";
+const std::string kContentType = "Content-Type";
+const std::string kApplication = "application/json";
 
 std::string GetReleaseName(const context::RequestContext &context) {
   return context.service_context()->service_name() + ":" +
@@ -168,7 +169,7 @@ Status AuthzChecker::ParseReleaseResponse(const std::string &json_str,
   }
 
   Status status = Status::OK;
-  const char *id = GetStringValue(json, kRulesetName);
+  const char *id = GetStringValue(json, kRulesetName.c_str());
   *ruleset_id = (id == nullptr) ? "" : id;
 
   if (ruleset_id->empty()) {

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -140,7 +140,7 @@ void AuthzChecker::Check(
 
 void AuthzChecker::CallNextRequest(
     std::function<void(Status status)> continuation) {
-  if (request_->IsDone()) {
+  if (request_->is_done()) {
     continuation(request_->RequestStatus());
     return;
   }

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -68,7 +68,7 @@ class AuthzChecker : public std::enable_shared_from_this<AuthzChecker> {
   // defined endpoints provided by the TestRulesetResponse.
   void CallNextRequest(std::function<void(Status status)> continuation);
 
-  // Parse the respose for GET RELEASE API call
+  // Parse the response for GET RELEASE API call
   Status ParseReleaseResponse(const std::string &json_str,
                               std::string *ruleset_id);
 

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -64,7 +64,8 @@ class AuthzChecker : public std::enable_shared_from_this<AuthzChecker> {
              std::function<void(Status status)> continuation);
 
  private:
-  // Helper method that invokes Http requests for firebase rules.
+  // This method invokes the Firebase TestRuleset API endpoint as well as user
+  // defined endpoints provided by the TestRulesetResponse.
   void CallNextRequest(std::function<void(Status status)> continuation);
 
   // Parse the respose for GET RELEASE API call

--- a/contrib/endpoints/src/api_manager/check_security_rules_test.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules_test.cc
@@ -397,7 +397,7 @@ class CheckSecurityRulesTest : public ::testing::Test {
                      const ::google::protobuf::Value &value,
                      ::google::protobuf::Value *head) {
     ::google::protobuf::Struct *s = head->mutable_struct_value();
-    Map<std::string, google::protobuf::Value> *fields = s->mutable_fields();
+    auto *fields = s->mutable_fields();
     (*fields)[key] = value;
   }
 

--- a/contrib/endpoints/src/api_manager/context/request_context.h
+++ b/contrib/endpoints/src/api_manager/context/request_context.h
@@ -42,7 +42,7 @@ class RequestContext {
   }
 
   // Get the request object.
-  Request *request() { return request_.get(); }
+  Request *request() const { return request_.get(); }
 
   // Get the method info.
   const MethodInfo *method() const { return method_call_.method_info; }
@@ -116,7 +116,7 @@ class RequestContext {
 
   void set_auth_claims(const std::string &claims) { auth_claims_ = claims; }
 
-  const std::string &auth_claims() { return auth_claims_; }
+  const std::string &auth_claims() const { return auth_claims_; }
 
  private:
   // Fill OperationInfo

--- a/contrib/endpoints/src/api_manager/context/service_context.cc
+++ b/contrib/endpoints/src/api_manager/context/service_context.cc
@@ -76,6 +76,18 @@ ServiceContext::ServiceContext(std::unique_ptr<ApiManagerEnvInterface> env,
 
   service_account_token_.SetAudience(
       auth::ServiceAccountToken::JWT_TOKEN_FOR_FIREBASE, kFirebaseAudience);
+
+  if (config_->server_config() &&
+      !config_->server_config()
+           ->api_check_security_rules_config()
+           .authorization_service_audience()
+           .empty()) {
+    service_account_token_.SetAudience(
+        auth::ServiceAccountToken::JWT_TOKEN_FOR_AUTHORIZATION_SERVICE,
+        config_->server_config()
+            ->api_check_security_rules_config()
+            .authorization_service_audience());
+  }
 }
 
 MethodCallInfo ServiceContext::GetMethodCallInfo(

--- a/contrib/endpoints/src/api_manager/firebase_rules/BUILD
+++ b/contrib/endpoints/src/api_manager/firebase_rules/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/contrib/endpoints/src/api_manager/firebase_rules/BUILD
+++ b/contrib/endpoints/src/api_manager/firebase_rules/BUILD
@@ -1,0 +1,41 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+package(default_visibility = ["//contrib/endpoints/src/api_manager:__subpackages__"])
+
+cc_library(
+    name = "firebase_rules",
+    srcs = [
+        "firebase_request.cc",
+    ],
+    hdrs = [
+        "firebase_request.h",
+    ],
+    linkopts = select({
+        "//:darwin": [],
+        "//conditions:default": [
+            "-lm",
+            "-luuid",
+        ],
+    }),
+    deps = [
+        "//contrib/endpoints/src/api_manager:security_rules_proto",
+        "//contrib/endpoints/src/api_manager/context",
+        "//contrib/endpoints/src/api_manager/utils",
+        "//external:cc_wkt_protos",
+        "//external:googletest_prod",
+    ],
+)

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
@@ -81,7 +81,6 @@ FirebaseRequest::FirebaseRequest(
     : env_(env),
       context_(context),
       ruleset_name_(ruleset_name),
-      service_name_(context->service_context()->service_name()),
       firebase_server_(
           context->service_context()->config()->GetFirebaseServer()),
       current_status_(Status::OK),

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
@@ -1,0 +1,405 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+#include "contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h"
+#include "contrib/endpoints/src/api_manager/utils/marshalling.h"
+#include "contrib/endpoints/src/api_manager/utils/url_util.h"
+#include "google/protobuf/util/message_differencer.h"
+
+#include <algorithm>
+#include <sstream>
+using ::google::api_manager::utils::Status;
+using ::google::api_manager::proto::TestRulesetResponse;
+using ::google::protobuf::util::MessageDifferencer;
+using ::google::protobuf::Map;
+
+namespace google {
+namespace api_manager {
+namespace firebase_rules {
+
+namespace {
+
+const char kToken[] = "token";
+const char kAuth[] = "auth";
+const char kPath[] = "path";
+const char kMethod[] = "method";
+const char kHttpGetMethod[] = "GET";
+const char kHttpPostMethod[] = "POST";
+const char kHttpHeadMethod[] = "HEAD";
+const char kHttpOptionsMethod[] = "OPTIONS";
+const char kHttpDeleteMethod[] = "DELETE";
+const char kFirebaseCreateMethod[] = "create";
+const char kFirebaseGetMethod[] = "get";
+const char kFirebaseDeleteMethod[] = "delete";
+const char kFirebaseUpdateMethod[] = "update";
+const char kV1[] = "/v1";
+const char kTestQuery[] = ":test?alt=json";
+
+void SetProtoValue(const std::string &key,
+                   const ::google::protobuf::Value &value,
+                   ::google::protobuf::Value *head) {
+  ::google::protobuf::Struct *s = head->mutable_struct_value();
+  Map<std::string, google::protobuf::Value> *fields = s->mutable_fields();
+  (*fields)[key] = value;
+}
+
+// Convert HTTP method to Firebase specific method.
+std::string GetOperation(const std::string &httpMethod) {
+  if (httpMethod == kHttpPostMethod) {
+    return kFirebaseCreateMethod;
+  }
+
+  if (httpMethod == kHttpGetMethod
+      || httpMethod == kHttpHeadMethod
+      || httpMethod == kHttpOptionsMethod) {
+    return kFirebaseGetMethod;
+  }
+
+  if (httpMethod == kHttpDeleteMethod) {
+    return kFirebaseDeleteMethod;
+  }
+
+  return kFirebaseUpdateMethod;
+}
+
+}
+
+// Constructor
+FirebaseRequest::FirebaseRequest(
+    const std::string &ruleset_name, ApiManagerEnvInterface *env,
+    std::shared_ptr<context::RequestContext> context)
+  : env_(env),
+    context_(context),
+    ruleset_name_(ruleset_name),
+    service_name_(context->service_context()->service_name()),
+    firebase_server_(context->service_context()->config()->GetFirebaseServer()),
+    current_status_(Status::OK),
+    is_done_(false),
+    next_request_(nullptr) {
+
+  firebase_http_request_.url =
+      firebase_server_ + kV1 + "/" + ruleset_name + kTestQuery;
+  firebase_http_request_.method = kHttpPostMethod;
+  firebase_http_request_.token_type =
+      auth::ServiceAccountToken::JWT_TOKEN_FOR_FIREBASE;
+  external_http_request_.token_type =
+      auth::ServiceAccountToken::JWT_TOKEN_FOR_AUTHORIZATION_SERVICE;
+
+  // Update the first request to be sent which is the TestRulesetRequest
+  // request.
+  SetStatus(UpdateRulesetRequestBody(RepeatedPtrField<FunctionCall>()));
+  if (!current_status_.ok()) {
+    return;
+  }
+
+  next_request_ = &firebase_http_request_;
+}
+
+bool FirebaseRequest::IsDone() {
+  return is_done_;
+}
+
+HttpRequest FirebaseRequest::GetHttpRequest() {
+  if (IsDone()) {
+    return HttpRequest();
+  }
+
+  if (next_request_ == nullptr) {
+    SetStatus(Status(Code::INTERNAL, "Internal state in error"));
+    return HttpRequest();
+  }
+
+  return *next_request_;
+}
+
+Status FirebaseRequest::RequestStatus() {
+  return current_status_;
+}
+
+void FirebaseRequest::UpdateResponse(const std::string &body) {
+  if (IsDone()) {
+    env_->LogError("Receive a response body when no HTTP request is outstanding");
+    return;
+  }
+
+  if (next_request_ == nullptr) {
+    env_->LogError("Received a response when there is no request set"
+                   "and when IsDone is false." " Looks like a code bug...");
+    SetStatus(Status(Code::INTERNAL,
+                     "Internal state error while processing Http request"));
+    return;
+  }
+
+  Status status = Status::OK;
+
+  // If the previous request was firebase request, then process its response.
+  // Otherwise, it is the response for external HTTP request.
+  if (next_request_ == &firebase_http_request_) {
+    status = ProcessTestRulesetResponse(body);
+  } else {
+    status = ProcessFunctionCallResponse(body);
+  }
+
+  if (status.ok()) {
+    status = SetNextRequest();
+  }
+
+  SetStatus(status);
+  return;
+}
+
+void FirebaseRequest::SetStatus(const Status &status) {
+  if (!status.ok() && !is_done_) {
+    current_status_ = status;
+    is_done_ = true;
+  }
+}
+
+// Create the TestRulesetRequest body.
+Status FirebaseRequest::UpdateRulesetRequestBody(
+    const RepeatedPtrField<FunctionCall> &function_calls) {
+
+  proto::TestRulesetRequest request;
+  auto test_case = request.mutable_test_suite()->add_test_cases();
+  test_case->set_expectation(proto::TestCase::ALLOW);
+
+  ::google::protobuf::Value token;
+  ::google::protobuf::Value claims;
+  ::google::protobuf::Value path;
+  ::google::protobuf::Value method;
+
+  Status status = utils::JsonToProto(context_->auth_claims(), &claims);
+  if (!status.ok()) {
+    return status;
+  }
+
+  auto *variables = test_case->mutable_request()->mutable_struct_value();
+  auto *fields = variables->mutable_fields();
+
+  path.set_string_value(context_->request()->GetRequestPath());
+  (*fields)[kPath] = path;
+
+  method.set_string_value(GetOperation(
+    context_->request()->GetRequestHTTPMethod()));
+  (*fields)[kMethod] = method;
+
+  SetProtoValue(kToken, claims, &token);
+  (*fields)[kAuth] = token;
+
+  for (auto func_call : function_calls) {
+    status = AddFunctionMock(&request, func_call);
+    if (!status.ok()) {
+      return status;
+    }
+  }
+
+  std::string body;
+  status = utils::ProtoToJson(request, &body,
+                            utils::JsonOptions::DEFAULT);
+  if (status.ok()) {
+    env_->LogDebug(std::string("FIREBASE REQUEST BODY = ") + body);
+    firebase_http_request_.body = body;
+  }
+
+  return status;
+}
+
+Status FirebaseRequest::ProcessTestRulesetResponse(const std::string& body) {
+  Status status = utils::JsonToProto(body, &response_);
+  if (!status.ok()) {
+    return status;
+  }
+
+  // If the state is SUCCESS, then we don't need to do any further processing.
+  if (response_.test_results(0).state() ==
+      TestRulesetResponse::TestResult::SUCCESS) {
+    is_done_ = true;
+    next_request_ = nullptr;
+    return Status::OK;
+  }
+
+  // Check that the test results size is 1 since we always send a single test
+  // case.
+  if (response_.test_results_size() != 1) {
+    std::ostringstream oss;
+    oss << "Received TestResultsetResponse with size = "
+        << response_.test_results_size() << " expecting only 1 test result";
+
+    env_->LogError(oss.str());
+    return Status(Code::INTERNAL, "Unexpected TestResultsetResponse");
+  }
+
+  bool allFunctionsProcessed = true;
+
+  // Iterate over all the function calls and make sure that the function calls
+  // are well formed.
+  for (auto func_call : response_.test_results(0).function_calls()) {
+    status = CheckFuncCallArgs(func_call);
+    if (!status.ok()) {
+      return status;
+    }
+    allFunctionsProcessed &= Find(func_call) != funcs_with_result_.end();
+  }
+
+  // Since all the functions have a response and the state is FAILURE, this
+  // means Unauthorized access to the resource.
+  if (allFunctionsProcessed) {
+    std::string message = "Unauthorized Access";
+    if (response_.test_results(0).debug_messages_size() > 0) {
+      std::ostringstream oss;
+      for (std::string msg : response_.test_results(0).debug_messages()) {
+        oss << msg << " ";
+      }
+      message = oss.str();
+    }
+
+    return Status(Code::PERMISSION_DENIED, message);
+  }
+
+  func_call_iter_ = response_.test_results(0).function_calls().begin();
+  return Status::OK;
+}
+
+std::vector<std::pair<FunctionCall, std::string>>::const_iterator
+FirebaseRequest::Find(const FunctionCall &func_call) {
+  return std::find_if(funcs_with_result_.begin(), funcs_with_result_.end(),
+                   [func_call](std::tuple<FunctionCall, std::string> item) {
+                     return MessageDifferencer::Equals(std::get<0>(item),
+                                                         func_call);
+                   });
+}
+
+Status FirebaseRequest::ProcessFunctionCallResponse(const std::string &body) {
+  if (IsDone() || AllFunctionCallsProcessed()) {
+      return Status(Code::INTERNAL, "No external function calls present."
+                               " But received a response. Possible code bug");
+    }
+
+  funcs_with_result_.emplace_back(*func_call_iter_, body);
+  func_call_iter_++;
+  return Status::OK;
+}
+
+// Sets the next HTTP request that should be issued.
+Status FirebaseRequest::SetNextRequest() {
+  if (IsDone()) {
+    next_request_ = nullptr;
+    return current_status_;
+  }
+
+  Status status = Status::OK;
+
+  // While there are more functions that should be processed, check if the HTTP
+  // response for the function is already buffered. Set the next HTTP request if
+  // we find a new function and break.
+  while (!AllFunctionCallsProcessed()) {
+
+    if (Find(*func_call_iter_) == funcs_with_result_.end()) {
+      auto call = *func_call_iter_;
+      external_http_request_.url = call.args(0).string_value();
+      external_http_request_.method = call.args(1).string_value();
+      std::string body;
+      status = utils::ProtoToJson(call.args(2), &body,
+                                  utils::JsonOptions::DEFAULT);
+      if (status.ok()) {
+        external_http_request_.body = body;
+        next_request_ = &external_http_request_;
+      }
+      break;
+    }
+
+    func_call_iter_++;
+  }
+
+  // If All functions are processed, then issue a TestRulesetRequest.
+  if (AllFunctionCallsProcessed()) {
+    next_request_ = &firebase_http_request_;
+    return UpdateRulesetRequestBody(response_.test_results(0).function_calls());
+  }
+
+    return status;
+}
+
+Status FirebaseRequest::CheckFuncCallArgs(
+    const FunctionCall &func) {
+  if (func.function().empty()) {
+    return Status(Code::INVALID_ARGUMENT, "No function name provided");
+  }
+
+  // We only support functions that call with three argument: HTTP URL, HTTP
+  // method and body. The body can be empty
+  if (func.args_size() < 2 || func.args_size() > 3) {
+    std::ostringstream os;
+    os << func.function() << " Require 2 or 3 arguments. But has " << func.args_size();
+    return Status(Code::INVALID_ARGUMENT, os.str());
+
+  }
+
+  if (func.args(0).kind_case() != google::protobuf::Value::kStringValue ||
+      func.args(1).kind_case() != google::protobuf::Value::kStringValue) {
+    return Status(Code::INVALID_ARGUMENT,
+                  std::string(func.function() + " Arguments 1 and 2 should be strings"));
+  }
+
+  if (!utils::IsHttpRequest(func.args(0).string_value())) {
+    return Status(Code::INVALID_ARGUMENT,
+                  func.function() + " The first argument should be a HTTP request");
+  }
+
+  if (std::string(func.args(1).string_value()).empty()) {
+    return Status(Code::INVALID_ARGUMENT,
+                  func.function() + " argument 2 [HTTP METHOD] cannot be emtpy");
+  }
+
+  return Status::OK;
+}
+
+bool FirebaseRequest::AllFunctionCallsProcessed() {
+  return func_call_iter_ == response_.test_results(0).function_calls().end();
+}
+
+Status FirebaseRequest::AddFunctionMock(proto::TestRulesetRequest *request,
+                                        const FunctionCall &func_call) {
+  if (Find(func_call) == funcs_with_result_.end()) {
+    return Status(Code::INTERNAL,
+                  std::string("Cannot find body for function call")
+                  + func_call.function());
+  }
+
+  auto *func_mock = request->mutable_test_suite()
+      ->mutable_test_cases(0)->add_function_mocks();
+
+  func_mock->set_function(func_call.function());
+  for (auto arg: func_call.args()) {
+    auto *toAdd = func_mock->add_args()->mutable_exact_value();
+    *toAdd = arg;
+  }
+
+  ::google::protobuf::Value result_json;
+  Status status = utils::JsonToProto(std::get<1>(*Find(func_call)),
+                                     &result_json);
+  if (!status.ok()) {
+    env_->LogError(std::string("Error creating protobuf from request body") +
+                   status.ToString());
+    return status;
+  }
+
+  *(func_mock->mutable_result()->mutable_value()) = result_json;
+  return Status::OK;
+}
+
+} // namespace firebase_rules
+} // namespace api_manager
+} // namespace google

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
@@ -104,10 +104,10 @@ FirebaseRequest::FirebaseRequest(
   next_request_ = &firebase_http_request_;
 }
 
-bool FirebaseRequest::IsDone() { return is_done_; }
+bool FirebaseRequest::is_done() { return is_done_; }
 
 HttpRequest FirebaseRequest::GetHttpRequest() {
-  if (IsDone()) {
+  if (is_done()) {
     return HttpRequest();
   }
 
@@ -122,7 +122,7 @@ HttpRequest FirebaseRequest::GetHttpRequest() {
 Status FirebaseRequest::RequestStatus() { return current_status_; }
 
 void FirebaseRequest::UpdateResponse(const std::string &body) {
-  if (IsDone()) {
+  if (is_done()) {
     env_->LogError(
         "Receive a response body when no HTTP request is outstanding");
     return;
@@ -131,7 +131,7 @@ void FirebaseRequest::UpdateResponse(const std::string &body) {
   if (next_request_ == nullptr) {
     env_->LogError(
         "Received a response when there is no request set"
-        "and when IsDone is false."
+        "and when is_done is false."
         " Looks like a code bug...");
     SetStatus(Status(Code::INTERNAL,
                      "Internal state error while processing Http request"));
@@ -276,7 +276,7 @@ FirebaseRequest::Find(const FunctionCall &func_call) {
 }
 
 Status FirebaseRequest::ProcessFunctionCallResponse(const std::string &body) {
-  if (IsDone() || AllFunctionCallsProcessed()) {
+  if (is_done() || AllFunctionCallsProcessed()) {
     return Status(Code::INTERNAL,
                   "No external function calls present."
                   " But received a response. Possible code bug");
@@ -289,7 +289,7 @@ Status FirebaseRequest::ProcessFunctionCallResponse(const std::string &body) {
 
 // Sets the next HTTP request that should be issued.
 Status FirebaseRequest::SetNextRequest() {
-  if (IsDone()) {
+  if (is_done()) {
     next_request_ = nullptr;
     return current_status_;
   }

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
@@ -24,6 +24,9 @@ using ::google::api_manager::utils::Status;
 using ::google::api_manager::proto::TestRulesetResponse;
 using ::google::protobuf::util::MessageDifferencer;
 using ::google::protobuf::Map;
+using TestRulesetResponse = ::google::api_manager::proto::TestRulesetResponse;
+using FunctionCall = TestRulesetResponse::TestResult::FunctionCall;
+using ::google::protobuf::RepeatedPtrField;
 
 namespace google {
 namespace api_manager {

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
@@ -34,21 +34,21 @@ namespace firebase_rules {
 
 namespace {
 
-const char kToken[] = "token";
-const char kAuth[] = "auth";
-const char kPath[] = "path";
-const char kMethod[] = "method";
-const char kHttpGetMethod[] = "GET";
-const char kHttpPostMethod[] = "POST";
-const char kHttpHeadMethod[] = "HEAD";
-const char kHttpOptionsMethod[] = "OPTIONS";
-const char kHttpDeleteMethod[] = "DELETE";
-const char kFirebaseCreateMethod[] = "create";
-const char kFirebaseGetMethod[] = "get";
-const char kFirebaseDeleteMethod[] = "delete";
-const char kFirebaseUpdateMethod[] = "update";
-const char kV1[] = "/v1";
-const char kTestQuery[] = ":test?alt=json";
+const std::string kToken = "token";
+const std::string kAuth = "auth";
+const std::string kPath = "path";
+const std::string kMethod = "method";
+const std::string kHttpGetMethod = "GET";
+const std::string kHttpPostMethod = "POST";
+const std::string kHttpHeadMethod = "HEAD";
+const std::string kHttpOptionsMethod = "OPTIONS";
+const std::string kHttpDeleteMethod = "DELETE";
+const std::string kFirebaseCreateMethod = "create";
+const std::string kFirebaseGetMethod = "get";
+const std::string kFirebaseDeleteMethod = "delete";
+const std::string kFirebaseUpdateMethod = "update";
+const std::string kV1 = "/v1";
+const std::string kTestQuery = ":test?alt=json";
 
 void SetProtoValue(const std::string &key,
                    const ::google::protobuf::Value &value,
@@ -59,7 +59,7 @@ void SetProtoValue(const std::string &key,
 }
 
 // Convert HTTP method to Firebase specific method.
-std::string GetOperation(const std::string &httpMethod) {
+const std::string &GetOperation(const std::string &httpMethod) {
   if (httpMethod == kHttpPostMethod) {
     return kFirebaseCreateMethod;
   }
@@ -125,17 +125,15 @@ HttpRequest FirebaseRequest::GetHttpRequest() {
 Status FirebaseRequest::RequestStatus() { return current_status_; }
 
 void FirebaseRequest::UpdateResponse(const std::string &body) {
-  if (is_done()) {
-    env_->LogError(
-        "Receive a response body when no HTTP request is outstanding");
-    return;
-  }
+  GOOGLE_DCHECK(!is_done())
+      << "Receive a response body when no HTTP request is outstanding";
 
-  if (next_request_ == nullptr) {
-    env_->LogError(
-        "Received a response when there is no request set"
-        "and when is_done is false."
-        " Looks like a code bug...");
+  GOOGLE_DCHECK(next_request_)
+      << "Received a response when there is no request set"
+         "and when is_done is false."
+         " Looks like a code bug...";
+
+  if (is_done() || next_request_ == nullptr) {
     SetStatus(Status(Code::INTERNAL,
                      "Internal state error while processing Http request"));
     return;

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
@@ -24,11 +24,45 @@
 #include "contrib/endpoints/src/api_manager/context/request_context.h"
 #include "contrib/endpoints/src/api_manager/proto/security_rules.pb.h"
 
-using ::google::api_manager::utils::Status;
-using TestRulesetResponse = ::google::api_manager::proto::TestRulesetResponse;
-using FunctionCall = TestRulesetResponse::TestResult::FunctionCall;
-using ::google::protobuf::RepeatedPtrField;
-
+// An object of this class should be created for each RequestContext object.
+// Here is the flow of messages between ESP, Firebase rules and User provided
+// HTTP endpoint:
+//
+// 1) ESP invokes GetRelease API call on Firebase Service to get the ruleset
+// name associated with the Release. The ruleset a representation of the rules
+// files that the user deployed to be enforced. The release name is built by
+// concatenating the service name and the api version number.
+//
+// 2) ESP receives the response from Firebase Service which contains the ruleset
+// name associated with the Release. From this point on, ESP invokes TestRuleset
+// request against this ruleset name.
+//
+// 3) ESP issues the TestRuleset request that includes the following
+// information:
+//  -- The payload of the JWT token which contains, uid, email or any additional
+//  claims that can be used to authorize the user.
+//  -- A test case that provides the Request's HTTP method and HTTP path.
+// Note that the above information is provided for ALL TestRuleset requests.
+//
+// 4) ESP receives a response in TestRulesetResponse message which has a state
+// variable that is either set to SUCCESS or FAILURE.
+//  -- If the state is SUCCESS, then ESP considers this as authorization
+//  approval and invokes the continution provided with Status::OK.
+//  -- If the state is FAILURE, then ESP looks more into the TestRulesetResponse
+//  message to see if there are any user defined HTTP requests that are to be
+//  invoked and ESP has not seen this request before. If there are no such
+//  functions, then ESP stops processing with Unauthorized Access error.
+//  Otherwise, ESP does Step 5.
+//
+// 5) ESP invokes rules defined HTTP requests that are not yet seen.
+// ESP invokes these requests sequentially. Once all HTTP requests are invoked,
+// then ESP builds a TestRulesetRequest which contains the following in addition
+// to the JWT claims and HTTP method and HTTP path.
+// -- For each HTTP request, ESP converts the JSON object into a protobuf::Value
+// and sets the result of the HTTP call that be accessed in the Firebase rules
+// like a Map.
+// ESP send the TestRuleset message to Firebase Service and processing moved to
+// step 4) above.
 namespace google {
 namespace api_manager {
 namespace firebase_rules {
@@ -74,7 +108,7 @@ class FirebaseRequest {
 
   // Get the request status. This request status is only valid if is_done is
   // true.
-  Status RequestStatus();
+  utils::Status RequestStatus();
 
   // This call should be invoked to get the next http request to execute.
   HttpRequest GetHttpRequest();
@@ -83,18 +117,22 @@ class FirebaseRequest {
   void UpdateResponse(const std::string &body);
 
  private:
-  Status UpdateRulesetRequestBody(
-      const RepeatedPtrField<FunctionCall> &func_calls);
-  Status ProcessTestRulesetResponse(const std::string &body);
-  Status ProcessFunctionCallResponse(const std::string &body);
-  Status CheckFuncCallArgs(const FunctionCall &func);
-  Status AddFunctionMock(proto::TestRulesetRequest *request,
-                         const FunctionCall &func_call);
-  void SetStatus(const Status &status);
-  Status SetNextRequest();
+  utils::Status UpdateRulesetRequestBody(
+      const ::google::protobuf::RepeatedPtrField<
+          proto::TestRulesetResponse::TestResult::FunctionCall> &func_calls);
+  utils::Status ProcessTestRulesetResponse(const std::string &body);
+  utils::Status ProcessFunctionCallResponse(const std::string &body);
+  utils::Status CheckFuncCallArgs(
+      const proto::TestRulesetResponse::TestResult::FunctionCall &func);
+  utils::Status AddFunctionMock(
+      proto::TestRulesetRequest *request,
+      const proto::TestRulesetResponse::TestResult::FunctionCall &func_call);
+  void SetStatus(const utils::Status &status);
+  utils::Status SetNextRequest();
   bool AllFunctionCallsProcessed();
-  std::vector<std::pair<FunctionCall, std::string>>::const_iterator Find(
-      const FunctionCall &func_call);
+  std::vector<std::pair<proto::TestRulesetResponse::TestResult::FunctionCall,
+                        std::string>>::const_iterator
+  Find(const proto::TestRulesetResponse::TestResult::FunctionCall &func_call);
 
   // The API manager environment. Primarily used for logging.
   ApiManagerEnvInterface *env_;
@@ -110,7 +148,7 @@ class FirebaseRequest {
   std::string firebase_server_;
 
   // This variable tracks the status of the state machine.
-  Status current_status_;
+  utils::Status current_status_;
 
   // Variable to track if the state machine is done processing. This is set to
   // true either when the processing is successfully done or when an error is
@@ -118,27 +156,31 @@ class FirebaseRequest {
   bool is_done_;
 
   // The map is used to buffer the response for the user defined function calls.
-  std::vector<std::pair<FunctionCall, std::string>> funcs_with_result_;
+  std::vector<std::pair<proto::TestRulesetResponse::TestResult::FunctionCall,
+                        std::string>>
+      funcs_with_result_;
 
   // The iterator iterates over the FunctionCalls the user wishes to invoke. So
   // long as this iterator is valid, the state machine issues HTTP requests to
   // the user defined HTTP endpoints. Once the iterator is equl to
   // func_call_iter.end(), then the TestRuleset is issued which includes the
   // function calls along with their responses.
-  RepeatedPtrField<FunctionCall>::const_iterator func_call_iter_;
+  ::google::protobuf::RepeatedPtrField<
+      proto::TestRulesetResponse::TestResult::FunctionCall>::const_iterator
+      func_call_iter_;
 
   // The Test ruleset response currently being processed.
-  TestRulesetResponse response_;
+  proto::TestRulesetResponse response_;
 
   // This variable points to either firebase_http_request_ or
-  // external_http_request_. This will allow the state machine to understand if
-  // the response received is for TestRuleset or user defined HTTP endpoint. If
-  // next_request points to firebase_http_request_, upon receiving a response,
-  // the state machine will convert the response to TestRulesetResponse and
-  // process the response. If next_request_ points to external_http_request_,
-  // then the reponse provided via UpdateResponse is converted into a
-  // protobuf::Value. This value is initialized to nullptr and will be nullptr
-  // once is_done_ is set to true.
+  // external_http_request_. This will allow the UpdateResponse method to
+  // understand if the response received is for TestRuleset or user
+  // defined HTTP endpoint. If next_request points to firebase_http_request_,
+  // upon receiving a response, UpdateResponse will convert the response to
+  // TestRulesetResponse and process the response. If next_request_ points
+  // to external_http_request_, then the reponse provided via UpdateResponse
+  // is converted into a protobuf::Value. This value is initialized to nullptr
+  // and will be nullptr once is_done_ is set to true.
   HttpRequest *next_request_;
 
   // The HTTP request to be sent to firebase TestRuleset API

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
@@ -46,7 +46,7 @@ struct HttpRequest {
 // to be generated as a part of the TestRuleset request and response cycle.
 // Here is the intented use of this code:
 // FirebaseRequest request(...);
-// while(!request.IsDone()) {
+// while(!request.is_done()) {
 //  std::string url, method, body;
 //
 //  /* The following is not a valid C++ statement. But written so the reader can
@@ -70,9 +70,9 @@ class FirebaseRequest {
                   std::shared_ptr<context::RequestContext> context);
 
   // If the firebase Request calling can be terminated.
-  bool IsDone();
+  bool is_done();
 
-  // Get the request status. This request status is only valid if IsDone is
+  // Get the request status. This request status is only valid if is_done is
   // true.
   Status RequestStatus();
 

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
@@ -20,13 +20,12 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "contrib/endpoints/include/api_manager/utils/status.h"
 #include "contrib/endpoints/src/api_manager/context/request_context.h"
 #include "contrib/endpoints/src/api_manager/proto/security_rules.pb.h"
-#include "contrib/endpoints/include/api_manager/utils/status.h"
 
 using ::google::api_manager::utils::Status;
-using TestRulesetResponse =
-  ::google::api_manager::proto::TestRulesetResponse;
+using TestRulesetResponse = ::google::api_manager::proto::TestRulesetResponse;
 using FunctionCall = TestRulesetResponse::TestResult::FunctionCall;
 using ::google::protobuf::RepeatedPtrField;
 
@@ -35,10 +34,10 @@ namespace api_manager {
 namespace firebase_rules {
 
 struct HttpRequest {
-    std::string url;
-    std::string method;
-    std::string body;
-    auth::ServiceAccountToken::JWT_TOKEN_TYPE token_type;
+  std::string url;
+  std::string method;
+  std::string body;
+  auth::ServiceAccountToken::JWT_TOKEN_TYPE token_type;
 };
 
 // A FirebaseRequest object understands the various http requests that need
@@ -64,7 +63,6 @@ struct HttpRequest {
 // }
 class FirebaseRequest {
  public:
-
   // Constructor.
   FirebaseRequest(const std::string &ruleset_name, ApiManagerEnvInterface *env,
                   std::shared_ptr<context::RequestContext> context);
@@ -83,7 +81,6 @@ class FirebaseRequest {
   void UpdateResponse(const std::string &body);
 
  private:
-
   Status UpdateRulesetRequestBody(
       const RepeatedPtrField<FunctionCall> &func_calls);
   Status ProcessTestRulesetResponse(const std::string &body);
@@ -94,8 +91,8 @@ class FirebaseRequest {
   void SetStatus(const Status &status);
   Status SetNextRequest();
   bool AllFunctionCallsProcessed();
-  std::vector<std::pair<FunctionCall, std::string>>::const_iterator
-      Find(const FunctionCall &func_call);
+  std::vector<std::pair<FunctionCall, std::string>>::const_iterator Find(
+      const FunctionCall &func_call);
 
   ApiManagerEnvInterface *env_;
   std::shared_ptr<context::RequestContext> context_;
@@ -105,16 +102,15 @@ class FirebaseRequest {
   Status current_status_;
   bool is_done_;
   std::vector<std::pair<FunctionCall, std::string>> funcs_with_result_;
-  RepeatedPtrField<FunctionCall>::const_iterator
-      func_call_iter_;
+  RepeatedPtrField<FunctionCall>::const_iterator func_call_iter_;
   TestRulesetResponse response_;
   HttpRequest *next_request_;
   HttpRequest firebase_http_request_;
   HttpRequest external_http_request_;
 };
 
-} // namespace firebase_rules
-} // namespace api_manager
-} // namespace google
+}  // namespace firebase_rules
+}  // namespace api_manager
+}  // namespace google
 
-#endif // FIREBASE_RULES_REQUEST_HELPER_H_
+#endif  // FIREBASE_RULES_REQUEST_HELPER_H_

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
@@ -1,0 +1,120 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef FIREBASE_RULES_FIREBASE_REQUEST_H_
+#define FIREBASE_RULES_FIREBASE_REQUEST_H_
+
+#include <string>
+#include <utility>
+#include <vector>
+#include "contrib/endpoints/src/api_manager/context/request_context.h"
+#include "contrib/endpoints/src/api_manager/proto/security_rules.pb.h"
+#include "contrib/endpoints/include/api_manager/utils/status.h"
+
+using ::google::api_manager::utils::Status;
+using TestRulesetResponse =
+  ::google::api_manager::proto::TestRulesetResponse;
+using FunctionCall = TestRulesetResponse::TestResult::FunctionCall;
+using ::google::protobuf::RepeatedPtrField;
+
+namespace google {
+namespace api_manager {
+namespace firebase_rules {
+
+struct HttpRequest {
+    std::string url;
+    std::string method;
+    std::string body;
+    auth::ServiceAccountToken::JWT_TOKEN_TYPE token_type;
+};
+
+// A FirebaseRequest object understands the various http requests that need
+// to be generated as a part of the TestRuleset request and response cycle.
+// Here is the intented use of this code:
+// FirebaseRequest request(...);
+// while(!request.IsDone()) {
+//  std::string url, method, body;
+//
+//  /* The following is not a valid C++ statement. But written so the reader can
+//  get a general idea ... */
+//
+//  (url, method, body, token_type) = request.GetHttpRequest();
+//  std::string body = InvokeHttpRequest(url, method, body,
+//                                       GetToken(token_type));
+//  updateResponse(body);
+// }
+//
+// if (request.RequestStatus.ok()) {
+//  .... ALLOW .....
+// } else {
+//  .... DENY .....
+// }
+class FirebaseRequest {
+ public:
+
+  // Constructor.
+  FirebaseRequest(const std::string &ruleset_name, ApiManagerEnvInterface *env,
+                  std::shared_ptr<context::RequestContext> context);
+
+  // If the firebase Request calling can be terminated.
+  bool IsDone();
+
+  // Get the request status. This request status is only valid if IsDone is
+  // true.
+  Status RequestStatus();
+
+  // This call should be invoked to get the next http request to execute.
+  HttpRequest GetHttpRequest();
+
+  // The response for previous HttpRequest.
+  void UpdateResponse(const std::string &body);
+
+ private:
+
+  Status UpdateRulesetRequestBody(
+      const RepeatedPtrField<FunctionCall> &func_calls);
+  Status ProcessTestRulesetResponse(const std::string &body);
+  Status ProcessFunctionCallResponse(const std::string &body);
+  Status CheckFuncCallArgs(const FunctionCall &func);
+  Status AddFunctionMock(proto::TestRulesetRequest *request,
+                         const FunctionCall &func_call);
+  void SetStatus(const Status &status);
+  Status SetNextRequest();
+  bool AllFunctionCallsProcessed();
+  std::vector<std::pair<FunctionCall, std::string>>::const_iterator
+      Find(const FunctionCall &func_call);
+
+  ApiManagerEnvInterface *env_;
+  std::shared_ptr<context::RequestContext> context_;
+  std::string ruleset_name_;
+  std::string service_name_;
+  std::string firebase_server_;
+  Status current_status_;
+  bool is_done_;
+  std::vector<std::pair<FunctionCall, std::string>> funcs_with_result_;
+  RepeatedPtrField<FunctionCall>::const_iterator
+      func_call_iter_;
+  TestRulesetResponse response_;
+  HttpRequest *next_request_;
+  HttpRequest firebase_http_request_;
+  HttpRequest external_http_request_;
+};
+
+} // namespace firebase_rules
+} // namespace api_manager
+} // namespace google
+
+#endif // FIREBASE_RULES_REQUEST_HELPER_H_

--- a/contrib/endpoints/src/api_manager/proto/security_rules.proto
+++ b/contrib/endpoints/src/api_manager/proto/security_rules.proto
@@ -24,7 +24,7 @@ import "google/protobuf/struct.proto";
 // The protobufs in this file model the messages that flow from ESP to Firebase
 // rules service. The naming of the protobufs start with "Test" and should not
 // be confused that the protobufs are used for testing. The protobuf names and
-// message structure exactly match the protobufs defined in the firebase rules. 
+// message structure exactly match the protobufs defined in the firebase rules.
 message TestCase {
   // The set of supported test case expectations.
   enum Expectation {

--- a/contrib/endpoints/src/api_manager/proto/security_rules.proto
+++ b/contrib/endpoints/src/api_manager/proto/security_rules.proto
@@ -21,6 +21,10 @@ package google.api_manager.proto;
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 
+// The protobufs in this file model the messages that flow from ESP to Firebase
+// rules service. The naming of the protobufs start with "Test" and should not
+// be confused that the protobufs are used for testing. The protobuf names and
+// message structure exactly match the protobufs defined in the firebase rules. 
 message TestCase {
   // The set of supported test case expectations.
   enum Expectation {

--- a/contrib/endpoints/src/api_manager/proto/security_rules.proto
+++ b/contrib/endpoints/src/api_manager/proto/security_rules.proto
@@ -18,40 +18,219 @@ syntax = "proto3";
 
 package google.api_manager.proto;
 
+import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 
-message TestRulesetRequest {
-  message TestCase {
-    // The set of supported test case expectations.
-    enum Expectation {
-      EXPECTATION_UNSPECIFIED = 0;  // Unspecified expectation.
-      ALLOW = 1;                    // Expect an allowed result.
-      DENY = 2;                     // Expect a denied result.
-    }
-
-    // The name of the service that is the subject of the test case.
-    string service_name = 1;
-
-    // The RESTful resource path of the mock `request`.
-    string resource_path = 2;
-
-    // The `request` `operation`. The operation will typically be one of `get`,
-    // `list`, `create`, `update`, or `delete`. Services also may provide custom
-    // operations.
-    string operation = 3;
-
-    // Test expectation.
-    Expectation expectation = 4;
-
-    // (--
-    // Variables and fake resources need to be updated to support multiple
-    // services and the standardized `request` definition.
-    // --)
-
-    // Optional set of variable values to use during evaluation.
-    map<string, google.protobuf.Value> variables = 5;
+message TestCase {
+  // The set of supported test case expectations.
+  enum Expectation {
+    EXPECTATION_UNSPECIFIED = 0;  // Unspecified expectation.
+    ALLOW = 1;                    // Expect an allowed result.
+    DENY = 2;                     // Expect a denied result.
   }
 
-  // The set of test cases to run against the `Source` if it is well-formed.
-  repeated TestCase test_cases = 3;
+  // Mock function definition.
+  //
+  // Mocks must refer to a function declared by the target service. The type of
+  // the function args and result will be inferred at test time. If either the
+  // arg or result values are not compatible with function type declaration, the
+  // request will be considered invalid.
+  //
+  // More than one `FunctionMock` may be provided for a given function name so
+  // long as the `Arg` matchers are distinct. In the event that multiple mocks
+  // match the expression, the request will be treated as an invalid argument.
+  message FunctionMock {
+    // Arg matchers for the mock function.
+    message Arg {
+      // Supported argument values.
+      oneof type {
+        // Argument exactly matches value provided.
+        google.protobuf.Value exact_value = 1;
+        // Argument matches any value provided.
+        google.protobuf.Empty any_value = 2;
+      }
+    }
+
+    // Possible result values from the function mock invocation.
+    message Result {
+      // Supported result values.
+      oneof type {
+        // The result is an actual value. The type of the value must match that
+        // of the type declared by the service.
+        google.protobuf.Value value = 1;
+        // The result is undefined, meaning the result could not be computed.
+        google.protobuf.Empty undefined = 2;
+      }
+    }
+
+    // The name of the function.
+    //
+    // The function name must match one provided by a service declaration.
+    string function = 1;
+
+    // The list of `Arg` values to match. The order in which the arguments are
+    // provided is the order in which they must appear in the function
+    // invocation.
+    repeated Arg args = 2;
+
+    // The mock result of the function call.
+    Result result = 3;
+  }
+
+  // Test expectation.
+  Expectation expectation = 1;
+
+  // Request context.
+  //
+  // The exact format of the request context is service-dependent. See the
+  // appropriate service documentation for information about the supported
+  // fields and types on the request. Minimally, all services support the
+  // following fields and types:
+  //
+  // Request field  | Type
+  // ---------------|-----------------
+  // auth.uid       | `string`
+  // auth.token     | `map<string, string>`
+  // headers        | `map<string, string>`
+  // method         | `string`
+  // params         | `map<string, string>`
+  // path           | `string`
+  // time           | `google.protobuf.Timestamp`
+  //
+  // If the request value is not well-formed for the service, the request will
+  // be rejected as an invalid argument.
+  google.protobuf.Value request = 2;
+
+  // Optional resource value as it appears in persistent storage before the
+  // request is fulfilled.
+  //
+  // The resource type depends on the `request.path` value.
+  google.protobuf.Value resource = 3;
+
+  // Optional function mocks for service-defined functions. If not set, any
+  // service defined function is expected to return an error, which may or may
+  // not influence the test outcome.
+  repeated FunctionMock function_mocks = 4;
+}
+
+message TestSuite {
+  // Test cases to be executed.
+  repeated TestCase test_cases = 1;
+}
+message TestRulesetRequest {
+  // Name of the ruleset resource.
+  // Format: 'projects/{project_id}/rulesets/{ruleset_id}'
+  string name = 1;
+
+  // The test suite to run against the ruleset
+  oneof test {
+    // Inline 'TestSuite' to run.
+    TestSuite test_suite = 3;
+  }
+}
+// Position in the `Source` content including its line, column number, and an
+// index of the `File` in the `Source` message. Used for debug purposes.
+message SourcePosition {
+  // Name of the `File`.
+  string file_name = 1;
+
+  // Index of the `File` in the `Source` message where the content appears.
+  // @OutputOnly
+  int32 file_index = 2;
+
+  // Line number of the source fragment. 1-based.
+  int32 line = 3;
+
+  // First column on the source line associated with the source fragment.
+  int32 column = 4;
+
+  // Position relative to the beginning of the file. This is used by the IDEA
+  // plugin, while the line and column are used by the compiler.
+  int32 current_offset = 5;
+}
+
+message TestRulesetResponse {
+  // Issues include warnings, errors, and deprecation notices.
+  message Issue {
+    // The set of issue severities.
+    enum Severity {
+      // An unspecified severity.
+      SEVERITY_UNSPECIFIED = 0;
+      // Deprecation issue for statements and method that may no longer be
+      // supported or maintained.
+      DEPRECATION = 1;
+      // Warnings such as: unused variables.
+      WARNING = 2;
+      // Errors such as: unmatched curly braces or variable redefinition.
+      ERROR = 3;
+    }
+
+    // Position of the issue in the `Source`.
+    SourcePosition source_position = 1;
+
+    // Short error description.
+    string description = 2;
+
+    // The severity of the issue.
+    Severity severity = 3;
+  }
+
+  // Test result message containing the state of the test as well as a
+  // description and source position for test failures.
+  message TestResult {
+    // Valid states for the test result.
+    enum State {
+      STATE_UNSPECIFIED = 0;  // Test state is not set.
+      SUCCESS = 1;            // Test is a success.
+      FAILURE = 2;            // Test is a failure.
+    }
+
+    // Represents a service-defined function call that was invoked during test
+    // execution.
+    message FunctionCall {
+      // Name of the function invoked.
+      string function = 1;
+
+      // The arguments that were provided to the function.
+      repeated google.protobuf.Value args = 2;
+    }
+
+    // State of the test.
+    State state = 1;
+
+    // Debug messages related to test execution issues encountered during
+    // evaluation.
+    //
+    // Debug messages may be related to too many or too few invocations of
+    // function mocks or to runtime errors that occur during evaluation.
+    //
+    // For example: ```Unable to read variable [name: "resource"]```
+    repeated string debug_messages = 2;
+
+    // Position in the `Source` or `Ruleset` where the principle runtime error
+    // occurs.
+    //
+    // Evaluation of an expression may result in an error. Rules are deny by
+    // default, so a `DENY` expectation when an error is generated is valid.
+    // When there is a `DENY` with an error, the `SourcePosition` is returned.
+    //
+    // E.g. `error_position { line: 19 column: 37 }`
+    SourcePosition error_position = 3;
+
+    // The set of function calls made to service-defined methods.
+    //
+    // Function calls are included in the order in which they are encountered
+    // during evaluation, are provided for both mocked and unmocked functions,
+    // and included on the response regardless of the test `state`.
+    repeated FunctionCall function_calls = 4;
+  }
+
+  // Syntactic and semantic `Source` issues of varying severity. Issues of
+  // `ERROR` severity will prevent tests from executing.
+  repeated Issue issues = 1;
+
+  // The set of test results given the test cases in the `TestSuite`.
+  // The results will appear in the same order as the test cases appear in the
+  // `TestSuite`.
+  repeated TestResult test_results = 2;
 }

--- a/contrib/endpoints/src/api_manager/proto/server_config.proto
+++ b/contrib/endpoints/src/api_manager/proto/server_config.proto
@@ -146,6 +146,7 @@ message ApiAuthenticationConfig {
 message ApiCheckSecurityRulesConfig {
   // Firebase server to use.
   string firebase_server = 1;
+  string authorization_service_audience = 2;
 }
 
 message Experimental {

--- a/contrib/endpoints/src/api_manager/utils/url_util.cc
+++ b/contrib/endpoints/src/api_manager/utils/url_util.cc
@@ -19,15 +19,17 @@
 namespace google {
 namespace api_manager {
 namespace utils {
+namespace {
+const std::string kHttpPrefix = "http://";
+const std::string kHttpsPrefix = "https://";
+}
 
 std::string GetUrlContent(const std::string &url) {
-  static const std::string https_prefix = "https://";
-  static const std::string http_prefix = "http://";
   std::string result;
-  if (url.compare(0, https_prefix.size(), https_prefix) == 0) {
-    result = url.substr(https_prefix.size());
-  } else if (url.compare(0, http_prefix.size(), http_prefix) == 0) {
-    result = url.substr(http_prefix.size());
+  if (url.compare(0, kHttpsPrefix.size(), kHttpsPrefix) == 0) {
+    result = url.substr(kHttpsPrefix.size());
+  } else if (url.compare(0, kHttpPrefix.size(), kHttpPrefix) == 0) {
+    result = url.substr(kHttpPrefix.size());
   } else {
     result = url;
   }
@@ -35,6 +37,11 @@ std::string GetUrlContent(const std::string &url) {
     result.pop_back();
   }
   return result;
+}
+
+bool IsHttpRequest(const std::string &url) {
+  return url.compare(0, kHttpPrefix.size(), kHttpPrefix) == 0 ||
+         url.compare(0, kHttpsPrefix.size(), kHttpsPrefix) == 0;
 }
 
 }  // namespace utils

--- a/contrib/endpoints/src/api_manager/utils/url_util.h
+++ b/contrib/endpoints/src/api_manager/utils/url_util.h
@@ -25,6 +25,8 @@ namespace utils {
 // processed string.
 std::string GetUrlContent(const std::string &url);
 
+bool IsHttpRequest(const std::string &url);
+
 }  // namespace utils
 }  // namespace api_manager
 }  // namespace google


### PR DESCRIPTION
The changes in this PR will allow firebase rules to fetch the required information to do authorization from a REST endpoint. This endpoint could be a Google Datastore or Cloud SQL or spanner endpoint. ESP will invoke the HTTP request on behalf of Firebase rules and provide the response back to the Firebase service as a JSON value. This value can directly used as a Map in firebase rules to check for various attributes or policies to make authorization decisions.

Testing:

Integration testing via Cloud Datastore works.
Added more Unit tests to cover the new implementation.
Note that the old implementation of basic firebase rules should still work and the unit tests for those remain.