### PR TITLE
add global context

### DIFF
--- a/contrib/endpoints/src/api_manager/api_manager_impl.h
+++ b/contrib/endpoints/src/api_manager/api_manager_impl.h
@@ -16,6 +16,7 @@
 #define API_MANAGER_API_MANAGER_IMPL_H_
 
 #include "contrib/endpoints/include/api_manager/api_manager.h"
+#include "contrib/endpoints/src/api_manager/context/global_context.h"
 #include "contrib/endpoints/src/api_manager/context/service_context.h"
 #include "contrib/endpoints/src/api_manager/service_control/interface.h"
 
@@ -28,7 +29,7 @@ class CheckWorkflow;
 class ApiManagerImpl : public ApiManager {
  public:
   ApiManagerImpl(std::unique_ptr<ApiManagerEnvInterface> env,
-                 std::unique_ptr<Config> config);
+                 const std::string &server_config);
 
   virtual bool Enabled() const { return service_context_->Enabled(); }
 
@@ -87,6 +88,9 @@ class ApiManagerImpl : public ApiManager {
     return service_context_->DisableLogStatus();
   };
 
+  // Add a new config.
+  void AddConfig(std::unique_ptr<Config> config);
+
  private:
   service_control::Interface *service_control() const {
     return service_context_->service_control();
@@ -95,7 +99,10 @@ class ApiManagerImpl : public ApiManager {
   // The check work flow.
   std::shared_ptr<CheckWorkflow> check_workflow_;
 
+  // Global context across multiple services.
+  std::shared_ptr<context::GlobalContext> global_context_;
   // Service context
+  // TODO: will be a map<config_id, ServiceContext>
   std::shared_ptr<context::ServiceContext> service_context_;
 };
 

--- a/contrib/endpoints/src/api_manager/api_manager_impl.h
+++ b/contrib/endpoints/src/api_manager/api_manager_impl.h
@@ -103,6 +103,9 @@ class ApiManagerImpl : public ApiManager {
   std::shared_ptr<context::GlobalContext> global_context_;
   // Service context
   // TODO: will be a map<config_id, ServiceContext>
+  // All ServiceContext objects are referring to the same service
+  // but different versions. One ESP instance needs to load
+  // multiple versions in order to support service rollout automation.
   std::shared_ptr<context::ServiceContext> service_context_;
 };
 

--- a/contrib/endpoints/src/api_manager/check_auth_test.cc
+++ b/contrib/endpoints/src/api_manager/check_auth_test.cc
@@ -326,12 +326,11 @@ class CheckAuthTest : public ::testing::Test {
     // save the raw pointer of env before calling std::move(env).
     raw_env_ = env.get();
 
-    std::unique_ptr<Config> config =
-        Config::Create(raw_env_, kServiceConfig, "");
+    std::unique_ptr<Config> config = Config::Create(raw_env_, kServiceConfig);
     ASSERT_NE(config.get(), nullptr);
 
     service_context_ = std::make_shared<context::ServiceContext>(
-        std::move(env), std::move(config));
+        std::move(env), "", std::move(config));
     ASSERT_NE(service_context_.get(), nullptr);
 
     std::unique_ptr<MockRequest> request(

--- a/contrib/endpoints/src/api_manager/check_security_rules_test.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules_test.cc
@@ -235,13 +235,12 @@ class CheckDisableSecurityRulesTest
     std::string server_config;
 
     std::tie(service_config, server_config) = GetParam();
-    std::unique_ptr<Config> config =
-        Config::Create(raw_env, service_config, server_config);
+    std::unique_ptr<Config> config = Config::Create(raw_env, service_config);
 
     ASSERT_TRUE(config != nullptr);
 
     service_context_ = std::make_shared<context::ServiceContext>(
-        std::move(env), std::move(config));
+        std::move(env), server_config, std::move(config));
 
     ASSERT_TRUE(service_context_.get() != nullptr);
 
@@ -279,12 +278,11 @@ class CheckSecurityRulesTest : public ::testing::Test {
         new ::testing::NiceMock<MockApiManagerEnvironment>());
     raw_env_ = env.get();
 
-    std::unique_ptr<Config> config =
-        Config::Create(raw_env_, service_config, server_config);
+    std::unique_ptr<Config> config = Config::Create(raw_env_, service_config);
     ASSERT_TRUE(config != nullptr);
 
     service_context_ = std::make_shared<context::ServiceContext>(
-        std::move(env), std::move(config));
+        std::move(env), server_config, std::move(config));
 
     ASSERT_TRUE(service_context_.get() != nullptr);
 

