### PR TITLE
Strip out "spiffe://" in the identity

### DIFF
--- a/src/envoy/mixer/utils.cc
+++ b/src/envoy/mixer/utils.cc
@@ -20,6 +20,12 @@ namespace Envoy {
 namespace Http {
 namespace Utils {
 
+namespace {
+
+const std::string kSPIFFEPrefix("spiffe://");
+
+}  // namespace
+
 std::map<std::string, std::string> ExtractHeaders(const HeaderMap& header_map) {
   std::map<std::string, std::string> headers;
   header_map.iterate(
@@ -55,11 +61,10 @@ bool GetSourceUser(const Network::Connection* connection, std::string* user) {
     Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());
     if (ssl != nullptr) {
       std::string result = ssl->uriSanPeerCertificate();
-      std::string prefix = "spiffe://";
-      // Strip out the prefix "spiffe://" in the identity.
-      std::size_t found = result.find(prefix);
-      if (found == 0) {
-        *user = result.substr(prefix.size());
+      if (result.length() >= kSPIFFEPrefix.length() &&
+          result.compare(0, kSPIFFEPrefix.length(), kSPIFFEPrefix) == 0) {
+        // Strip out the prefix "spiffe://" in the identity.
+        *user = result.substr(kSPIFFEPrefix.size());
         return true;
       }
     }

--- a/src/envoy/mixer/utils.cc
+++ b/src/envoy/mixer/utils.cc
@@ -65,8 +65,10 @@ bool GetSourceUser(const Network::Connection* connection, std::string* user) {
           result.compare(0, kSPIFFEPrefix.length(), kSPIFFEPrefix) == 0) {
         // Strip out the prefix "spiffe://" in the identity.
         *user = result.substr(kSPIFFEPrefix.size());
-        return true;
+      } else {
+        *user = result;
       }
+      return true;
     }
   }
   return false;

--- a/src/envoy/mixer/utils.cc
+++ b/src/envoy/mixer/utils.cc
@@ -54,8 +54,14 @@ bool GetSourceUser(const Network::Connection* connection, std::string* user) {
   if (connection) {
     Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());
     if (ssl != nullptr) {
-      *user = ssl->uriSanPeerCertificate();
-      return true;
+      std::string result = ssl->uriSanPeerCertificate();
+      std::string prefix = "spiffe://";
+      // Strip out the prefix "spiffe://" in the identity.
+      std::size_t found = result.find(prefix);
+      if (found == 0) {
+        *user = result.substr(prefix.size());
+        return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
**What this PR does / why we need it**:Strips out the prefix "spiffe://" from the URI in the SAN field of the peer certificate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
