### PR TITLE
Handle Json to Proto crash on empty TestRulesetResponse.

### DIFF
--- a/contrib/endpoints/src/api_manager/check_security_rules.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules.cc
@@ -148,8 +148,8 @@ void AuthzChecker::CallNextRequest(
             http_request.token_type, http_request.audience,
             [continuation, checker](Status status, std::string &&body) {
 
-              checker->env_->LogError(std::string("Response Body = ") + body);
-              if (status.ok() && !body.empty()) {
+              checker->env_->LogInfo(std::string("Response Body = ") + body);
+              if (status.ok() && !body.empty() && body != "{}") {
                 checker->request_handler_->UpdateResponse(body);
                 checker->CallNextRequest(continuation);
               } else {

--- a/contrib/endpoints/src/api_manager/check_security_rules_test.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules_test.cc
@@ -464,8 +464,7 @@ TEST_F(CheckSecurityRulesTest, CheckAuthzFailWithEmptyTestRulesetResponse) {
   request_context_->set_auth_claims(kJwtEmailPayload);
   ExpectCall(release_url_, "GET", "", kRelease);
 
-  ExpectCall(ruleset_test_url_, "POST", kFirstRequest,
-             "{}");
+  ExpectCall(ruleset_test_url_, "POST", kFirstRequest, "{}");
   CheckSecurityRules(request_context_, [](Status status) {
     ASSERT_TRUE(status.CanonicalCode() == Code::INTERNAL);
   });

--- a/contrib/endpoints/src/api_manager/check_security_rules_test.cc
+++ b/contrib/endpoints/src/api_manager/check_security_rules_test.cc
@@ -455,6 +455,22 @@ TEST_F(CheckSecurityRulesTest, CheckAuthzFailWithTestResultFailure) {
   });
 }
 
+TEST_F(CheckSecurityRulesTest, CheckAuthzFailWithEmptyTestRulesetResponse) {
+  std::string service_config = std::string(kServiceName) + kProducerProjectId +
+                               kApis + kAuthentication + kHttp;
+  std::string server_config = kServerConfig;
+  SetUp(service_config, server_config);
+
+  request_context_->set_auth_claims(kJwtEmailPayload);
+  ExpectCall(release_url_, "GET", "", kRelease);
+
+  ExpectCall(ruleset_test_url_, "POST", kFirstRequest,
+             "{}");
+  CheckSecurityRules(request_context_, [](Status status) {
+    ASSERT_TRUE(status.CanonicalCode() == Code::INTERNAL);
+  });
+}
+
 // Check for success case.
 // 1. Ensure GetRelease is invoked properly and in this case mock responds with
 // the ruelset Id.


### PR DESCRIPTION
This only happens on google projects that are not whitelisted. Invoking a TestRulesetRequest on a non-firebase project will result in a response with "200 OK" with an empty body "{}". Firebase rules service does not return a HTTP error in this case. We use the JsonToProto to handle this issue and it crashes when we give it an empty json. This will be a non-issue once TestRulesetRequest API is made public soon. 