### PR TITLE
Remove entrypoint

### DIFF
--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -34,4 +34,3 @@ RUN useradd -m --uid 1337 istio-proxy && \
     echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers && \
     chown -R istio-proxy /var/lib/istio
 
-ENTRYPOINT /usr/local/bin/istio-start.sh

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -7,5 +7,4 @@ ADD istio-iptables.sh /usr/local/bin/istio-iptables.sh
 ADD istio-start.sh /usr/local/bin/istio-start.sh
 ADD envoy.json /var/lib/istio/envoy/envoy.json
 
-ENTRYPOINT /usr/local/bin/istio-start.sh
 


### PR DESCRIPTION
May create confusion in pilot docker images.

(the long term plan is to generate docker images and deb files in istio-build, and migrate to the 
new iptable script and consistent images)