### PR TITLE
Add per-route mixer attributes.

### DIFF
--- a/src/envoy/mixer/README.md
+++ b/src/envoy/mixer/README.md
@@ -131,7 +131,23 @@ By default, the mixer filter only forwards attributes and does not call mixer se
    }
 ```
 
-This route opaque config reverts the behavior by sending requests to mixer server but not forwarding any attributes.
+Above route opaque config reverts the behavior by sending requests to mixer server but not forwarding any attributes.
+
+Mixer attributes and forward attributes can be set per-route in the route opaque config.
+
+```
+ "routes": [
+   {
+     "timeout_ms": 0,
+     "prefix": "/",
+     "cluster": "service1",
+     "opaque_config": {
+      "mixer_attributes.key1": "value1",
+      "mixer_forward_attributes.key2": "value2"
+     }
+   }
+```
+Attribute key1 = value1 will be sent to the mixer if mixer is on. Attribute key1 = value2 will be forwarded to next proxy if mixer_forward is on.
 
 
 ## How to enable quota (rate limiting)
@@ -185,6 +201,7 @@ When there is any network problems between the proxy and the mixer server, what 
          "network_fail_policy": "close",
 
 ```
+The default value is "open".
 
 ## How to configurate TCP Mixer filters
 

--- a/src/envoy/mixer/integration_test/check_report_test.go
+++ b/src/envoy/mixer/integration_test/check_report_test.go
@@ -31,6 +31,10 @@ const checkAttributesOkGet = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -56,6 +60,10 @@ const reportAttributesOkGet = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -93,6 +101,10 @@ const checkAttributesOkPost = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -118,6 +130,10 @@ const reportAttributesOkPost = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {

--- a/src/envoy/mixer/integration_test/envoy_conf.go
+++ b/src/envoy/mixer/integration_test/envoy_conf.go
@@ -111,7 +111,9 @@ const envoyConfTempl = `
                       "cluster": "service1",
                       "opaque_config": {
                         "mixer_control": "on",
-                        "mixer_forward": "off"
+                        "mixer_forward": "off",
+                        "mixer_attributes.target.user": "target-user",
+                        "mixer_attributes.target.name": "target-name"
                       }
                     }
                   ]
@@ -160,7 +162,11 @@ const envoyConfTempl = `
                     {
                       "timeout_ms": 0,
                       "prefix": "/",
-                      "cluster": "service2"
+                      "cluster": "service2",
+                      "opaque_config": {
+                        "mixer_forward_attributes.source.user": "source-user",
+                        "mixer_forward_attributes.source.name": "source-name"
+                      }
                     }
                   ]
                 }

