### PR TITLE
Remove GetRequestPath method.

### DIFF
--- a/contrib/endpoints/include/api_manager/request.h
+++ b/contrib/endpoints/include/api_manager/request.h
@@ -33,11 +33,10 @@ class Request {
   // Returns the HTTP method used for this call.
   virtual std::string GetRequestHTTPMethod() = 0;
 
-  // Returns the REST path or RPC path for this call.
-  virtual std::string GetRequestPath() = 0;
   // Returns the query parameters
   virtual std::string GetQueryParameters() = 0;
-  // Returns the request path before parsed.
+  // Returns the REST path or RPC path for this call.
+  // It should be "Unparsed" original URL path.
   virtual std::string GetUnparsedRequestPath() = 0;
 
   // Gets Client IP

--- a/contrib/endpoints/src/api_manager/check_auth_test.cc
+++ b/contrib/endpoints/src/api_manager/check_auth_test.cc
@@ -341,7 +341,7 @@ class CheckAuthTest : public ::testing::Test {
 
     EXPECT_CALL(*raw_request_, GetRequestHTTPMethod())
         .WillOnce(Return(std::string("GET")));
-    EXPECT_CALL(*raw_request_, GetRequestPath())
+    EXPECT_CALL(*raw_request_, GetUnparsedRequestPath())
         .WillOnce(Return(std::string("/ListShelves")));
     EXPECT_CALL(*raw_request_, FindQuery(_, _))
         .WillOnce(Invoke([](const std::string &, std::string *apikey) {

--- a/contrib/endpoints/src/api_manager/context/request_context.cc
+++ b/contrib/endpoints/src/api_manager/context/request_context.cc
@@ -88,7 +88,7 @@ RequestContext::RequestContext(std::shared_ptr<ServiceContext> service_context,
   last_report_time_ = std::chrono::steady_clock::now();
   operation_id_ = GenerateUUID();
   const std::string &method = request_->GetRequestHTTPMethod();
-  const std::string &path = request_->GetRequestPath();
+  const std::string &path = request_->GetUnparsedRequestPath();
   std::string query_params = request_->GetQueryParameters();
 
   // In addition to matching the method, service_context_->GetMethodCallInfo()

--- a/contrib/endpoints/src/api_manager/mock_request.h
+++ b/contrib/endpoints/src/api_manager/mock_request.h
@@ -29,7 +29,6 @@ class MockRequest : public Request {
                utils::Status(const std::string &, const std::string &));
   MOCK_METHOD1(SetAuthToken, void(const std::string &));
   MOCK_METHOD0(GetRequestHTTPMethod, std::string());
-  MOCK_METHOD0(GetRequestPath, std::string());
   MOCK_METHOD0(GetQueryParameters, std::string());
   MOCK_METHOD0(GetRequestProtocol, ::google::api_manager::protocol::Protocol());
   MOCK_METHOD0(GetUnparsedRequestPath, std::string());


### PR DESCRIPTION
API Manager should only use "Unparsed" or original URL.