### PR TITLE
Update api manager interface.

### DIFF
--- a/contrib/endpoints/include/api_manager/api_manager.h
+++ b/contrib/endpoints/include/api_manager/api_manager.h
@@ -46,15 +46,9 @@ class ApiManager {
   // Gets the service name.
   virtual const std::string &service_name() const = 0;
 
-  // Gets the service config
-  virtual const ::google::api::Service &service() const = 0;
-
-  // Set the metadata server for GCP platforms.
-  virtual void SetMetadataServer(const std::string &server) = 0;
-
-  // Sets the client auth secret and uses it to generate auth token.
-  // If it fails to generate an auth token, return failure.
-  virtual utils::Status SetClientAuthSecret(const std::string &secret) = 0;
+  // Gets the service config by config_id.
+  virtual const ::google::api::Service &service(
+      const std::string &config_id) const = 0;
 
   // Initializes the API Manager. It should be called:
   // 1) Before first CreateRequestHandler().
@@ -103,22 +97,12 @@ class ApiManager {
 class ApiManagerFactory {
  public:
   ApiManagerFactory() {}
-  ~ApiManagerFactory() {}
+  virtual ~ApiManagerFactory() {}
 
-  // Gets or creates an ApiManager instance. Service configurations with the
-  // same service names will resolve to the same live ApiManager instance.
-  // The environment is used iff the instance needs to be created;
-  // otherwise, it's deleted. This means that the returned ApiManager may
-  // use a different environment than the one provided.
-  std::shared_ptr<ApiManager> GetOrCreateApiManager(
+  // Create an ApiManager object.
+  std::shared_ptr<ApiManager> CreateApiManager(
       std::unique_ptr<ApiManagerEnvInterface> env,
       const std::string &service_config, const std::string &server_config);
-
- private:
-  typedef std::map<std::string, std::weak_ptr<ApiManager>> ApiManagerMap;
-  ApiManagerMap api_manager_map_;
-
-  GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ApiManagerFactory);
 };
 
 }  // namespace api_manager

--- a/contrib/endpoints/include/api_manager/request_handler_interface.h
+++ b/contrib/endpoints/include/api_manager/request_handler_interface.h
@@ -44,6 +44,9 @@ class RequestHandlerInterface {
   // Attempt to send intermediate report in streaming calls.
   virtual void AttemptIntermediateReport() = 0;
 
+  // Get the service config_id this request is using.
+  virtual std::string GetServiceConfigId() const = 0;
+
   // Get the backend address.
   virtual std::string GetBackendAddress() const = 0;
 

--- a/contrib/endpoints/src/api_manager/api_manager_impl.cc
+++ b/contrib/endpoints/src/api_manager/api_manager_impl.cc
@@ -15,26 +15,32 @@
 ////////////////////////////////////////////////////////////////////////////////
 //
 #include "contrib/endpoints/src/api_manager/api_manager_impl.h"
-
 #include "contrib/endpoints/src/api_manager/check_workflow.h"
 #include "contrib/endpoints/src/api_manager/request_handler.h"
-
-using ::google::api_manager::proto::ServerConfig;
 
 namespace google {
 namespace api_manager {
 
 ApiManagerImpl::ApiManagerImpl(std::unique_ptr<ApiManagerEnvInterface> env,
-                               const std::string& server_config)
+                               const std::string &service_config,
+                               const std::string &server_config)
     : global_context_(
           new context::GlobalContext(std::move(env), server_config)) {
+  if (!service_config.empty()) {
+    AddConfig(service_config);
+  }
+
   check_workflow_ = std::unique_ptr<CheckWorkflow>(new CheckWorkflow);
   check_workflow_->RegisterAll();
 }
 
-void ApiManagerImpl::AddConfig(std::unique_ptr<Config> config) {
-  service_context_ = std::make_shared<context::ServiceContext>(
-      global_context_, std::move(config));
+void ApiManagerImpl::AddConfig(const std::string &service_config) {
+  std::unique_ptr<Config> config =
+      Config::Create(global_context_->env(), service_config);
+  if (config != nullptr) {
+    service_context_ = std::make_shared<context::ServiceContext>(
+        global_context_, std::move(config));
+  }
 }
 
 std::unique_ptr<RequestHandlerInterface> ApiManagerImpl::CreateRequestHandler(
@@ -43,29 +49,11 @@ std::unique_ptr<RequestHandlerInterface> ApiManagerImpl::CreateRequestHandler(
       check_workflow_, service_context_, std::move(request_data)));
 }
 
-std::shared_ptr<ApiManager> ApiManagerFactory::GetOrCreateApiManager(
+std::shared_ptr<ApiManager> ApiManagerFactory::CreateApiManager(
     std::unique_ptr<ApiManagerEnvInterface> env,
-    const std::string& service_config, const std::string& server_config) {
-  std::unique_ptr<Config> config = Config::Create(env.get(), service_config);
-  if (config == nullptr) {
-    return nullptr;
-  }
-
-  ApiManagerMap::iterator it;
-  std::tie(it, std::ignore) = api_manager_map_.emplace(
-      config->service_name(), std::weak_ptr<ApiManager>());
-  std::shared_ptr<ApiManager> result = it->second.lock();
-
-  if (!result) {
-    // TODO: Handle the case where the caller gives us a different
-    // config with the same service name.
-    auto api_impl = new ApiManagerImpl(std::move(env), server_config);
-    api_impl->AddConfig(std::move(config));
-    result = std::shared_ptr<ApiManager>(api_impl);
-    it->second = result;
-  }
-
-  return result;
+    const std::string &service_config, const std::string &server_config) {
+  return std::shared_ptr<ApiManager>(
+      new ApiManagerImpl(std::move(env), service_config, server_config));
 }
 
 }  // namespace api_manager

--- a/contrib/endpoints/src/api_manager/api_manager_impl.h
+++ b/contrib/endpoints/src/api_manager/api_manager_impl.h
@@ -29,6 +29,7 @@ class CheckWorkflow;
 class ApiManagerImpl : public ApiManager {
  public:
   ApiManagerImpl(std::unique_ptr<ApiManagerEnvInterface> env,
+                 const std::string &service_config,
                  const std::string &server_config);
 
   virtual bool Enabled() const { return service_context_->Enabled(); }
@@ -37,17 +38,10 @@ class ApiManagerImpl : public ApiManager {
     return service_context_->service_name();
   }
 
-  virtual const ::google::api::Service &service() const {
+  virtual const ::google::api::Service &service(
+      const std::string &config_id) const {
+    // TODO: use config_id.
     return service_context_->service();
-  }
-
-  virtual void SetMetadataServer(const std::string &server) {
-    service_context_->SetMetadataServer(server);
-  }
-
-  virtual utils::Status SetClientAuthSecret(const std::string &secret) {
-    return service_context_->service_account_token()->SetClientAuthSecret(
-        secret);
   }
 
   virtual utils::Status Init() {
@@ -88,8 +82,8 @@ class ApiManagerImpl : public ApiManager {
     return service_context_->DisableLogStatus();
   };
 
-  // Add a new config.
-  void AddConfig(std::unique_ptr<Config> config);
+  // Add a new service config.
+  void AddConfig(const std::string &service_config);
 
  private:
   service_control::Interface *service_control() const {

--- a/contrib/endpoints/src/api_manager/context/global_context.h
+++ b/contrib/endpoints/src/api_manager/context/global_context.h
@@ -47,10 +47,6 @@ class GlobalContext {
     return &service_account_token_;
   }
 
-  // metadata server
-  void SetMetadataServer(const std::string &server) {
-    metadata_server_ = server;
-  }
   const std::string &metadata_server() const { return metadata_server_; }
 
   // fetched metadata.

--- a/contrib/endpoints/src/api_manager/context/service_context.h
+++ b/contrib/endpoints/src/api_manager/context/service_context.h
@@ -44,11 +44,6 @@ class ServiceContext {
 
   Config *config() { return config_.get(); }
 
-  // Following methods will be delegated to global context.
-  void SetMetadataServer(const std::string &server) {
-    global_context_->SetMetadataServer(server);
-  }
-
   auth::ServiceAccountToken *service_account_token() {
     return global_context_->service_account_token();
   }

--- a/contrib/endpoints/src/api_manager/fetch_metadata_test.cc
+++ b/contrib/endpoints/src/api_manager/fetch_metadata_test.cc
@@ -16,6 +16,7 @@
 //
 #include "contrib/endpoints/src/api_manager/fetch_metadata.h"
 
+#include "contrib/endpoints/src/api_manager/context/global_context.h"
 #include "contrib/endpoints/src/api_manager/context/service_context.h"
 #include "contrib/endpoints/src/api_manager/mock_api_manager_environment.h"
 #include "contrib/endpoints/src/api_manager/mock_request.h"
@@ -41,8 +42,15 @@ const char kServiceConfig[] = R"(
   }
 })";
 
+const char kServerConfig[] = R"(
+{
+  "metadata_server_config": {
+     "enabled": true,
+     "url": "http://127.0.0.1:8090"
+   }
+})";
+
 const char kEmptyBody[] = R"({})";
-const char kMetadataServer[] = "http://127.0.0.1:8090";
 
 class FetchMetadataTest : public ::testing::Test {
  public:
@@ -54,12 +62,11 @@ class FetchMetadataTest : public ::testing::Test {
 
     std::unique_ptr<Config> config = Config::Create(raw_env_, kServiceConfig);
     ASSERT_NE(config.get(), nullptr);
-
+    auto global_context =
+        std::make_shared<context::GlobalContext>(std::move(env), kServerConfig);
     service_context_ = std::make_shared<context::ServiceContext>(
-        std::move(env), "", std::move(config));
+        global_context, std::move(config));
     ASSERT_NE(service_context_.get(), nullptr);
-
-    service_context_->SetMetadataServer(kMetadataServer);
 
     std::unique_ptr<MockRequest> request(
         new ::testing::NiceMock<MockRequest>());

--- a/contrib/endpoints/src/api_manager/request_handler.cc
+++ b/contrib/endpoints/src/api_manager/request_handler.cc
@@ -115,6 +115,10 @@ void RequestHandler::Report(std::unique_ptr<Response> response,
   continuation();
 }
 
+std::string RequestHandler::GetServiceConfigId() const {
+  return context_->service_context()->service().id();
+}
+
 std::string RequestHandler::GetBackendAddress() const {
   if (context_->method()) {
     return context_->method()->backend_address();

--- a/contrib/endpoints/src/api_manager/request_handler.h
+++ b/contrib/endpoints/src/api_manager/request_handler.h
@@ -40,6 +40,8 @@ class RequestHandler : public RequestHandlerInterface {
   virtual void Report(std::unique_ptr<Response> response,
                       std::function<void(void)> continuation);
 
+  virtual std::string GetServiceConfigId() const;
+
   virtual void AttemptIntermediateReport();
 
   virtual std::string GetBackendAddress() const;


### PR DESCRIPTION
1) For external to create transcoding_factory which requires service_config,  request_handler will return config_id and api_manager has get_service(config_id).
2) Remove SetMeatadataServer and SetClientAuthSecrect function calls in api_manager,  these data are already in server_config, global_context can get them directly.
3) Simplify ApiManagerFactory, not to re-use api_manager object with same service.  Always create a new api_manager object.