### PR TITLE
Proper install for cloud builder

### DIFF
--- a/script/build_proxy_release.yaml
+++ b/script/build_proxy_release.yaml
@@ -3,6 +3,6 @@
 
 steps:
 - name: 'gcr.io/istio-io/istio-builder'
-  args: [ './script/release.sh', '-t', '$TAG_NAME' ]
+  args: [ './script/cloud_builder.sh', '-t', '$TAG_NAME' ]
 
 timeout: 1800s

--- a/script/build_proxy_release.yaml
+++ b/script/build_proxy_release.yaml
@@ -2,7 +2,7 @@
 #   \d+\.\d+\.\d+
 
 steps:
-- name: 'gcr.io/istio-io/istio-builder'
+- name: 'gcr.io/istio-io/istio-builder:0.1'
   args: [ './script/cloud_builder.sh', '-t', '$TAG_NAME' ]
 options:
   machineType: 'N1_STANDARD_8'

--- a/script/build_proxy_release.yaml
+++ b/script/build_proxy_release.yaml
@@ -4,5 +4,6 @@
 steps:
 - name: 'gcr.io/istio-io/istio-builder'
   args: [ './script/cloud_builder.sh', '-t', '$TAG_NAME' ]
-
+options:
+  machineType: 'N1_STANDARD_8'
 timeout: 1800s

--- a/script/cloud_builder.sh
+++ b/script/cloud_builder.sh
@@ -25,7 +25,11 @@ gcloud kms decrypt \
   --key=DockerHub \
   --verbosity=info
 
-echo "Changing ${WORKSPACE} ownership to releng"
-chown -R releng -R "${WORKSPACE}"
+echo 'Setting bazel.rc'
+cp tools/bazel.rc.cloudbuilder "${HOME}/.bazelrc"
 
-su releng -c "./script/release.sh $*"
+#echo "Changing ${WORKSPACE} ownership to releng"
+#chown -R releng -R "${WORKSPACE}"
+
+#su releng -c "./
+script/release.sh ${@}

--- a/script/cloud_builder.sh
+++ b/script/cloud_builder.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
+
+# Cloud Builder does not support running as a user
+# Note the image used has a releng user, but we start as root
+# and need to su into releng
+
+RELENG_HOME='/home/releng'
+WORKSPACE="${PWD}"
+
+echo 'Downloading docker.io encoded config'
+gsutil cp gs://istio-secrets/dockerhub_config.json.enc \
+  "${RELENG_HOME}/config.json.enc"
+
+echo 'Decoding docker.io config'
+gcloud kms decrypt \
+  --ciphertext-file="${RELENG_HOME}/config.json.enc" \
+  --plaintext-file="${RELENG_HOME}/config.json" \
+  --location=global \
+  --keyring=Secrets \
+  --key=DockerHub \
+  --verbosity=info
+
+echo "Changing ${WORKSPACE} ownership to releng"
+chown -R releng -R "${WORKSPACE}"
+
+su releng -c "./script/release.sh $*"

--- a/script/cloud_builder.sh
+++ b/script/cloud_builder.sh
@@ -5,25 +5,7 @@ set -o nounset
 set -o pipefail
 set -x
 
-# Cloud Builder does not support running as a user
-# Note the image used has a releng user, but we start as root
-# and need to su into releng
-
-RELENG_HOME='/home/releng'
-WORKSPACE="${PWD}"
-
-echo 'Downloading docker.io encoded config'
-gsutil cp gs://istio-secrets/dockerhub_config.json.enc \
-  "${RELENG_HOME}/config.json.enc"
-
-echo 'Decoding docker.io config'
-gcloud kms decrypt \
-  --ciphertext-file="${RELENG_HOME}/config.json.enc" \
-  --plaintext-file="${RELENG_HOME}/config.json" \
-  --location=global \
-  --keyring=Secrets \
-  --key=DockerHub \
-  --verbosity=info
+# Use this file for Cloud Builder specific settings.
 
 echo 'Setting bazel.rc'
 cp tools/bazel.rc.cloudbuilder "${HOME}/.bazelrc"

--- a/script/cloud_builder.sh
+++ b/script/cloud_builder.sh
@@ -28,8 +28,4 @@ gcloud kms decrypt \
 echo 'Setting bazel.rc'
 cp tools/bazel.rc.cloudbuilder "${HOME}/.bazelrc"
 
-#echo "Changing ${WORKSPACE} ownership to releng"
-#chown -R releng -R "${WORKSPACE}"
-
-#su releng -c "./
 script/release.sh ${@}

--- a/script/push-debian.sh
+++ b/script/push-debian.sh
@@ -12,6 +12,7 @@ VERSION_FILE="${ROOT}/tools/deb/version"
 BAZEL_ARGS=()
 BAZEL_TARGET='//tools/deb:istio-proxy'
 BAZEL_BINARY="${ROOT}/bazel-bin/tools/deb/istio-proxy"
+ISTIO_VERSION=''
 
 set -o errexit
 set -o nounset

--- a/script/push-debian.sh
+++ b/script/push-debian.sh
@@ -13,7 +13,10 @@ BAZEL_ARGS=()
 BAZEL_TARGET='//tools/deb:istio-proxy'
 BAZEL_BINARY="${ROOT}/bazel-bin/tools/deb/istio-proxy"
 
-set -ex
+set -o errexit
+set -o nounset
+set -o pipefail
+set -x
 
 function usage() {
   echo "$0 \

--- a/script/release.sh
+++ b/script/release.sh
@@ -22,16 +22,8 @@ while getopts i:t: arg ; do
   esac
 done
 
-mkdir -p $HOME/.docker
-gsutil cp gs://istio-secrets/dockerhub_config.json.enc $HOME/.docker/config.json.enc
-gcloud kms decrypt \
-       --ciphertext-file=$HOME/.docker/config.json.enc \
-       --plaintext-file=$HOME/.docker/config.json \
-       --location=global \
-       --keyring=Secrets \
-       --key=DockerHub
-
-./script/push-debian.sh \
+script/push-debian.sh \
     -c opt \
     -v "${TAG_NAME}" \
     -p "gs://istio-release/releases/${TAG_NAME}/deb"
+

--- a/tools/bazel.rc.cloudbuilder
+++ b/tools/bazel.rc.cloudbuilder
@@ -1,0 +1,8 @@
+# This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
+startup --host_jvm_args=-Xmx2500m
+startup --host_jvm_args=-Xms2500m
+startup --batch
+
+# This is so we understand failures better
+build --verbose_failures
+

--- a/tools/bazel.rc.cloudbuilder
+++ b/tools/bazel.rc.cloudbuilder
@@ -1,6 +1,6 @@
 # This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
-startup --host_jvm_args=-Xmx2500m
-startup --host_jvm_args=-Xms2500m
+startup --host_jvm_args=-Xmx8192m
+startup --host_jvm_args=-Xms8192m
 startup --batch
 
 # This is so we understand failures better


### PR DESCRIPTION
* Separate release from cloud builder setup to ease reproduction and testing
* Increase to more robust machine
* Use specific bazel.rc for cloudbuilder and use recommanded batch mode for container