--- a/src/envoy/mixer/integration_test/failed_request_test.go
+++ b/src/envoy/mixer/integration_test/failed_request_test.go
@@ -37,6 +37,10 @@ const checkAttributesMixerFail = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -62,6 +66,10 @@ const reportAttributesMixerFail = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -99,6 +107,10 @@ const reportAttributesBackendFail = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {

--- a/src/envoy/mixer/integration_test/report_batch_test.go
+++ b/src/envoy/mixer/integration_test/report_batch_test.go
@@ -31,6 +31,10 @@ const reportAttributesOkGet = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -68,6 +72,10 @@ const reportAttributesOkPost1 = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {
@@ -105,6 +113,10 @@ const reportAttributesOkPost2 = `
   "request.scheme": "http",
   "source.uid": "POD11",
   "source.namespace": "XYZ11",
+  "source.name": "source-name",
+  "source.user": "source-user",
+  "target.name": "target-name",
+  "target.user": "target-user",
   "target.uid": "POD222",
   "target.namespace": "XYZ222",
   "request.headers": {

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -254,7 +254,8 @@ void MixerControl::ForwardAttributes(HeaderMap& headers,
   }
   std::string serialized_str = Utils::SerializeTwoStringMaps(
       mixer_config_.forward_attributes, route_attributes);
-  std::string base64 = Base64::encode(serialized_str.c_str(), serialized_str.size());
+  std::string base64 =
+      Base64::encode(serialized_str.c_str(), serialized_str.size());
   log().debug("Mixer forward attributes set: {}", base64);
   headers.addReferenceKey(Utils::kIstioAttributeHeader, base64);
 }

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -22,7 +22,6 @@
 #include "src/envoy/mixer/grpc_transport.h"
 #include "src/envoy/mixer/string_map.pb.h"
 #include "src/envoy/mixer/thread_dispatcher.h"
-#include "src/envoy/mixer/utils.h"
 
 using ::google::protobuf::util::Status;
 using StatusCode = ::google::protobuf::util::error::Code;
@@ -248,8 +247,21 @@ void MixerControl::SendReport(HttpRequestDataPtr request_data) {
   mixer_client_->Report(request_data->attributes);
 }
 
+void MixerControl::ForwardAttributes(HeaderMap& headers,
+                                     const Utils::StringMap& route_attributes) {
+  if (mixer_config_.forward_attributes.empty() && route_attributes.empty()) {
+    return;
+  }
+  std::string serialized_str = Utils::SerializeTwoStringMaps(
+      mixer_config_.forward_attributes, route_attributes);
+  std::string base64 = Base64::encode(serialized_str.c_str(), serialized_str.size());
+  log().debug("Mixer forward attributes set: {}", base64);
+  headers.addReferenceKey(Utils::kIstioAttributeHeader, base64);
+}
+
 void MixerControl::CheckHttp(HttpRequestDataPtr request_data,
                              HeaderMap& headers, std::string source_user,
+                             const Utils::StringMap& route_attributes,
                              DoneFunc on_done) {
   if (!mixer_client_) {
     on_done(
@@ -257,6 +269,11 @@ void MixerControl::CheckHttp(HttpRequestDataPtr request_data,
     return;
   }
   FillCheckAttributes(headers, &request_data->attributes);
+  for (const auto& attribute : route_attributes) {
+    SetStringAttribute(attribute.first, attribute.second,
+                       &request_data->attributes);
+  }
+
   SetStringAttribute(kSourceUser, source_user, &request_data->attributes);
 
   request_data->attributes.attributes[kRequestTime] =

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -26,6 +26,7 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "include/client.h"
 #include "src/envoy/mixer/config.h"
+#include "src/envoy/mixer/utils.h"
 
 namespace Envoy {
 namespace Http {
@@ -45,9 +46,14 @@ class MixerControl final : public Logger::Loggable<Logger::Id::http> {
   // The constructor.
   MixerControl(const MixerConfig& mixer_config, Upstream::ClusterManager& cm);
 
+  // Add a special header to forward mixer attribues to upstream proxy.
+  void ForwardAttributes(HeaderMap& headers,
+                         const Utils::StringMap& route_attributes);
+
   // Make mixer check call for HTTP requests.
   void CheckHttp(HttpRequestDataPtr request_data, HeaderMap& headers,
                  std::string origin_user,
+                 const Utils::StringMap& route_attributes,
                  ::istio::mixer_client::DoneFunc on_done);
 
   // Make mixer report call for HTTP requests.

--- a/src/envoy/mixer/utils.cc
+++ b/src/envoy/mixer/utils.cc
@@ -22,10 +22,14 @@ namespace Utils {
 
 const LowerCaseString kIstioAttributeHeader("x-istio-attributes");
 
-std::string SerializeStringMap(const StringMap& string_map) {
+std::string SerializeTwoStringMaps(const StringMap& map1,
+                                   const StringMap& map2) {
   ::istio::proxy::mixer::StringMap pb;
   ::google::protobuf::Map<std::string, std::string>* map_pb = pb.mutable_map();
-  for (const auto& it : string_map) {
+  for (const auto& it : map1) {
+    (*map_pb)[it.first] = it.second;
+  }
+  for (const auto& it : map2) {
     (*map_pb)[it.first] = it.second;
   }
   std::string str;

--- a/src/envoy/mixer/utils.h
+++ b/src/envoy/mixer/utils.h
@@ -31,8 +31,9 @@ extern const LowerCaseString kIstioAttributeHeader;
 // The string map.
 typedef std::map<std::string, std::string> StringMap;
 
-// Serialize a string map to string.
-std::string SerializeStringMap(const StringMap& map);
+// Serialize two string maps to string.
+std::string SerializeTwoStringMaps(const StringMap& map1,
+                                   const StringMap& map2);
 
 }  // namespace Utils
 }  // namespace Http


### PR DESCRIPTION
Get mixer_attributes and mixer_forward_attributes from route opaque config.