### PR TITLE
Allow HTTP functions in firebase rules to specify audience

### DIFF
--- a/contrib/endpoints/src/api_manager/auth/service_account_token.cc
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.cc
@@ -59,8 +59,18 @@ void ServiceAccountToken::SetAudience(JWT_TOKEN_TYPE type,
   jwt_tokens_[type].set_audience(audience);
 }
 
-const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type,
-                                                     bool ignore_cache) {
+const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type) {
+  return GetAuthToken(type, jwt_tokens_[type].audience());
+}
+
+const std::string& ServiceAccountToken::GetAuthToken(
+    JWT_TOKEN_TYPE type, const std::string& audience) {
+  bool ignore_cache = false;
+  if (jwt_tokens_[type].audience() != audience) {
+    SetAudience(type, audience);
+    ignore_cache = true;
+  }
+
   // Uses authentication secret if available.
   if (!client_auth_secret_.empty()) {
     GOOGLE_CHECK(type >= 0 && type < JWT_TOKEN_TYPE_MAX);
@@ -77,12 +87,6 @@ const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type,
     return jwt_tokens_[type].token();
   }
   return access_token_.token();
-}
-
-const std::string& ServiceAccountToken::GetAuthToken(
-    JWT_TOKEN_TYPE type, const std::string& audience, bool ignore_cache) {
-  SetAudience(type, audience);
-  return GetAuthToken(type, ignore_cache);
 }
 
 Status ServiceAccountToken::JwtTokenInfo::GenerateJwtToken(

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.cc
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.cc
@@ -78,6 +78,12 @@ const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type) {
   return access_token_.token();
 }
 
