### PR TITLE
Not to send legacy quota for v2 config.

### DIFF
--- a/src/envoy/mixer/config.cc
+++ b/src/envoy/mixer/config.cc
@@ -113,6 +113,10 @@ void HttpMixerConfig::Load(const Json::Object& json) {
   ReadTransportConfig(json, http_config.mutable_transport());
 
   has_v2_config = ReadV2Config(json, &http_config);
+  if (has_v2_config) {
+    // If v2 config is valid, clear v1 legacy_quotas.
+    legacy_quotas.clear();
+  }
 }
 
 void HttpMixerConfig::CreateLegacyRouteConfig(


### PR DESCRIPTION
**What this PR does / why we need it**:

If v2 mixer client config is used,  not to use legacy quota config

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
