### PR TITLE
Shrink and better document the debug image

### DIFF
--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -1,22 +1,26 @@
 FROM ubuntu:xenial
+# Do not add more stuff to this list that isn't small or critically useful.
+# If you occasionally need something on the container do
+# sudo /usr/local/bin/proxy-redirection-clear
+# sudo apt-get update && apt-get whichever
+# sudo /usr/local/bin/proxy-redirection-restore
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install --no-install-recommends -y \
     curl \
-    iptables \
-    iproute2 \
-    iputils-ping \
-    dnsutils \
-    netcat \
-    tcpdump \
-    net-tools \
-    libc6-dbg gdb valgrind \
-    vim \
-    nano \
-    emacs \
-    wrk \
-    lsof \
-    busybox \
-    sudo
+      iptables \
+      iproute2 \
+      iputils-ping \
+      dnsutils \
+      netcat \
+      tcpdump \
+      net-tools \
+      libc6-dbg gdb \
+      elvis-tiny \
+      lsof \
+      busybox \
+      sudo && \
+    rm -rf /var/lib/apt/lists/*
+
 # Deprecated: use "/usr/local/bin/istio-iptables.sh clear"
 ADD proxy-redirection-clear /usr/local/bin/proxy-redirection-clear
 ADD proxy-redirection-restore /usr/local/bin/proxy-redirection-restore

--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -6,7 +6,7 @@ FROM ubuntu:xenial
 # sudo /usr/local/bin/proxy-redirection-restore
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-    curl \
+      curl \
       iptables \
       iproute2 \
       iputils-ping \


### PR DESCRIPTION
 before: 722MB
after: 236MB
(Not counting envoy itself)

Fixes #423

Needs https://github.com/istio/pilot/pull/1202 to fully work

```release-note
Reduce proxy debug image by 2/3rd (486Mb saved) yet as functional
```