### PR TITLE
Change docker image name to enable auto dependency update

### DIFF
--- a/script/release-docker
+++ b/script/release-docker
@@ -33,10 +33,9 @@ set -o pipefail
 
 PROJECT=${PROJECT:-istio-testing}
 
-DATE_PART=$(date +"%Y%m%d")
-SHA_PART=$(git show -q HEAD --pretty=format:%h)
+SHA=$(git rev-parse HEAD)
 
-DOCKER_TAG="${DATE_PART}-${SHA_PART}"
+DOCKER_TAG="${SHA}"
 
 REPO=${REPO:-gcr.io}
 


### PR DESCRIPTION
This change names future docker images using the full sha of the head commit, which is consistent with artifacts from mixer, pilot, etc. It is also required to implement the auto dependency update on this repo.  