### PR TITLE
Typo fix and missing serviceCluster setting for release-0.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,7 @@ def presubmit(gitUtils, bazel) {
       sh 'script/release-binary'
     }
     stage('Push Debian Package') {
-      sh "script/push-debian.sh -c opt -p gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs"
+      sh "script/push-debian.sh -c dbg -p gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs"
     }
   }
 }
@@ -61,7 +61,7 @@ def postsubmit(gitUtils, bazel, utils) {
       sh 'script/release-docker'
     }
     stage('Push Debian Package') {
-      sh "script/push-debian.sh -c opt -p gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs"
+      sh "script/push-debian.sh -c dbg -p gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs"
     }
   }
 }

--- a/script/push-debian.sh
+++ b/script/push-debian.sh
@@ -9,7 +9,7 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 VERSION_FILE="${ROOT}/tools/deb/version"
-BAZEL_ARGS=()
+BAZEL_ARGS=""
 BAZEL_TARGET='//tools/deb:istio-proxy'
 BAZEL_BINARY="${ROOT}/bazel-bin/tools/deb/istio-proxy"
 ISTIO_VERSION=''
@@ -29,7 +29,7 @@ function usage() {
 
 while getopts ":c:p:v:" arg; do
   case ${arg} in
-    c) BAZEL_ARGS+=("--config=${OPTARG}");;
+    c) BAZEL_ARGS+=" -c ${OPTARG}";;
     p) GCS_PATH="${OPTARG}";;
     v) ISTIO_VERSION="${OPTARG}";;
     *) usage;;
@@ -45,6 +45,6 @@ fi
 
 [[ -z "${GCS_PATH}" ]] && usage
 
-bazel build ${BAZEL_ARGS[@]} ${BAZEL_TARGET}
+bazel build ${BAZEL_ARGS} ${BAZEL_TARGET}
 
 gsutil -m cp -r "${BAZEL_BINARY}.deb" ${GCS_PATH}/

--- a/tools/deb/istio-start.sh
+++ b/tools/deb/istio-start.sh
@@ -30,8 +30,8 @@ fi
 ISTIO_BIN_BASE=${ISTIO_BIN_BASE:-/usr/local/bin}
 ISTIO_LOG_DIR=${ISTIO_LOG_DIR:-/var/log/istio}
 ISTIO_CFG=${ISTIO_CFG:-/var/lib/istio}
-NS=${POD_NAMESPACE:-default}
-SVC=${ISTO_SERVICE:-rawvm}
+NS=${ISTIO_NAMESPACE:-default}
+SVC=${ISTIO_SERVICE:-rawvm}
 
 
 if [ -z "${ISTIO_SVC_IP:-}" ]; then
@@ -54,10 +54,9 @@ fi
 ${ISTIO_BIN_BASE}/istio-iptables.sh
 
 if [ -f ${ISTIO_BIN_BASE}/pilot-agent ]; then
-  exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy > ${ISTIO_LOG_DIR}/istio.log" istio-proxy
+  exec su -s /bin/bash -c "INSTANCE_IP=${ISTIO_SVC_IP} POD_NAME=${POD_NAME} POD_NAMESPACE=${NS} exec ${ISTIO_BIN_BASE}/pilot-agent proxy --serviceCluster $SVC > ${ISTIO_LOG_DIR}/istio.log" istio-proxy
 else
   ENVOY_CFG=${ENVOY_CFG:-${ISTIO_CFG}/envoy/envoy.json}
   # Run envoy directly - agent not installed. This should be used only for debugging/testing standalone envoy
-  exec su -s /bin/bash -c "exec ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster istio-proxy --service-node 'sidecar~${ISTIO_SVC_IP}~${SVC}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
+  exec su -s /bin/bash -c "exec ${ISTIO_BIN_BASE}/envoy -c $ENVOY_CFG --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster $SVC --service-node 'sidecar~${ISTIO_SVC_IP}~${POD_NAME}.${NS}.svc.cluster.local~${NS}.svc.cluster.local' $ISTIO_DEBUG >${ISTIO_LOG_DIR}/istio.log" istio-proxy
 fi
-


### PR DESCRIPTION
(cherry pick of #579)

* Typo fix and missing serviceCluster setting

* don't build .deb with opt for now

```release-note
ISTIO_NAMESPACE / ISTIO_SERVICE VM script args
Don’t build with opt the proxy debug for now to be consistent with rest of images
```

* Build -c dbg

(cherry picked from commit a05c813aa01b8eed00d1698f5daba3f468b0a293)