### PR TITLE
Scaffold for JWT auth filter

### DIFF
--- a/src/envoy/auth/BUILD
+++ b/src/envoy/auth/BUILD
@@ -1,0 +1,48 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
+    "envoy_cc_library",
+    "envoy_cc_test",
+)
+
+envoy_cc_binary(
+    name = "envoy",
+    repository = "@envoy",
+    deps = [
+        ":http_filter_config",
+        "@envoy//source/exe:envoy_main_entry_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "http_filter_lib",
+    srcs = ["http_filter.cc"],
+    hdrs = ["http_filter.h"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "http_filter_config",
+    srcs = ["http_filter_config.cc"],
+    repository = "@envoy",
+    deps = [
+        ":http_filter_lib",
+        "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "http_filter_integration_test",
+    srcs = [":integration_test/http_filter_integration_test.cc"],
+    data = [":integration_test/envoy.conf"],
+    repository = "@envoy",
+    deps = [
+        ":http_filter_config",
+        "@envoy//test/integration:integration_lib",
+    ],
+)

--- a/src/envoy/auth/http_filter.cc
+++ b/src/envoy/auth/http_filter.cc
@@ -1,0 +1,40 @@
+#include <string>
+
+#include "http_filter.h"
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Envoy {
+namespace Http {
+
+/*
+ * TODO: receive issuer's info & pubkey
+ */
+JwtVerificationFilter::JwtVerificationFilter() {}
+
+JwtVerificationFilter::~JwtVerificationFilter() {}
+
+void JwtVerificationFilter::onDestroy() {}
+
+FilterHeadersStatus JwtVerificationFilter::decodeHeaders(HeaderMap&, bool) {
+  /*
+   * TODO: verify the JWT in the auth header
+   */
+  return FilterHeadersStatus::Continue;
+}
+
+FilterDataStatus JwtVerificationFilter::decodeData(Buffer::Instance&, bool) {
+  return FilterDataStatus::Continue;
+}
+
+FilterTrailersStatus JwtVerificationFilter::decodeTrailers(HeaderMap&) {
+  return FilterTrailersStatus::Continue;
+}
+
+void JwtVerificationFilter::setDecoderFilterCallbacks(
+    StreamDecoderFilterCallbacks& callbacks) {
+  decoder_callbacks_ = &callbacks;
+}
+
+}  // Http
+}  // Envoy

--- a/src/envoy/auth/http_filter.h
+++ b/src/envoy/auth/http_filter.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+
+#include "server/config/network/http_connection_manager.h"
+
+namespace Envoy {
+namespace Http {
+
+class JwtVerificationFilter : public StreamDecoderFilter {
+ public:
+  JwtVerificationFilter();
+  ~JwtVerificationFilter();
+
+  // Http::StreamFilterBase
+  void onDestroy() override;
+
+  // Http::StreamDecoderFilter
+  FilterHeadersStatus decodeHeaders(HeaderMap&, bool) override;
+  FilterDataStatus decodeData(Buffer::Instance&, bool) override;
+  FilterTrailersStatus decodeTrailers(HeaderMap&) override;
+  void setDecoderFilterCallbacks(
+      StreamDecoderFilterCallbacks& callbacks) override;
+
+ private:
+  StreamDecoderFilterCallbacks* decoder_callbacks_;
+};
+
+}  // Http
+}  // Envoy

--- a/src/envoy/auth/http_filter_config.cc
+++ b/src/envoy/auth/http_filter_config.cc
@@ -1,0 +1,37 @@
+#include <string>
+
+#include "http_filter.h"
+
+#include "envoy/registry/registry.h"
+
+namespace Envoy {
+namespace Server {
+namespace Configuration {
+
+class JwtVerificationFilterConfig : public NamedHttpFilterConfigFactory {
+ public:
+  HttpFilterFactoryCb createFilterFactory(const Json::Object&,
+                                          const std::string&,
+                                          FactoryContext&) override {
+    return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+      callbacks.addStreamDecoderFilter(Http::StreamDecoderFilterSharedPtr{
+          new Http::JwtVerificationFilter()});
+      /*
+       * TODO: pass issuer's info & pubkey to the filter through config JSON
+       */
+    };
+  }
+  std::string name() override { return "jwt-auth"; }
+  HttpFilterType type() override { return HttpFilterType::Decoder; }
+};
+
+/**
+ * Static registration for this JWT verification filter. @see RegisterFactory.
+ */
+static Registry::RegisterFactory<JwtVerificationFilterConfig,
+                                 NamedHttpFilterConfigFactory>
+    register_;
+
+}  // Configuration
+}  // Server
+}  // Envoy

--- a/src/envoy/auth/integration_test/envoy.conf
+++ b/src/envoy/auth/integration_test/envoy.conf
@@ -1,0 +1,68 @@
+{
+  "listeners": [
+    {
+      "address": "tcp://{{ ip_loopback_address }}:0",
+      "bind_to_port": true,
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "service1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ],
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "jwt-auth",
+                "config": {}
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "access_log_path": "/dev/stdout",
+    "address": "tcp://{{ ip_loopback_address }}:0"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "service1",
+        "connect_timeout_ms": 5000,
+        "type": "static",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/envoy/auth/integration_test/http_filter_integration_test.cc
+++ b/src/envoy/auth/integration_test/http_filter_integration_test.cc
@@ -1,0 +1,59 @@
+#include "test/integration/integration.h"
+#include "test/integration/utility.h"
+
+namespace Envoy {
+class JwtVerificationFilterIntegrationTest
+    : public BaseIntegrationTest,
+      public testing::TestWithParam<Network::Address::IpVersion> {
+ public:
+  JwtVerificationFilterIntegrationTest() : BaseIntegrationTest(GetParam()) {}
+  /**
+   * Initializer for an individual integration test.
+   */
+  void SetUp() override {
+    fake_upstreams_.emplace_back(
+        new FakeUpstream(0, FakeHttpConnection::Type::HTTP1, version_));
+    registerPort("upstream_0",
+                 fake_upstreams_.back()->localAddress()->ip()->port());
+    createTestServer("src/envoy/auth/integration_test/envoy.conf", {"http"});
+  }
+
+  /**
+   * Destructor for an individual integration test.
+   */
+  void TearDown() override {
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    IpVersions, JwtVerificationFilterIntegrationTest,
+    testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+/*
+ * A trivial test. Just making connection and sending a request, testing
+ * nothing.
+ */
+TEST_P(JwtVerificationFilterIntegrationTest, Trivial) {
+  Http::TestHeaderMapImpl headers{
+      {":method", "GET"}, {":path", "/"}, {":authority", "host"}};
+
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection;
+  IntegrationStreamDecoderPtr response(
+      new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request_stream;
+
+  codec_client =
+      makeHttpConnection(lookupPort("http"), Http::CodecClient::Type::HTTP1);
+  codec_client->makeHeaderOnlyRequest(headers, *response);
+  fake_upstream_connection =
+      fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+  request_stream = fake_upstream_connection->waitForNewStream();
+  request_stream->waitForEndStream(*dispatcher_);
+  response->waitForEndStream();
+
+  codec_client->close();
+}
+}  // Envoy


### PR DESCRIPTION
Just copied HTTP filter from lyft/envoy-filter-example and did nothing actually new. And
- modify class/filter name and directory structure
- delete header-adding feature