### PR TITLE
Not check cluster existence

### DIFF
--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -86,10 +86,6 @@ const int kCheckCacheEntries = 10000;
 // The name for the mixer server cluster.
 const char* kMixerServerClusterName = "mixer_server";
 
-bool IsMixerServerConfigured(Upstream::ClusterManager& cm) {
-  return cm.get(kMixerServerClusterName) != nullptr;
-}
-
 CheckOptions GetCheckOptions(const MixerConfig& config) {
   CheckOptions options(kCheckCacheEntries);
   options.cache_keys = config.check_cache_keys;
@@ -227,32 +223,28 @@ class EnvoyTimer : public ::istio::mixer_client::Timer {
 MixerControl::MixerControl(const MixerConfig& mixer_config,
                            Upstream::ClusterManager& cm)
     : cm_(cm), mixer_config_(mixer_config) {
-  if (IsMixerServerConfigured(cm)) {
-    MixerClientOptions options(GetCheckOptions(mixer_config), ReportOptions(),
-                               QuotaOptions());
+  MixerClientOptions options(GetCheckOptions(mixer_config), ReportOptions(),
+                             QuotaOptions());
 
-    check_client_.reset(
-        new Grpc::AsyncClientImpl<istio::mixer::v1::CheckRequest,
-                                  istio::mixer::v1::CheckResponse>(
-            cm, kMixerServerClusterName));
-    report_client_.reset(
-        new Grpc::AsyncClientImpl<istio::mixer::v1::ReportRequest,
-                                  istio::mixer::v1::ReportResponse>(
-            cm, kMixerServerClusterName));
+  check_client_.reset(
+      new Grpc::AsyncClientImpl<istio::mixer::v1::CheckRequest,
+                                istio::mixer::v1::CheckResponse>(
+          cm, kMixerServerClusterName));
+  report_client_.reset(
+      new Grpc::AsyncClientImpl<istio::mixer::v1::ReportRequest,
+                                istio::mixer::v1::ReportResponse>(
+          cm, kMixerServerClusterName));
 
-    options.check_transport = CheckTransport::GetFunc(*check_client_, nullptr);
-    options.report_transport = ReportTransport::GetFunc(*report_client_);
+  options.check_transport = CheckTransport::GetFunc(*check_client_, nullptr);
+  options.report_transport = ReportTransport::GetFunc(*report_client_);
 
-    options.timer_create_func = [](std::function<void()> timer_cb)
-        -> std::unique_ptr<::istio::mixer_client::Timer> {
-          return std::unique_ptr<::istio::mixer_client::Timer>(
-              new EnvoyTimer(GetThreadDispatcher().createTimer(timer_cb)));
-        };
+  options.timer_create_func = [](std::function<void()> timer_cb)
+      -> std::unique_ptr<::istio::mixer_client::Timer> {
+        return std::unique_ptr<::istio::mixer_client::Timer>(
+            new EnvoyTimer(GetThreadDispatcher().createTimer(timer_cb)));
+      };
 
-    mixer_client_ = ::istio::mixer_client::CreateMixerClient(options);
-  } else {
-    log().error("Mixer server cluster is not configured");
-  }
+  mixer_client_ = ::istio::mixer_client::CreateMixerClient(options);
 
   mixer_config_.ExtractQuotaAttributes(&quota_attributes_);
 }

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -223,14 +223,14 @@ class EnvoyTimer : public ::istio::mixer_client::Timer {
 MixerControl::MixerControl(const MixerConfig& mixer_config,
                            Upstream::ClusterManager& cm)
     : cm_(cm),
-      mixer_config_(mixer_config),
       check_client_(new Grpc::AsyncClientImpl<istio::mixer::v1::CheckRequest,
                                               istio::mixer::v1::CheckResponse>(
           cm, kMixerServerClusterName)),
       report_client_(
           new Grpc::AsyncClientImpl<istio::mixer::v1::ReportRequest,
                                     istio::mixer::v1::ReportResponse>(
-              cm, kMixerServerClusterName)) {
+              cm, kMixerServerClusterName)),
+      mixer_config_(mixer_config) {
   MixerClientOptions options(GetCheckOptions(mixer_config), ReportOptions(),
                              QuotaOptions());
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -222,18 +222,19 @@ class EnvoyTimer : public ::istio::mixer_client::Timer {
 
 MixerControl::MixerControl(const MixerConfig& mixer_config,
                            Upstream::ClusterManager& cm)
-    : cm_(cm), mixer_config_(mixer_config) {
+    : cm_(cm),
+      mixer_config_(mixer_config),
+      check_client_(new Grpc::AsyncClientImpl<istio::mixer::v1::CheckRequest,
+                                              istio::mixer::v1::CheckResponse>(
+          cm, kMixerServerClusterName)),
+      report_client_(
+          new Grpc::AsyncClientImpl<istio::mixer::v1::ReportRequest,
+                                    istio::mixer::v1::ReportResponse>(
+              cm, kMixerServerClusterName))
+
+{
   MixerClientOptions options(GetCheckOptions(mixer_config), ReportOptions(),
                              QuotaOptions());
-
-  check_client_.reset(
-      new Grpc::AsyncClientImpl<istio::mixer::v1::CheckRequest,
-                                istio::mixer::v1::CheckResponse>(
-          cm, kMixerServerClusterName));
-  report_client_.reset(
-      new Grpc::AsyncClientImpl<istio::mixer::v1::ReportRequest,
-                                istio::mixer::v1::ReportResponse>(
-          cm, kMixerServerClusterName));
 
   options.check_transport = CheckTransport::GetFunc(*check_client_, nullptr);
   options.report_transport = ReportTransport::GetFunc(*report_client_);

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -230,9 +230,7 @@ MixerControl::MixerControl(const MixerConfig& mixer_config,
       report_client_(
           new Grpc::AsyncClientImpl<istio::mixer::v1::ReportRequest,
                                     istio::mixer::v1::ReportResponse>(
-              cm, kMixerServerClusterName))
-
-{
+              cm, kMixerServerClusterName)) {
   MixerClientOptions options(GetCheckOptions(mixer_config), ReportOptions(),
                              QuotaOptions());
 

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -86,15 +86,16 @@ class MixerControl final : public Logger::Loggable<Logger::Id::http> {
 
   // Envoy cluster manager for making gRPC calls.
   Upstream::ClusterManager& cm_;
+
+  CheckTransport::AsyncClientPtr check_client_;
+  ReportTransport::AsyncClientPtr report_client_;
+
   // The mixer client
   std::unique_ptr<::istio::mixer_client::MixerClient> mixer_client_;
   // The mixer config
   const MixerConfig& mixer_config_;
   // Quota attributes; extracted from envoy filter config.
   ::istio::mixer_client::Attributes quota_attributes_;
-
-  CheckTransport::AsyncClientPtr check_client_;
-  ReportTransport::AsyncClientPtr report_client_;
 };
 
 // A class to create and store per thread mixer control instance.


### PR DESCRIPTION
Grpc::AsyncClient holds a reference to ClusterManager and cluster_name, the mixer cluster can be configured after MixerControl construction without problem.