### PR TITLE
Not to use therad local dispatch to delete grpc transport object

### DIFF
--- a/src/envoy/mixer/grpc_transport.cc
+++ b/src/envoy/mixer/grpc_transport.cc
@@ -52,16 +52,16 @@ inline void CopyHeaderEntry(const HeaderEntry* entry,
 }
 
 thread_local std::vector<GrpcTransport*> pending_freelist;
-  
+
 }  // namespace
 
 void GrpcTransport::FreePendingGrpcObject() {
-    for (GrpcTransport* obj : pending_freelist) {
-      delete obj;
-    }
-    pending_freelist.clear();
+  for (GrpcTransport* obj : pending_freelist) {
+    delete obj;
   }
-  
+  pending_freelist.clear();
+}
+
 GrpcTransport::GrpcTransport(Upstream::ClusterManager& cm,
                              const HeaderMap* headers)
     : channel_(NewChannel(cm)), stub_(channel_.get()), headers_(headers) {

--- a/src/envoy/mixer/grpc_transport.h
+++ b/src/envoy/mixer/grpc_transport.h
@@ -44,8 +44,6 @@ class GrpcTransport : public Grpc::RpcChannelCallbacks,
   // Check if mixer server cluster configured in cluster_manager.
   static bool IsMixerServerConfigured(Upstream::ClusterManager& cm);
 
-  static void FreePendingGrpcObject();
-
  protected:
   // Create a new grpc channel.
   Grpc::RpcChannelPtr NewChannel(Upstream::ClusterManager& cm);

--- a/src/envoy/mixer/grpc_transport.h
+++ b/src/envoy/mixer/grpc_transport.h
@@ -44,6 +44,8 @@ class GrpcTransport : public Grpc::RpcChannelCallbacks,
   // Check if mixer server cluster configured in cluster_manager.
   static bool IsMixerServerConfigured(Upstream::ClusterManager& cm);
 
+  static void FreePendingGrpcObject();
+
  protected:
   // Create a new grpc channel.
   Grpc::RpcChannelPtr NewChannel(Upstream::ClusterManager& cm);


### PR DESCRIPTION
My suspicious is:  grpc callback function onSuccess() may be called in a different thread than filter->set_callback thread in some cases during race conditions.  This causes thread local dispatcher was not set for that thread. This caused assertion failure.

Just store the pending free objects in a thread local list.  For each new grpc call,  free the objects in the pending list.  So dispatcher is not needed.

thread local dispatcher is still used by timer_callback for report_batch.  It should be fine; it is called during Report() call which should be at the same thread as fitler->set_callback.   Beside, it only needs to call once for the whole process. 

