### PR TITLE
fix test failures.

### DIFF
--- a/src/envoy/mixer/integration_test/repositories.bzl
+++ b/src/envoy/mixer/integration_test/repositories.bzl
@@ -211,6 +211,6 @@ def go_mixer_repositories(use_local_api=False):
 
     go_repository(
         name = "com_github_istio_mixer",
-        commit = "f987228ebce1d02470a6d4f8fbc8a9f75521edcb",
+        commit = "a6bfb91da1325908fa8084dbe06486436e14f0ce",
         importpath = "github.com/istio/mixer",
     )

--- a/src/envoy/mixer/integration_test/repositories.bzl
+++ b/src/envoy/mixer/integration_test/repositories.bzl
@@ -139,7 +139,7 @@ gogoslick_proto_library(
       native.new_git_repository(
           name = "com_github_istio_api",
           build_file_content = ISTIO_API_BUILD_FILE,
-          commit = "972765388bbadfeb8d57a707a0576748a59aa80c",  # top of unary branch.
+          commit = "8edd0f7d57cd336ed8acd7ada91ffd4ef5f2a1c4",
           remote = "https://github.com/istio/api.git",
       )
 
@@ -211,6 +211,6 @@ def go_mixer_repositories(use_local_api=False):
 
     go_repository(
         name = "com_github_istio_mixer",
-        commit = "0ad9fa3aca4063f050f829338b06abdf9977ac75",
+        commit = "f987228ebce1d02470a6d4f8fbc8a9f75521edcb",
         importpath = "github.com/istio/mixer",
     )

--- a/src/envoy/mixer/repositories.bzl
+++ b/src/envoy/mixer/repositories.bzl
@@ -15,7 +15,7 @@
 ################################################################################
 #
 
-MIXER_CLIENT = "42fe370f677f45693ecb2d6e42b41db914d75592"
+MIXER_CLIENT = "7c9a3f8b66d8d909eef27d1d7ff358e16b0f9845"
 
 def mixer_client_repositories(bind=True):
     native.git_repository(


### PR DESCRIPTION
integration_test still points to istio/api unary branch SHA which has been deleted.
also updated to latest mixerclient fix.