+const std::string& ServiceAccountToken::GetAuthToken(
+    JWT_TOKEN_TYPE type, const std::string& audience) {
+  SetAudience(type, audience);
+  return GetAuthToken(type);
+}
+
 Status ServiceAccountToken::JwtTokenInfo::GenerateJwtToken(
     const std::string& client_auth_secret) {
   // Make sure audience is set.

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.cc
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.cc
@@ -59,11 +59,12 @@ void ServiceAccountToken::SetAudience(JWT_TOKEN_TYPE type,
   jwt_tokens_[type].set_audience(audience);
 }
 
-const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type) {
+const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type,
+                                                     bool ignore_cache) {
   // Uses authentication secret if available.
   if (!client_auth_secret_.empty()) {
     GOOGLE_CHECK(type >= 0 && type < JWT_TOKEN_TYPE_MAX);
-    if (!jwt_tokens_[type].is_valid(0)) {
+    if (ignore_cache || !jwt_tokens_[type].is_valid(0)) {
       Status status = jwt_tokens_[type].GenerateJwtToken(client_auth_secret_);
       if (!status.ok()) {
         if (env_) {
@@ -79,9 +80,9 @@ const std::string& ServiceAccountToken::GetAuthToken(JWT_TOKEN_TYPE type) {
 }
 
 const std::string& ServiceAccountToken::GetAuthToken(
-    JWT_TOKEN_TYPE type, const std::string& audience) {
+    JWT_TOKEN_TYPE type, const std::string& audience, bool ignore_cache) {
   SetAudience(type, audience);
-  return GetAuthToken(type);
+  return GetAuthToken(type, ignore_cache);
 }
 
 Status ServiceAccountToken::JwtTokenInfo::GenerateJwtToken(

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.h
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.h
@@ -79,16 +79,14 @@ class ServiceAccountToken {
   // Otherwise, use the access token fetched from metadata server.
   // If ignore_cache is true then a JWT token is regenerated even if the current
   // cached JWT token is valid.
-  const std::string& GetAuthToken(JWT_TOKEN_TYPE type,
-                                  bool ignore_cache = false);
+  const std::string& GetAuthToken(JWT_TOKEN_TYPE type);
 
   // Gets the auth token to access Google services. This method accepts an
   // audience parameter to set when generating JWT token.
   // If client auth secret is specified, use it to calcualte JWT token.
   // Otherwise, use the access token fetched from metadata server.
   const std::string& GetAuthToken(JWT_TOKEN_TYPE type,
-                                  const std::string& audience,
-                                  bool ignore_cache = false);
+                                  const std::string& audience);
 
  private:
   // Stores base token info. Used for both OAuth and JWT tokens.

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.h
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.h
@@ -79,6 +79,13 @@ class ServiceAccountToken {
   // Otherwise, use the access token fetched from metadata server.
   const std::string& GetAuthToken(JWT_TOKEN_TYPE type);
 
+  // Gets the auth token to access Google services. This method accepts an
+  // audience parameter to set when generating JWT token.
+  // If client auth secret is specified, use it to calcualte JWT token.
+  // Otherwise, use the access token fetched from metadata server.
+  const std::string& GetAuthToken(JWT_TOKEN_TYPE type,
+                                  const std::string& audience);
+
  private:
   // Stores base token info. Used for both OAuth and JWT tokens.
   class TokenInfo {

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.h
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.h
@@ -77,8 +77,6 @@ class ServiceAccountToken {
   // Gets the auth token to access Google services.
   // If client auth secret is specified, use it to calcualte JWT token.
   // Otherwise, use the access token fetched from metadata server.
-  // If ignore_cache is true then a JWT token is regenerated even if the current
-  // cached JWT token is valid.
   const std::string& GetAuthToken(JWT_TOKEN_TYPE type);
 
   // Gets the auth token to access Google services. This method accepts an

--- a/contrib/endpoints/src/api_manager/auth/service_account_token.h
+++ b/contrib/endpoints/src/api_manager/auth/service_account_token.h
@@ -77,14 +77,18 @@ class ServiceAccountToken {
   // Gets the auth token to access Google services.
   // If client auth secret is specified, use it to calcualte JWT token.
   // Otherwise, use the access token fetched from metadata server.
-  const std::string& GetAuthToken(JWT_TOKEN_TYPE type);
+  // If ignore_cache is true then a JWT token is regenerated even if the current
+  // cached JWT token is valid.
+  const std::string& GetAuthToken(JWT_TOKEN_TYPE type,
+                                  bool ignore_cache = false);
 
   // Gets the auth token to access Google services. This method accepts an
   // audience parameter to set when generating JWT token.
   // If client auth secret is specified, use it to calcualte JWT token.
   // Otherwise, use the access token fetched from metadata server.
   const std::string& GetAuthToken(JWT_TOKEN_TYPE type,
-                                  const std::string& audience);
+                                  const std::string& audience,
+                                  bool ignore_cache = false);
 
  private:
   // Stores base token info. Used for both OAuth and JWT tokens.

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -111,9 +111,8 @@ void AuthzChecker::Check(
   auto checker = GetPtr();
   HttpFetch(GetReleaseUrl(*context), kHttpGetMethod, "",
             auth::ServiceAccountToken::JWT_TOKEN_FOR_FIREBASE,
-            kFirebaseAudience,
-            [context, final_continuation, checker](Status status,
-                                                   std::string &&body) {
+            kFirebaseAudience, [context, final_continuation, checker](
+                                   Status status, std::string &&body) {
               std::string ruleset_id;
               if (status.ok()) {
                 checker->env_->LogDebug(

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -151,12 +151,13 @@ void AuthzChecker::CallNextRequest(
             [continuation, checker](Status status, std::string &&body) {
 
               checker->env_->LogError(std::string("Response Body = ") + body);
-              if (status.ok()) {
+              if (status.ok() && !body.empty()) {
                 checker->request_handler_->UpdateResponse(body);
                 checker->CallNextRequest(continuation);
               } else {
-                checker->env_->LogError(std::string("Test API failed with ") +
-                                        status.ToString());
+                checker->env_->LogError(
+                    std::string("Test API failed with ") +
+                    (status.ok() ? "Empty Response" : status.ToString()));
                 status = Status(Code::INTERNAL, kFailedFirebaseTest);
                 continuation(status);
               }

--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -23,6 +23,9 @@
 using ::google::api_manager::auth::GetStringValue;
 using ::google::api_manager::firebase_rules::FirebaseRequest;
 using ::google::api_manager::utils::Status;
+const char kFirebaseAudience[] =
+    "https://staging-firebaserules.sandbox.googleapis.com/"
+    "google.firebase.rules.v1.FirebaseRulesService";
 
 namespace google {
 namespace api_manager {
@@ -77,6 +80,7 @@ class AuthzChecker : public std::enable_shared_from_this<AuthzChecker> {
   void HttpFetch(const std::string &url, const std::string &method,
                  const std::string &request_body,
                  auth::ServiceAccountToken::JWT_TOKEN_TYPE token_type,
+                 const std::string &audience,
                  std::function<void(Status, std::string &&)> continuation);
 
   std::shared_ptr<AuthzChecker> GetPtr() { return shared_from_this(); }
@@ -107,6 +111,7 @@ void AuthzChecker::Check(
   auto checker = GetPtr();
   HttpFetch(GetReleaseUrl(*context), kHttpGetMethod, "",
             auth::ServiceAccountToken::JWT_TOKEN_FOR_FIREBASE,
+            kFirebaseAudience,
             [context, final_continuation, checker](Status status,
                                                    std::string &&body) {
               std::string ruleset_id;
@@ -143,7 +148,7 @@ void AuthzChecker::CallNextRequest(
   auto checker = GetPtr();
   firebase_rules::HttpRequest http_request = request_handler_->GetHttpRequest();
   HttpFetch(http_request.url, http_request.method, http_request.body,
-            http_request.token_type,
+            http_request.token_type, http_request.audience,
             [continuation, checker](Status status, std::string &&body) {
 
               checker->env_->LogError(std::string("Response Body = ") + body);
@@ -187,6 +192,7 @@ void AuthzChecker::HttpFetch(
     const std::string &url, const std::string &method,
     const std::string &request_body,
     auth::ServiceAccountToken::JWT_TOKEN_TYPE token_type,
+    const std::string &audience,
     std::function<void(Status, std::string &&)> continuation) {
   env_->LogDebug(std::string("Issue HTTP Request to url :") + url +
                  " method : " + method + " body: " + request_body);
@@ -201,7 +207,7 @@ void AuthzChecker::HttpFetch(
   }
 
   request->set_method(method).set_url(url).set_auth_token(
-      sa_token_->GetAuthToken(token_type));
+      sa_token_->GetAuthToken(token_type, audience));
 
   if (!request_body.empty()) {
     request->set_header(kContentType, kApplication).set_body(request_body);

--- a/contrib/endpoints/src/api_manager/check_security_rules_test.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules_test.cc
@@ -537,26 +537,30 @@ class CheckSecurityRulesFunctions : public CheckSecurityRulesTest,
     InSequence s;
 
     ExpectCall(release_url_, "GET", "", kRelease);
-    ExpectCall(
-        ruleset_test_url_, "POST", kFirstRequest,
-        BuildTestRulesetResponse(
-            false, {std::make_tuple("f1", "http://url1", "POST", kDummyBody, kDummyAudience)}));
+    ExpectCall(ruleset_test_url_, "POST", kFirstRequest,
+               BuildTestRulesetResponse(
+                   false, {std::make_tuple("f1", "http://url1", "POST",
+                                           kDummyBody, kDummyAudience)}));
 
     ExpectCall("http://url1", "POST", kDummyBody, kDummyBody);
-    ExpectCall(
-        ruleset_test_url_, "POST", kSecondRequest,
-        BuildTestRulesetResponse(
-            false, {std::make_tuple("f2", "http://url2", "GET", kDummyBody, kDummyAudience),
-                    std::make_tuple("f3", "https://url3", "GET", kDummyBody, kDummyAudience),
-                    std::make_tuple("f1", "http://url1", "POST", kDummyBody, kDummyAudience)}));
+    ExpectCall(ruleset_test_url_, "POST", kSecondRequest,
+               BuildTestRulesetResponse(
+                   false, {std::make_tuple("f2", "http://url2", "GET",
+                                           kDummyBody, kDummyAudience),
+                           std::make_tuple("f3", "https://url3", "GET",
+                                           kDummyBody, kDummyAudience),
+                           std::make_tuple("f1", "http://url1", "POST",
+                                           kDummyBody, kDummyAudience)}));
     ExpectCall("http://url2", "GET", kDummyBody, kDummyBody);
     ExpectCall("https://url3", "GET", kDummyBody, kDummyBody);
     ExpectCall(ruleset_test_url_, "POST", kThirdRequest,
                BuildTestRulesetResponse(
-                   GetParam(),
-                   {std::make_tuple("f2", "http://url2", "GET", kDummyBody, kDummyAudience),
-                    std::make_tuple("f3", "https://url3", "GET", kDummyBody, kDummyAudience),
-                    std::make_tuple("f1", "http://url1", "POST", kDummyBody, kDummyAudience)}));
+                   GetParam(), {std::make_tuple("f2", "http://url2", "GET",
+                                                kDummyBody, kDummyAudience),
+                                std::make_tuple("f3", "https://url3", "GET",
+                                                kDummyBody, kDummyAudience),
+                                std::make_tuple("f1", "http://url1", "POST",
+                                                kDummyBody, kDummyAudience)}));
   }
 };
 
@@ -622,20 +626,19 @@ TEST_P(CheckSecurityRulesBadFunctions, CheckBadFunctionArguments) {
   });
 }
 
-INSTANTIATE_TEST_CASE_P(CheckSecurityRulesBadFunctionArguments,
-                        CheckSecurityRulesBadFunctions,
-                        ::testing::Values(
-                            // Empty function name
-                            std::make_tuple("", "http://url1", "POST",
-                                            kDummyBody, kDummyAudience),
-                            // Argument count less than 3
-                            std::make_tuple("f1", "http://url1", "", "", kDummyAudience),
-                            // The url is not set
-                            std::make_tuple("f1", "", "POST", kDummyBody, kDummyAudience),
-                            // The url is not a http or https protocol
-                            std::make_tuple("f1", "ftp://url1", "POST", kDummyBody, kDummyAudience),
-                            // The audience is not present
-                            std::make_tuple("f1", "http://url1", "GET", kDummyBody, "")));
+INSTANTIATE_TEST_CASE_P(
+    CheckSecurityRulesBadFunctionArguments, CheckSecurityRulesBadFunctions,
+    ::testing::Values(
+        // Empty function name
+        std::make_tuple("", "http://url1", "POST", kDummyBody, kDummyAudience),
+        // Argument count less than 3
+        std::make_tuple("f1", "http://url1", "", "", kDummyAudience),
+        // The url is not set
+        std::make_tuple("f1", "", "POST", kDummyBody, kDummyAudience),
+        // The url is not a http or https protocol
+        std::make_tuple("f1", "ftp://url1", "POST", kDummyBody, kDummyAudience),
+        // The audience is not present
+        std::make_tuple("f1", "http://url1", "GET", kDummyBody, "")));
 }
 }  // namespace api_manager
 }  // namespace google

--- a/contrib/endpoints/src/api_manager/context/service_context.cc
+++ b/contrib/endpoints/src/api_manager/context/service_context.cc
@@ -73,21 +73,6 @@ ServiceContext::ServiceContext(std::unique_ptr<ApiManagerEnvInterface> env,
                                         ->service_control_config()
                                         .intermediate_report_min_interval();
   }
-
-  service_account_token_.SetAudience(
-      auth::ServiceAccountToken::JWT_TOKEN_FOR_FIREBASE, kFirebaseAudience);
-
-  if (config_->server_config() &&
-      !config_->server_config()
-           ->api_check_security_rules_config()
-           .authorization_service_audience()
-           .empty()) {
-    service_account_token_.SetAudience(
-        auth::ServiceAccountToken::JWT_TOKEN_FOR_AUTHORIZATION_SERVICE,
-        config_->server_config()
-            ->api_check_security_rules_config()
-            .authorization_service_audience());
-  }
 }
 
 MethodCallInfo ServiceContext::GetMethodCallInfo(

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.cc
@@ -310,7 +310,8 @@ Status FirebaseRequest::SetNextRequest() {
       auto call = *func_call_iter_;
       external_http_request_.url = call.args(0).string_value();
       external_http_request_.method = call.args(1).string_value();
-      external_http_request_.audience = call.args(call.args_size()-1).string_value();
+      external_http_request_.audience =
+          call.args(call.args_size() - 1).string_value();
       std::string body;
       status =
           utils::ProtoToJson(call.args(2), &body, utils::JsonOptions::DEFAULT);
@@ -354,11 +355,12 @@ Status FirebaseRequest::CheckFuncCallArgs(const FunctionCall &func) {
         std::string(func.function() + " Arguments 1 and 2 should be strings"));
   }
 
-  if (func.args(func.args_size()-1).kind_case() != google::protobuf::Value::kStringValue) {
+  if (func.args(func.args_size() - 1).kind_case() !=
+      google::protobuf::Value::kStringValue) {
     return Status(
         Code::INVALID_ARGUMENT,
         std::string(func.function() + "The last argument should be a string"
-                    "that specifies audience"));
+                                      "that specifies audience"));
   }
 
   if (!utils::IsHttpRequest(func.args(0).string_value())) {

--- a/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
+++ b/contrib/endpoints/src/api_manager/firebase_rules/firebase_request.h
@@ -74,6 +74,7 @@ struct HttpRequest {
   std::string method;
   std::string body;
   auth::ServiceAccountToken::JWT_TOKEN_TYPE token_type;
+  std::string audience;
 };
 
 // A FirebaseRequest object understands the various http requests that need

--- a/contrib/endpoints/src/api_manager/proto/server_config.proto
+++ b/contrib/endpoints/src/api_manager/proto/server_config.proto
@@ -164,7 +164,6 @@ message ApiAuthenticationConfig {
 message ApiCheckSecurityRulesConfig {
   // Firebase server to use.
   string firebase_server = 1;
-  string authorization_service_audience = 2;
 }
 
 message Experimental {


### PR DESCRIPTION
We need the right audience in order to generate the JWT token to invoke into the authorization endpoint. The code change allows the audience to be specified from the firebase rules function call. 

- Updated tests to reflect this change.
- Updated parameter test to check that audience is always present as the last parameter.