### PR TITLE
fetch_metadata to use global context.

### DIFF
--- a/contrib/endpoints/src/api_manager/context/service_context.h
+++ b/contrib/endpoints/src/api_manager/context/service_context.h
@@ -92,6 +92,8 @@ class ServiceContext {
     return global_context_->intermediate_report_interval();
   }
 
+  std::shared_ptr<GlobalContext> global_context() { return global_context_; }
+
  private:
   // Create service control.
   std::unique_ptr<service_control::Interface> CreateInterface();

--- a/contrib/endpoints/src/api_manager/fetch_metadata.h
+++ b/contrib/endpoints/src/api_manager/fetch_metadata.h
@@ -16,10 +16,19 @@
 #define API_MANAGER_FETCH_METADATA_H_
 
 #include "contrib/endpoints/include/api_manager/utils/status.h"
+#include "contrib/endpoints/src/api_manager/context/global_context.h"
 #include "contrib/endpoints/src/api_manager/context/request_context.h"
 
 namespace google {
 namespace api_manager {
+
+// Fetchs GCE metadata from metadata server.
+void GlobalFetchGceMetadata(std::shared_ptr<context::GlobalContext>,
+                            std::function<void(utils::Status)>);
+
+// Fetchs service account token from metadata server.
+void GlobalFetchServiceAccountToken(std::shared_ptr<context::GlobalContext>,
+                                    std::function<void(utils::Status)>);
 
 // Fetchs GCE metadata from metadata server.
 void FetchGceMetadata(std::shared_ptr<context::RequestContext>,


### PR DESCRIPTION
So the code can be shared by the new config_manager