### PR TITLE
use envoy v1.4.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,7 +39,7 @@ bind(
 git_repository(
     name = "envoy",
     remote = "https://github.com/lyft/envoy.git",
-    commit = "3f3fc94f85766b70ca6239dfbba7067e95ee0bdb",
+    commit = "v1.4.0",
 )
 
 load("@envoy//bazel:repositories.bzl", "envoy_dependencies")


### PR DESCRIPTION
v1.4.0 (a8507f67225cdd912712971bf72d41f219eb74ed) slightly newer than 3f3fc94f85766b70ca6239dfbba7067e95ee0bdb