### PR TITLE
Update to use latest mixerclient.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,7 +71,7 @@ git_repository(
 
 git_repository(
     name = "com_github_istio_mixer",
-    commit = "2da5a16120f913ec4f5ee7b34e84d7a08a02740f",  # Aug 30, 2017
+    commit = "535eb564667cef6aed334cb4f5e967a104768387",  # Sep 26, 2017
     remote = "https://github.com/istio/mixer",
 )
 

--- a/src/envoy/mixer/repositories.bzl
+++ b/src/envoy/mixer/repositories.bzl
@@ -15,7 +15,7 @@
 ################################################################################
 #
 
-MIXER_CLIENT = "c46e75a46c83a76098bd841b40d36f8fcbf52534"
+MIXER_CLIENT = "c64486ac6fabcbd023420ec77187ca703879ca84"
 
 def mixer_client_repositories(bind=True):
     native.git_repository(


### PR DESCRIPTION
Also need to update Mixer SHA. 
The new mixerclient is automatically using latest global dictionary. 
If Mixer is not updated to use the latest global dictionary,  integration test will fail.