--- a/contrib/endpoints/src/api_manager/config.h
+++ b/contrib/endpoints/src/api_manager/config.h
@@ -40,9 +40,19 @@ class Config {
   // any of protobuf format json, binary or text. It can be nullptr if there is
   // not server_config.
   static std::unique_ptr<Config> Create(ApiManagerEnvInterface *env,
+                                        const std::string &service_config);
+  // For unit test only
+  static std::unique_ptr<Config> Create(ApiManagerEnvInterface *env,
                                         const std::string &service_config,
                                         const std::string &server_config);
 
+  // Loads the server config into protobuf.
+  static std::shared_ptr<proto::ServerConfig> LoadServerConfig(
+      ApiManagerEnvInterface *env, const std::string &server_config);
+
+  void set_server_config(std::shared_ptr<proto::ServerConfig> server_config) {
+    server_config_ = server_config;
+  }
   // Returns server_config.  nullptr if no server_config.
   const proto::ServerConfig *server_config() const {
     return server_config_.get();
@@ -90,10 +100,6 @@ class Config {
   bool LoadService(ApiManagerEnvInterface *env,
                    const std::string &service_config);
 
-  // Loads the server config into protobuf.
-  void LoadServerConfig(ApiManagerEnvInterface *env,
-                        const std::string &server_config);
-
   // Create MethodInfo for HTTP methods, register them to PathMatcher.
   bool LoadHttpMethods(ApiManagerEnvInterface *env,
                        PathMatcherBuilder<MethodInfo *> *pmb);
@@ -127,7 +133,7 @@ class Config {
   bool LoadBackends(ApiManagerEnvInterface *env);
 
   ::google::api::Service service_;
-  std::unique_ptr<proto::ServerConfig> server_config_;
+  std::shared_ptr<proto::ServerConfig> server_config_;
   PathMatcherPtr<MethodInfo *> path_matcher_;
   std::map<std::string, MethodInfoImplPtr> method_map_;
   // Maps issuer to {jwksUri, openIdValid} pair.

--- a/contrib/endpoints/src/api_manager/context/BUILD
+++ b/contrib/endpoints/src/api_manager/context/BUILD
@@ -19,10 +19,12 @@ package(default_visibility = ["//contrib/endpoints/src/api_manager:__subpackages
 cc_library(
     name = "context",
     srcs = [
+        "global_context.cc",
         "request_context.cc",
         "service_context.cc",
     ],
     hdrs = [
+        "global_context.h",
         "request_context.h",
         "service_context.h",
     ],
@@ -35,8 +37,8 @@ cc_library(
     }),
     deps = [
         "//contrib/endpoints/src/api_manager:http_template",
-        "//contrib/endpoints/src/api_manager:path_matcher",
         "//contrib/endpoints/src/api_manager:impl_headers",
+        "//contrib/endpoints/src/api_manager:path_matcher",
         "//contrib/endpoints/src/api_manager:server_config_proto",
         "//contrib/endpoints/src/api_manager/auth",
         "//contrib/endpoints/src/api_manager/auth:service_account_token",

--- a/contrib/endpoints/src/api_manager/context/global_context.cc
+++ b/contrib/endpoints/src/api_manager/context/global_context.cc
@@ -1,0 +1,119 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+#include "contrib/endpoints/src/api_manager/context/global_context.h"
+#include "contrib/endpoints/src/api_manager/config.h"
+#include "contrib/endpoints/src/api_manager/service_control/aggregated.h"
+
+namespace google {
+namespace api_manager {
+namespace context {
+
+namespace {
+
+// Default Cloud Trace URL. Points to prod Cloud Trace.
+const char kCloudTraceUrl[] = "https://cloudtrace.googleapis.com";
+
+// Default maximum time to aggregate traces.
+const int kDefaultAggregateTimeMillisec = 1000;
+
+// Default maximum amount of traces to aggregate. The amount should ensure
+// the http request payload with the aggregated traces not reaching MB in size.
+const int kDefaultTraceCacheMaxSize = 100;
+
+// Default trace sample rate, in QPS.
+const double kDefaultTraceSampleQps = 0.1;
+
+// The time window to send intermediate report for Grpc streaming (second).
+// Default to 10s.
+const int kIntermediateReportInterval = 10;
+
+}  // namespace
+
+GlobalContext::GlobalContext(std::unique_ptr<ApiManagerEnvInterface> env,
+                             const std::string& server_config)
+    : env_(std::move(env)),
+      service_account_token_(env_.get()),
+      is_auth_force_disabled_(false) {
+  // Need to load server config first.
+  server_config_ = Config::LoadServerConfig(env_.get(), server_config);
+
+  cloud_trace_aggregator_ = CreateCloudTraceAggregator();
+
+  is_auth_force_disabled_ =
+      server_config_ && server_config_->has_api_authentication_config() &&
+      server_config_->api_authentication_config().force_disable();
+
+  // Check server_config override.
+  intermediate_report_interval_ = kIntermediateReportInterval;
+  if (server_config_ && server_config_->has_service_control_config() &&
+      server_config_->service_control_config()
+          .intermediate_report_min_interval()) {
+    intermediate_report_interval_ = server_config_->service_control_config()
+                                        .intermediate_report_min_interval();
+  }
+}
+
+std::unique_ptr<cloud_trace::Aggregator>
+GlobalContext::CreateCloudTraceAggregator() {
+  // If force_disable is set in server config, completely disable tracing.
+  if (server_config_ &&
+      server_config_->cloud_tracing_config().force_disable()) {
+    env()->LogInfo(
+        "Cloud Trace is force disabled. There will be no trace written.");
+    return std::unique_ptr<cloud_trace::Aggregator>();
+  }
+
+  std::string url = kCloudTraceUrl;
+  int aggregate_time_millisec = kDefaultAggregateTimeMillisec;
+  int cache_max_size = kDefaultTraceCacheMaxSize;
+  double minimum_qps = kDefaultTraceSampleQps;
+  if (server_config_ && server_config_->has_cloud_tracing_config()) {
+    // If url_override is set in server config, use it to query Cloud Trace.
+    const auto& tracing_config = server_config_->cloud_tracing_config();
+    if (!tracing_config.url_override().empty()) {
+      url = tracing_config.url_override();
+    }
+
+    // If aggregation config is set, take the values from it.
+    if (tracing_config.has_aggregation_config()) {
+      aggregate_time_millisec =
+          tracing_config.aggregation_config().time_millisec();
+      cache_max_size = tracing_config.aggregation_config().cache_max_size();
+    }
+
+    // If sampling config is set, take the values from it.
+    if (tracing_config.has_samling_config()) {
+      minimum_qps = tracing_config.samling_config().minimum_qps();
+    }
+  }
+
+  return std::unique_ptr<cloud_trace::Aggregator>(new cloud_trace::Aggregator(
+      &service_account_token_, url, aggregate_time_millisec, cache_max_size,
+      minimum_qps, env_.get()));
+}
+
+const std::string& GlobalContext::project_id() const {
+  if (gce_metadata_.has_valid_data() && !gce_metadata_.project_id().empty()) {
+    return gce_metadata_.project_id();
+  }
+  static std::string empty;
+  return empty;
+}
+
+}  // namespace context
+}  // namespace api_manager
+}  // namespace google

--- a/contrib/endpoints/src/api_manager/context/global_context.h
+++ b/contrib/endpoints/src/api_manager/context/global_context.h
@@ -1,0 +1,117 @@
+/* Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_
+#define API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_
+
+#include "contrib/endpoints/src/api_manager/auth/certs.h"
+#include "contrib/endpoints/src/api_manager/auth/jwt_cache.h"
+#include "contrib/endpoints/src/api_manager/auth/service_account_token.h"
+#include "contrib/endpoints/src/api_manager/cloud_trace/cloud_trace.h"
+#include "contrib/endpoints/src/api_manager/gce_metadata.h"
+#include "contrib/endpoints/src/api_manager/proto/server_config.pb.h"
+
+namespace google {
+namespace api_manager {
+
+namespace context {
+
+// A global context shared across all services. It stores
+// * env
+// * server_config
+// * service_account_token
+// * certs and jwt_cache
+// * metadata server and fetched data.
+// * cloud trace object.
+class GlobalContext {
+ public:
+  GlobalContext(std::unique_ptr<ApiManagerEnvInterface> env,
+                const std::string &server_config);
+
+  // the env interface.
+  ApiManagerEnvInterface *env() { return env_.get(); }
+
+  // the service account token store
+  auth::ServiceAccountToken *service_account_token() {
+    return &service_account_token_;
+  }
+
+  // certs and jwt_cache
+  auth::Certs &certs() { return certs_; }
+  auth::JwtCache &jwt_cache() { return jwt_cache_; }
+
+  // metadata server
+  void SetMetadataServer(const std::string &server) {
+    metadata_server_ = server;
+  }
+  const std::string &metadata_server() const { return metadata_server_; }
+
+  // fetched metadata.
+  GceMetadata *gce_metadata() { return &gce_metadata_; }
+
+  // cloud_trace
+  cloud_trace::Aggregator *cloud_trace_aggregator() const {
+    return cloud_trace_aggregator_.get();
+  }
+
+  std::shared_ptr<proto::ServerConfig> server_config() {
+    return server_config_;
+  }
+
+  // report interval can be override by server_config.
+  int64_t intermediate_report_interval() const {
+    return intermediate_report_interval_;
+  }
+
+  // Check if auth is disabled from server_config.
+  bool is_auth_force_disabled() const { return is_auth_force_disabled_; }
+
+  // get producer project id from fetched metadata
+  const std::string &project_id() const;
+
+ private:
+  // create cloud trace.
+  std::unique_ptr<cloud_trace::Aggregator> CreateCloudTraceAggregator();
+
+  std::unique_ptr<ApiManagerEnvInterface> env_;
+
+  auth::Certs certs_;
+  auth::JwtCache jwt_cache_;
+
+  std::shared_ptr<proto::ServerConfig> server_config_;
+
+  // service account tokens
+  auth::ServiceAccountToken service_account_token_;
+
+  // The service control object. When trace is force disabled, this will be a
+  // nullptr.
+  std::unique_ptr<cloud_trace::Aggregator> cloud_trace_aggregator_;
+
+  // meta data server.
+  std::string metadata_server_;
+  // GCE metadata
+  GceMetadata gce_metadata_;
+
+  // Is auth force-disabled
+  bool is_auth_force_disabled_;
+
+  // The time interval for grpc intermediate report.
+  int64_t intermediate_report_interval_;
+};
+
+}  // namespace context
+}  // namespace api_manager
+}  // namespace google
+
+#endif  // API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_

--- a/contrib/endpoints/src/api_manager/context/global_context.h
+++ b/contrib/endpoints/src/api_manager/context/global_context.h
@@ -47,10 +47,6 @@ class GlobalContext {
     return &service_account_token_;
   }
 
-  // certs and jwt_cache
-  auth::Certs &certs() { return certs_; }
-  auth::JwtCache &jwt_cache() { return jwt_cache_; }
-
   // metadata server
   void SetMetadataServer(const std::string &server) {
     metadata_server_ = server;
@@ -85,9 +81,6 @@ class GlobalContext {
   std::unique_ptr<cloud_trace::Aggregator> CreateCloudTraceAggregator();
 
   std::unique_ptr<ApiManagerEnvInterface> env_;
-
-  auth::Certs certs_;
-  auth::JwtCache jwt_cache_;
 
   std::shared_ptr<proto::ServerConfig> server_config_;
 

--- a/contrib/endpoints/src/api_manager/context/service_context.h
+++ b/contrib/endpoints/src/api_manager/context/service_context.h
@@ -72,8 +72,8 @@ class ServiceContext {
            !config_->GetFirebaseServer().empty();
   }
 
-  auth::Certs &certs() { return global_context_->certs(); }
-  auth::JwtCache &jwt_cache() { return global_context_->jwt_cache(); }
+  auth::Certs &certs() { return certs_; }
+  auth::JwtCache &jwt_cache() { return jwt_cache_; }
 
   bool GetJwksUri(const std::string &issuer, std::string *url) {
     return config_->GetJwksUri(issuer, url);
@@ -114,6 +114,9 @@ class ServiceContext {
   std::shared_ptr<GlobalContext> global_context_;
   // The service config object.
   std::unique_ptr<Config> config_;
+
+  auth::Certs certs_;
+  auth::JwtCache jwt_cache_;
 
   // The service control object.
   std::unique_ptr<service_control::Interface> service_control_;

--- a/contrib/endpoints/src/api_manager/context/service_context.h
+++ b/contrib/endpoints/src/api_manager/context/service_context.h
@@ -16,12 +16,8 @@
 #define API_MANAGER_CONTEXT_SERVICE_CONTEXT_H_
 
 #include "contrib/endpoints/include/api_manager/method.h"
-#include "contrib/endpoints/src/api_manager/auth/certs.h"
-#include "contrib/endpoints/src/api_manager/auth/jwt_cache.h"
-#include "contrib/endpoints/src/api_manager/auth/service_account_token.h"
-#include "contrib/endpoints/src/api_manager/cloud_trace/cloud_trace.h"
 #include "contrib/endpoints/src/api_manager/config.h"
-#include "contrib/endpoints/src/api_manager/gce_metadata.h"
+#include "contrib/endpoints/src/api_manager/context/global_context.h"
 #include "contrib/endpoints/src/api_manager/service_control/interface.h"
 
 namespace google {
@@ -33,7 +29,11 @@ namespace context {
 // Each RequestContext will hold a refcount to this object.
 class ServiceContext {
  public:
+  ServiceContext(std::shared_ptr<GlobalContext> global_context,
+                 std::unique_ptr<Config> config);
+  // For unit-test only.  It will create a global context
   ServiceContext(std::unique_ptr<ApiManagerEnvInterface> env,
+                 const std::string &server_config,
                  std::unique_ptr<Config> config);
 
   bool Enabled() const { return RequireAuth() || service_control_; }
@@ -42,16 +42,18 @@ class ServiceContext {
 
   const ::google::api::Service &service() const { return config_->service(); }
 
+  Config *config() { return config_.get(); }
+
+  // Following methods will be delegated to global context.
   void SetMetadataServer(const std::string &server) {
-    metadata_server_ = server;
+    global_context_->SetMetadataServer(server);
   }
 
   auth::ServiceAccountToken *service_account_token() {
-    return &service_account_token_;
+    return global_context_->service_account_token();
   }
 
-  ApiManagerEnvInterface *env() { return env_.get(); }
-  Config *config() { return config_.get(); }
+  ApiManagerEnvInterface *env() { return global_context_->env(); }
 
   MethodCallInfo GetMethodCallInfo(const std::string &http_method,
                                    const std::string &url,
@@ -62,7 +64,7 @@ class ServiceContext {
   }
 
   bool RequireAuth() const {
-    return !is_auth_force_disabled_ && config_->HasAuth();
+    return !global_context_->is_auth_force_disabled() && config_->HasAuth();
   }
 
   bool IsRulesCheckEnabled() const {
@@ -70,8 +72,8 @@ class ServiceContext {
            !config_->GetFirebaseServer().empty();
   }
 
-  auth::Certs &certs() { return certs_; }
-  auth::JwtCache &jwt_cache() { return jwt_cache_; }
+  auth::Certs &certs() { return global_context_->certs(); }
+  auth::JwtCache &jwt_cache() { return global_context_->jwt_cache(); }
 
   bool GetJwksUri(const std::string &issuer, std::string *url) {
     return config_->GetJwksUri(issuer, url);
@@ -82,11 +84,13 @@ class ServiceContext {
     config_->SetJwksUri(issuer, jwks_uri, openid_valid);
   }
 
-  const std::string &metadata_server() const { return metadata_server_; }
-  GceMetadata *gce_metadata() { return &gce_metadata_; }
+  const std::string &metadata_server() const {
+    return global_context_->metadata_server();
+  }
+  GceMetadata *gce_metadata() { return global_context_->gce_metadata(); }
   const std::string &project_id() const;
   cloud_trace::Aggregator *cloud_trace_aggregator() const {
-    return cloud_trace_aggregator_.get();
+    return global_context_->cloud_trace_aggregator();
   }
 
   bool DisableLogStatus() {
@@ -99,40 +103,20 @@ class ServiceContext {
   }
 
   int64_t intermediate_report_interval() const {
-    return intermediate_report_interval_;
+    return global_context_->intermediate_report_interval();
   }
 
  private:
+  // Create service control.
   std::unique_ptr<service_control::Interface> CreateInterface();
 
-  std::unique_ptr<cloud_trace::Aggregator> CreateCloudTraceAggregator();
-
-  std::unique_ptr<ApiManagerEnvInterface> env_;
+  // The shared global context object.
+  std::shared_ptr<GlobalContext> global_context_;
+  // The service config object.
   std::unique_ptr<Config> config_;
-
-  auth::Certs certs_;
-  auth::JwtCache jwt_cache_;
-
-  // service account tokens
-  auth::ServiceAccountToken service_account_token_;
 
   // The service control object.
   std::unique_ptr<service_control::Interface> service_control_;
-
-  // The service control object. When trace is force disabled, this will be a
-  // nullptr.
-  std::unique_ptr<cloud_trace::Aggregator> cloud_trace_aggregator_;
-
-  // meta data server.
-  std::string metadata_server_;
-  // GCE metadata
-  GceMetadata gce_metadata_;
-
-  // Is auth force-disabled
-  bool is_auth_force_disabled_;
-
-  // The time interval for grpc intermediate report.
-  int64_t intermediate_report_interval_;
 };
 
 }  // namespace context

--- a/contrib/endpoints/src/api_manager/fetch_metadata_test.cc
+++ b/contrib/endpoints/src/api_manager/fetch_metadata_test.cc
@@ -52,12 +52,11 @@ class FetchMetadataTest : public ::testing::Test {
     // save the raw pointer of env before calling std::move(env).
     raw_env_ = env.get();
 
-    std::unique_ptr<Config> config =
-        Config::Create(raw_env_, kServiceConfig, "");
+    std::unique_ptr<Config> config = Config::Create(raw_env_, kServiceConfig);
     ASSERT_NE(config.get(), nullptr);
 
     service_context_ = std::make_shared<context::ServiceContext>(
-        std::move(env), std::move(config));
+        std::move(env), "", std::move(config));
     ASSERT_NE(service_context_.get(), nullptr);
 
     service_context_->SetMetadataServer(kMetadataServer);


### PR DESCRIPTION
This is in preparation for service rollout feature to support multiple services.
==Create a GlobalContext object and move global objects from ServiceContext.
== Server_config is stored in GlobalContext and in Config by using share_ptr.

It seems that incremental change can be done in the master branch without impacting basic features.  So I am trying to develop this feature in the master branch.  