### PR TITLE
Fix mixer forward attribute bug.

### DIFF
--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -205,13 +205,12 @@ class Instance : public Http::StreamDecoderFilter,
   FilterHeadersStatus decodeHeaders(HeaderMap& headers, bool) override {
     Log().debug("Called Mixer::Instance : {}", __func__);
 
-    if (!forward_disabled()) {
-      mixer_control_->ForwardAttributes(
-          headers, GetRouteStringMap(kPrefixForwardAttributes));
-    }
-
     mixer_disabled_ = mixer_disabled();
     if (mixer_disabled_) {
+      if (!forward_disabled()) {
+        mixer_control_->ForwardAttributes(
+            headers, GetRouteStringMap(kPrefixForwardAttributes));
+      }
       return FilterHeadersStatus::Continue;
     }
 
@@ -226,11 +225,28 @@ class Instance : public Http::StreamDecoderFilter,
       origin_user = ssl->uriSanPeerCertificate();
     }
 
+    // Extract attributes from x-istio-attributes header
+    ::istio::proxy::mixer::StringMap forwarded_attributes;
+    const HeaderEntry* entry = headers.get(Utils::kIstioAttributeHeader);
+    if (entry) {
+      std::string str(entry->value().c_str(), entry->value().size());
+      forwarded_attributes.ParseFromString(Base64::decode(str));
+      headers.remove(Utils::kIstioAttributeHeader);
+    }
+
+    mixer_control_->BuildHttpCheck(request_data_, headers, forwarded_attributes,
+                                   origin_user,
+                                   GetRouteStringMap(kPrefixMixerAttributes),
+                                   decoder_callbacks_->connection());
+
+    if (!forward_disabled()) {
+      mixer_control_->ForwardAttributes(
+          headers, GetRouteStringMap(kPrefixForwardAttributes));
+    }
+
     auto instance = GetPtr();
-    mixer_control_->CheckHttp(
-        request_data_, headers, origin_user,
-        GetRouteStringMap(kPrefixMixerAttributes),
-        decoder_callbacks_->connection(),
+    mixer_control_->SendCheck(
+        request_data_, &headers,
         [instance](const Status& status) { instance->completeCheck(status); });
     initiating_call_ = false;
 
@@ -302,10 +318,9 @@ class Instance : public Http::StreamDecoderFilter,
     Log().debug("Called Mixer::Instance : {}", __func__);
     // If decodeHaeders() is not called, not to call Mixer report.
     if (!request_data_) return;
-    // Make sure not to use any class members at the callback.
-    // The class may be gone when it is called.
-    mixer_control_->ReportHttp(request_data_, response_headers, request_info,
-                               check_status_code_);
+    mixer_control_->BuildHttpReport(request_data_, response_headers,
+                                    request_info, check_status_code_);
+    mixer_control_->SendReport(request_data_);
   }
 
   static spdlog::logger& Log() {

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -20,7 +20,6 @@
 #include "common/http/utility.h"
 
 #include "src/envoy/mixer/grpc_transport.h"
-#include "src/envoy/mixer/string_map.pb.h"
 #include "src/envoy/mixer/thread_dispatcher.h"
 
 using ::google::protobuf::util::Status;
@@ -172,22 +171,6 @@ void FillRequestInfoAttributes(const AccessLog::RequestInfo& info,
   }
 }
 
