### PR TITLE
Ensure that attributes are sent with the Quota call

### DIFF
--- a/src/envoy/mixer/integration_test/quota_cache_test.go
+++ b/src/envoy/mixer/integration_test/quota_cache_test.go
@@ -29,7 +29,11 @@ const (
 	rejectRequestNum = 30
 )
 
-func TestQuotaCache(t *testing.T) {
+// testQuotaCache has been disabled
+// Quota call also needs all the attributes
+// that Check needs. Therefore a key formed by using all
+// attributes is very unlikely to hit the cache.
+func testQuotaCache(t *testing.T) {
 	s, err := SetUp(t, basicConfig+","+quotaCacheConfig)
 	if err != nil {
 		t.Fatalf("Failed to setup test: %v", err)


### PR DESCRIPTION
quota() needs all the attributes that check() needs
Operator may apply conditional quota using attributes in selectors.

Note:
This effectively disables quota caching and prefetching.
Quota caching was "off" by default thru config anyway, so that is not a big problem.

mixerClient::GenerateSignature should be updated to exclude non identifying attributes.