### PR TITLE
Update attributes to match the canonical attribute list.

### DIFF
--- a/src/envoy/mixer/http_control.cc
+++ b/src/envoy/mixer/http_control.cc
@@ -125,8 +125,7 @@ void FillRequestInfoAttributes(const AccessLog::RequestInfo& info,
     attr->attributes[kResponseCode] =
         Attributes::Int64Value(info.responseCode().value());
   } else {
-    attr->attributes[kResponseCode] =
-        Attributes::Int64Value(check_status_code);
+    attr->attributes[kResponseCode] = Attributes::Int64Value(check_status_code);
   }
 }
 

--- a/src/envoy/mixer/http_control.cc
+++ b/src/envoy/mixer/http_control.cc
@@ -44,8 +44,8 @@ const std::string kRequestSize = "request.size";
 const std::string kRequestTime = "request.time";
 
 const std::string kResponseHeaders = "response.headers";
-const std::string kResponseHttpCode = "response.http.code";
-const std::string kResponseLatency = "response.latency";
+const std::string kResponseCode = "response.code";
+const std::string kResponseDuration = "response.duration";
 const std::string kResponseSize = "response.size";
 const std::string kResponseTime = "response.time";
 
@@ -118,14 +118,14 @@ void FillRequestInfoAttributes(const AccessLog::RequestInfo& info,
     attr->attributes[kResponseSize] = Attributes::Int64Value(info.bytesSent());
   }
 
-  attr->attributes[kResponseLatency] = Attributes::DurationValue(
+  attr->attributes[kResponseDuration] = Attributes::DurationValue(
       std::chrono::duration_cast<std::chrono::nanoseconds>(info.duration()));
 
   if (info.responseCode().valid()) {
-    attr->attributes[kResponseHttpCode] =
+    attr->attributes[kResponseCode] =
         Attributes::Int64Value(info.responseCode().value());
   } else {
-    attr->attributes[kResponseHttpCode] =
+    attr->attributes[kResponseCode] =
         Attributes::Int64Value(check_status_code);
   }
 }

--- a/src/envoy/mixer/integration_test/check_report_test.go
+++ b/src/envoy/mixer/integration_test/check_report_test.go
@@ -61,8 +61,8 @@ const reportAttributesOkGet = `
   "request.size": 0,
   "response.time": "*",
   "response.size": 0,
-  "response.latency": "*",
-  "response.http.code": 200,
+  "response.duration": "*",
+  "response.code": 200,
   "response.headers": {
      "date": "*",
      "content-type": "text/plain; charset=utf-8",
@@ -115,8 +115,8 @@ const reportAttributesOkPost = `
   "request.size": 12,
   "response.time": "*",
   "response.size": 12,
-  "response.latency": "*",
-  "response.http.code": 200,
+  "response.duration": "*",
+  "response.code": 200,
   "response.headers": {
      "date": "*",
      "content-type": "text/plain",

--- a/src/envoy/mixer/integration_test/failed_request_test.go
+++ b/src/envoy/mixer/integration_test/failed_request_test.go
@@ -67,8 +67,8 @@ const reportAttributesMixerFail = `
   "request.size": 0,
   "response.time": "*",
   "response.size": 41,
-  "response.latency": "*",
-  "response.http.code": 401,
+  "response.duration": "*",
+  "response.code": 401,
   "response.headers": {
      "date": "*",
      "content-type": "text/plain",
@@ -100,8 +100,8 @@ const reportAttributesBackendFail = `
   "request.size": 0,
   "response.time": "*",
   "response.size": 25,
-  "response.latency": "*",
-  "response.http.code": 400,
+  "response.duration": "*",
+  "response.code": 400,
   "response.headers": {
      "date": "*",
      "content-type": "text/plain; charset=utf-8",


### PR DESCRIPTION
Update `response.http.code` to `response.code` and `response.latency` to `response.duration` to line up with the canonical [attributes](https://github.com/istio/istio.github.io/blob/master/docs/reference/attributes.md).