-void FillCheckAttributes(HeaderMap& header_map, Attributes* attr) {
-  // Extract attributes from x-istio-attributes header
-  const HeaderEntry* entry = header_map.get(Utils::kIstioAttributeHeader);
-  if (entry) {
-    ::istio::proxy::mixer::StringMap pb;
-    std::string str(entry->value().c_str(), entry->value().size());
-    pb.ParseFromString(Base64::decode(str));
-    for (const auto& it : pb.map()) {
-      SetStringAttribute(it.first, it.second, attr);
-    }
-    header_map.remove(Utils::kIstioAttributeHeader);
-  }
-
-  FillRequestHeaderAttributes(header_map, attr);
-}
-
 // A class to wrap envoy timer for mixer client timer.
 class EnvoyTimer : public ::istio::mixer_client::Timer {
  public:
@@ -229,20 +212,20 @@ MixerControl::MixerControl(const MixerConfig& mixer_config,
 
 void MixerControl::SendCheck(HttpRequestDataPtr request_data,
                              const HeaderMap* headers, DoneFunc on_done) {
-  for (const auto& attribute : quota_attributes_.attributes) {
-    request_data->attributes.attributes[attribute.first] = attribute.second;
+  if (!mixer_client_) {
+    on_done(
+        Status(StatusCode::INVALID_ARGUMENT, "Missing mixer_server cluster"));
+    return;
   }
-  for (const auto& attribute : mixer_config_.mixer_attributes) {
-    SetStringAttribute(attribute.first, attribute.second,
-                       &request_data->attributes);
-  }
-
   log().debug("Send Check: {}", request_data->attributes.DebugString());
   mixer_client_->Check(request_data->attributes,
                        CheckGrpcTransport::GetFunc(cm_, headers), on_done);
 }
 
 void MixerControl::SendReport(HttpRequestDataPtr request_data) {
+  if (!mixer_client_) {
+    return;
+  }
   log().debug("Send Report: {}", request_data->attributes.DebugString());
   mixer_client_->Report(request_data->attributes);
 }
@@ -260,21 +243,19 @@ void MixerControl::ForwardAttributes(HeaderMap& headers,
   headers.addReferenceKey(Utils::kIstioAttributeHeader, base64);
 }
 
-void MixerControl::CheckHttp(HttpRequestDataPtr request_data,
-                             HeaderMap& headers, std::string source_user,
-                             const Utils::StringMap& route_attributes,
-                             const Network::Connection* connection,
-                             DoneFunc on_done) {
-  if (!mixer_client_) {
-    on_done(
-        Status(StatusCode::INVALID_ARGUMENT, "Missing mixer_server cluster"));
-    return;
+void MixerControl::BuildHttpCheck(
+    HttpRequestDataPtr request_data, HeaderMap& headers,
+    const ::istio::proxy::mixer::StringMap& map_pb, std::string source_user,
+    const Utils::StringMap& route_attributes,
+    const Network::Connection* connection) {
+  for (const auto& it : map_pb.map()) {
+    SetStringAttribute(it.first, it.second, &request_data->attributes);
   }
-  FillCheckAttributes(headers, &request_data->attributes);
   for (const auto& attribute : route_attributes) {
     SetStringAttribute(attribute.first, attribute.second,
                        &request_data->attributes);
   }
+  FillRequestHeaderAttributes(headers, &request_data->attributes);
 
   if (connection) {
     const Network::Address::Ip* remote_ip = connection->remoteAddress().ip();
@@ -292,17 +273,19 @@ void MixerControl::CheckHttp(HttpRequestDataPtr request_data,
       Attributes::TimeValue(std::chrono::system_clock::now());
   SetStringAttribute(kContextProtocol, "http", &request_data->attributes);
 
-  SendCheck(request_data, &headers, on_done);
+  for (const auto& attribute : quota_attributes_.attributes) {
+    request_data->attributes.attributes[attribute.first] = attribute.second;
+  }
+  for (const auto& attribute : mixer_config_.mixer_attributes) {
+    SetStringAttribute(attribute.first, attribute.second,
+                       &request_data->attributes);
+  }
 }
 
-void MixerControl::ReportHttp(HttpRequestDataPtr request_data,
-                              const HeaderMap* response_headers,
-                              const AccessLog::RequestInfo& request_info,
-                              int check_status) {
-  if (!mixer_client_) {
-    return;
-  }
-
+void MixerControl::BuildHttpReport(HttpRequestDataPtr request_data,
+                                   const HeaderMap* response_headers,
+                                   const AccessLog::RequestInfo& request_info,
+                                   int check_status) {
   // Use all Check attributes for Report.
   // Add additional Report attributes.
   FillResponseHeaderAttributes(response_headers, &request_data->attributes);
@@ -312,18 +295,11 @@ void MixerControl::ReportHttp(HttpRequestDataPtr request_data,
 
   request_data->attributes.attributes[kResponseTime] =
       Attributes::TimeValue(std::chrono::system_clock::now());
-  SendReport(request_data);
 }
 
-void MixerControl::CheckTcp(HttpRequestDataPtr request_data,
-                            Network::Connection& connection,
-                            std::string source_user, DoneFunc on_done) {
-  if (!mixer_client_) {
-    on_done(
-        Status(StatusCode::INVALID_ARGUMENT, "Missing mixer_server cluster"));
-    return;
-  }
-
+void MixerControl::BuildTcpCheck(HttpRequestDataPtr request_data,
+                                 Network::Connection& connection,
+                                 std::string source_user) {
   SetStringAttribute(kSourceUser, source_user, &request_data->attributes);
 
   const Network::Address::Ip* remote_ip = connection.remoteAddress().ip();
@@ -337,18 +313,21 @@ void MixerControl::CheckTcp(HttpRequestDataPtr request_data,
   request_data->attributes.attributes[kContextTime] =
       Attributes::TimeValue(std::chrono::system_clock::now());
   SetStringAttribute(kContextProtocol, "tcp", &request_data->attributes);
-  SendCheck(request_data, nullptr, on_done);
+
+  for (const auto& attribute : quota_attributes_.attributes) {
+    request_data->attributes.attributes[attribute.first] = attribute.second;
+  }
+  for (const auto& attribute : mixer_config_.mixer_attributes) {
+    SetStringAttribute(attribute.first, attribute.second,
+                       &request_data->attributes);
+  }
 }
 
-void MixerControl::ReportTcp(
+void MixerControl::BuildTcpReport(
     HttpRequestDataPtr request_data, uint64_t received_bytes,
     uint64_t send_bytes, int check_status_code,
     std::chrono::nanoseconds duration,
     Upstream::HostDescriptionConstSharedPtr upstreamHost) {
-  if (!mixer_client_) {
-    return;
-  }
-
   SetInt64Attribute(kConnectionReceviedBytes, received_bytes,
                     &request_data->attributes);
   SetInt64Attribute(kConnectionReceviedTotalBytes, received_bytes,
@@ -375,7 +354,6 @@ void MixerControl::ReportTcp(
 
   request_data->attributes.attributes[kContextTime] =
       Attributes::TimeValue(std::chrono::system_clock::now());
-  SendReport(request_data);
 }
 
 std::shared_ptr<MixerControl> MixerControlPerThreadStore::Get() {

--- a/src/envoy/mixer/tcp_filter.cc
+++ b/src/envoy/mixer/tcp_filter.cc
@@ -126,10 +126,12 @@ class TcpInstance : public Network::Filter,
       filter_callbacks_->connection().readDisable(true);
       auto instance = GetPtr();
       calling_check_ = true;
-      mixer_control_->CheckTcp(request_data_, filter_callbacks_->connection(),
-                               origin_user, [instance](const Status& status) {
-                                 instance->completeCheck(status);
-                               });
+      mixer_control_->BuildTcpCheck(
+          request_data_, filter_callbacks_->connection(), origin_user);
+      mixer_control_->SendCheck(request_data_, nullptr,
+                                [instance](const Status& status) {
+                                  instance->completeCheck(status);
+                                });
       calling_check_ = false;
     }
     return state_ == State::Calling ? Network::FilterStatus::StopIteration
@@ -168,11 +170,12 @@ class TcpInstance : public Network::Filter,
     if (event == Network::ConnectionEvent::RemoteClose ||
         event == Network::ConnectionEvent::LocalClose) {
       if (state_ != State::Closed && request_data_) {
-        mixer_control_->ReportTcp(
+        mixer_control_->BuildTcpReport(
             request_data_, received_bytes_, send_bytes_, check_status_code_,
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                 std::chrono::system_clock::now() - start_time_),
             filter_callbacks_->upstreamHost());
+        mixer_control_->SendReport(request_data_);
       }
       state_ = State::Closed;
     }


### PR DESCRIPTION
Split CheckHTTP() into two calls:  BuildHttpCheck and SendCheck so that after BuildHttpCheck additional headers can be added.
Do the similar splitting for ReportHTTP, CheckTCP and ReportTCP