### PR TITLE
Handle possible white spaces in audiences string in service config.

### DIFF
--- a/contrib/endpoints/src/api_manager/fetch_metadata.cc
+++ b/contrib/endpoints/src/api_manager/fetch_metadata.cc
@@ -18,7 +18,7 @@
 
 #include "contrib/endpoints/include/api_manager/http_request.h"
 #include "contrib/endpoints/src/api_manager/auth/lib/auth_token.h"
-
+#include <cstring>
 using ::google::api_manager::utils::Status;
 using ::google::protobuf::util::error::Code;
 
@@ -176,10 +176,11 @@ void FetchServiceAccountToken(std::shared_ptr<context::RequestContext> context,
                   // process token from the body
                   char *auth_token = nullptr;
                   int expires = 0;
+                  char body_copy[body.length()+1];
+                  std::strncpy(body_copy, body.c_str(), body.length()+1);
                   if (!auth::esp_get_service_account_auth_token(
-                          const_cast<char *>(body.data()), body.length(),
-                          &auth_token, &expires) ||
-                      token == nullptr) {
+                          body_copy, body.length(), &auth_token, &expires)
+                      || token == nullptr) {
                     env->LogDebug("Failed to parse token response body");
                     token->set_state(auth::ServiceAccountToken::FAILED);
                     continuation(Status(Code::INTERNAL, kFailedTokenParse));

--- a/contrib/endpoints/src/api_manager/method_impl.cc
+++ b/contrib/endpoints/src/api_manager/method_impl.cc
@@ -42,7 +42,7 @@ MethodInfoImpl::MethodInfoImpl(const string &name, const string &api_name,
       response_streaming_(false) {}
 
 void MethodInfoImpl::addAudiencesForIssuer(const string &issuer,
-                                           const string &audiences_list) {
+                                           string audiences_list) {
   if (issuer.empty()) {
     return;
   }

--- a/contrib/endpoints/src/api_manager/method_impl.cc
+++ b/contrib/endpoints/src/api_manager/method_impl.cc
@@ -54,7 +54,7 @@ void MethodInfoImpl::addAudiencesForIssuer(const string &issuer,
   set<string> &audiences = issuer_audiences_map_[iss];
 
   // Audience list is comma-delimited with possible white spaces.
-  char *tokens = strtok(const_cast<char *>(audiences_list.c_str()), " ,");
+  char *tokens = strtok(&audiences_list[0], " ,");
   while (tokens != nullptr) {
     std::string aud = utils::GetUrlContent(tokens);
     if (!aud.empty()) {

--- a/contrib/endpoints/src/api_manager/method_impl.cc
+++ b/contrib/endpoints/src/api_manager/method_impl.cc
@@ -15,7 +15,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 #include "contrib/endpoints/src/api_manager/method_impl.h"
-#include <string.h>
+#include <cstring>
 #include "contrib/endpoints/src/api_manager/utils/url_util.h"
 
 using std::map;
@@ -42,7 +42,7 @@ MethodInfoImpl::MethodInfoImpl(const string &name, const string &api_name,
       response_streaming_(false) {}
 
 void MethodInfoImpl::addAudiencesForIssuer(const string &issuer,
-                                           string audiences_list) {
+                                           const string &audiences_list) {
   if (issuer.empty()) {
     return;
   }
@@ -52,15 +52,17 @@ void MethodInfoImpl::addAudiencesForIssuer(const string &issuer,
   }
 
   set<string> &audiences = issuer_audiences_map_[iss];
+  char *audiences_copy = new char[audiences_list.length()+1];
+  std::strcpy(audiences_copy, audiences_list.c_str());
 
   // Audience list is comma-delimited with possible white spaces.
-  char *tokens = strtok(&audiences_list[0], " ,");
+  char *tokens = std::strtok(audiences_copy, " ,");
   while (tokens != nullptr) {
     std::string aud = utils::GetUrlContent(tokens);
     if (!aud.empty()) {
       audiences.insert(aud);
     }
-    tokens = strtok(nullptr, " ,");
+    tokens = std::strtok(nullptr, " ,");
   }
 }
 

--- a/contrib/endpoints/src/api_manager/method_impl.cc
+++ b/contrib/endpoints/src/api_manager/method_impl.cc
@@ -16,6 +16,7 @@
 //
 #include "contrib/endpoints/src/api_manager/method_impl.h"
 #include <cstring>
+#include <string.h>
 #include "contrib/endpoints/src/api_manager/utils/url_util.h"
 
 using std::map;
@@ -52,8 +53,9 @@ void MethodInfoImpl::addAudiencesForIssuer(const string &issuer,
   }
 
   set<string> &audiences = issuer_audiences_map_[iss];
-  char *audiences_copy = new char[audiences_list.length()+1];
-  std::strcpy(audiences_copy, audiences_list.c_str());
+  char audiences_copy[audiences_list.length()+1];
+  std::strncpy(audiences_copy, audiences_list.c_str(),
+                audiences_list.length()+1);
 
   // Audience list is comma-delimited with possible white spaces.
   char *tokens = std::strtok(audiences_copy, " ,");

--- a/contrib/endpoints/src/api_manager/method_impl.cc
+++ b/contrib/endpoints/src/api_manager/method_impl.cc
@@ -15,9 +15,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 #include "contrib/endpoints/src/api_manager/method_impl.h"
+#include <string.h>
 #include "contrib/endpoints/src/api_manager/utils/url_util.h"
-
-#include <sstream>
 
 using std::map;
 using std::set;
@@ -51,17 +50,17 @@ void MethodInfoImpl::addAudiencesForIssuer(const string &issuer,
   if (iss.empty()) {
     return;
   }
+
   set<string> &audiences = issuer_audiences_map_[iss];
-  stringstream ss(audiences_list);
-  string audience;
-  // Audience list is comma-delimited.
-  while (getline(ss, audience, ',')) {
-    if (!audience.empty()) {  // Only adds non-empty audience.
-      std::string aud = utils::GetUrlContent(audience);
-      if (!aud.empty()) {
-        audiences.insert(aud);
-      }
+
+  // Audience list is comma-delimited with possible white spaces.
+  char *tokens = strtok(const_cast<char *>(audiences_list.c_str()), " ,");
+  while (tokens != nullptr) {
+    std::string aud = utils::GetUrlContent(tokens);
+    if (!aud.empty()) {
+      audiences.insert(aud);
     }
+    tokens = strtok(nullptr, " ,");
   }
 }
 

--- a/contrib/endpoints/src/api_manager/method_impl.h
+++ b/contrib/endpoints/src/api_manager/method_impl.h
@@ -82,7 +82,7 @@ class MethodInfoImpl : public MethodInfo {
   // Adds allowed audiences (comma delimated, no space) for the issuer.
   // audiences_list can be empty.
   void addAudiencesForIssuer(const std::string &issuer,
-                             const std::string &audiences_list);
+                             const std::string audiences_list);
   void set_auth(bool v) { auth_ = v; }
   void set_allow_unregistered_calls(bool v) { allow_unregistered_calls_ = v; }
 

--- a/contrib/endpoints/src/api_manager/method_impl.h
+++ b/contrib/endpoints/src/api_manager/method_impl.h
@@ -82,7 +82,7 @@ class MethodInfoImpl : public MethodInfo {
   // Adds allowed audiences (comma delimated, no space) for the issuer.
   // audiences_list can be empty.
   void addAudiencesForIssuer(const std::string &issuer,
-                             const std::string audiences_list);
+                             const std::string &audiences_list);
   void set_auth(bool v) { auth_ = v; }
   void set_allow_unregistered_calls(bool v) { allow_unregistered_calls_ = v; }
 


### PR DESCRIPTION
Added service config string in tests that reproduces the issue without the fix. 