### PR TITLE
Fix postsubmit to publish debian packages

### DIFF
--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -44,4 +44,4 @@ cd $ROOT
 echo 'Create and push artifacts'
 script/release-binary
 script/release-docker
-make artifacts
+ARTIFACTS_DIR="gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs" make artifacts


### PR DESCRIPTION
The postsubmit was trying to push to a local directory instead of remote location

```release-note
none
```