### PR TITLE
Use shorter name for proxy debian files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,14 @@ config_setting(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "deb_version",
+    srcs = [],
+    outs = ["deb_version.txt"],
+    cmd = "echo $${ISTIO_VERSION:-\"0.3.0-dev\"} > \"$@\"",
+    visibility = ["//visibility:public"],
+)
+
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/proxy")

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - qiwzhang
+  - lizan
+  - sebastienvas
+  - geeknoid
+  - rshriram
+  - linsun
+approvers:
+  - qiwzhang
+  - lizan
+  - sebastienvas
+  - geeknoid
+  - rshriram
+  - linsun

--- a/script/push-debian.sh
+++ b/script/push-debian.sh
@@ -23,7 +23,6 @@
 #   -p gs://istio-release/release/0.2.1/deb
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-VERSION_FILE="${ROOT}/tools/deb/version"
 BAZEL_ARGS=""
 BAZEL_TARGET='//tools/deb:istio-proxy'
 BAZEL_BINARY="${ROOT}/bazel-bin/tools/deb/istio-proxy"
@@ -56,10 +55,8 @@ while getopts ":c:o:p:v:" arg; do
 done
 
 if [[ -n "${ISTIO_VERSION}" ]]; then
-  BAZEL_TARGET+='-release'
-  BAZEL_BINARY+='-release'
-  echo "${ISTIO_VERSION}" > "${VERSION_FILE}"
-  trap 'rm "${VERSION_FILE}"' EXIT
+  BAZEL_ARGS+=" --action_env=ISTIO_VERSION"
+  export ISTIO_VERSION
 fi
 
 [[ -z "${GCS_PATH}" ]] && [[ -z "${OUTPUT_DIR}" ]] && usage

--- a/script/release-binary
+++ b/script/release-binary
@@ -23,7 +23,7 @@ UBUNTU_RELEASE=${UBUNTU_RELEASE:-$(lsb_release -c -s)}
 [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'must run on Ubuntu Xenial'; exit 1; }
 
 # The bucket name to store proxy binary
-DST="gs://delco-experimental/proxy"
+DST="gs://istio-build/proxy"
 
 # The proxy binary name.
 SHA="$(git rev-parse --verify HEAD)"

--- a/script/release-binary
+++ b/script/release-binary
@@ -71,7 +71,7 @@ gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 
 BINARY_NAME="istio-proxy-debug-${SHA}.deb"
 SHA256_NAME="istio-proxy-debug${SHA}.sha256"
-bazel build -c dbg //:deb_version //tools/deb:istio-proxy
+bazel build -c dbg //tools/deb:istio-proxy
 BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy__amd64.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"

--- a/script/release-binary
+++ b/script/release-binary
@@ -48,7 +48,7 @@ gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 BINARY_NAME="istio-proxy-${SHA}.deb"
 SHA256_NAME="istio-proxy-${SHA}.sha256"
 bazel build --config=release //tools/deb:istio-proxy
-BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy__amd64.deb"
+BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
@@ -72,7 +72,7 @@ gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 BINARY_NAME="istio-proxy-debug-${SHA}.deb"
 SHA256_NAME="istio-proxy-debug${SHA}.sha256"
 bazel build -c dbg //tools/deb:istio-proxy
-BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy__amd64.deb"
+BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 

--- a/script/release-binary
+++ b/script/release-binary
@@ -47,7 +47,6 @@ gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 
 BINARY_NAME="istio-proxy-${SHA}.deb"
 SHA256_NAME="istio-proxy-${SHA}.sha256"
-
 bazel build --config=release //tools/deb:istio-proxy
 BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy__amd64.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"

--- a/script/release-binary
+++ b/script/release-binary
@@ -35,6 +35,11 @@ gsutil stat "${DST}/${BINARY_NAME}" \
   && { echo 'Binary already exists'; exit 0; } \
   || echo 'Building a new binary.'
 
+# Generate the version file
+bazel build :deb_version
+ls -ld bazel-genfiles/deb_version.txt
+cat bazel-genfiles/deb_version.txt
+
 # Build the release binary
 bazel build --config=release //src/envoy:envoy_tar
 BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"

--- a/script/release-binary
+++ b/script/release-binary
@@ -23,7 +23,7 @@ UBUNTU_RELEASE=${UBUNTU_RELEASE:-$(lsb_release -c -s)}
 [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'must run on Ubuntu Xenial'; exit 1; }
 
 # The bucket name to store proxy binary
-DST="gs://istio-build/proxy"
+DST="gs://delco-experimental/proxy"
 
 # The proxy binary name.
 SHA="$(git rev-parse --verify HEAD)"

--- a/script/release-binary
+++ b/script/release-binary
@@ -23,7 +23,7 @@ UBUNTU_RELEASE=${UBUNTU_RELEASE:-$(lsb_release -c -s)}
 [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'must run on Ubuntu Xenial'; exit 1; }
 
 # The bucket name to store proxy binary
-DST="gs://delco-experimental/proxy"
+DST="gs://istio-build/proxy"
 
 # The proxy binary name.
 SHA="$(git rev-parse --verify HEAD)"
@@ -35,26 +35,21 @@ gsutil stat "${DST}/${BINARY_NAME}" \
   && { echo 'Binary already exists'; exit 0; } \
   || echo 'Building a new binary.'
 
-# Generate the version file
-#bazel build :deb_version
-#ls -ld bazel-genfiles/deb_version.txt
-#cat bazel-genfiles/deb_version.txt
-
 # Build the release binary
-#bazel build --config=release //src/envoy:envoy_tar
-#BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
-#cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
-#sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
+bazel build --config=release //src/envoy:envoy_tar
+BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
+cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
 # Copy it to the bucket.
-#echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-#gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 
 BINARY_NAME="istio-proxy-${SHA}.deb"
 SHA256_NAME="istio-proxy-${SHA}.sha256"
 
-bazel build --config=release //:deb_version //tools/deb:istio-proxy || cat bazel-genfiles/deb_version.txt
-BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy_0.3-dev_amd64.deb"
+bazel build --config=release //tools/deb:istio-proxy
+BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy__amd64.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
@@ -78,7 +73,7 @@ gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 BINARY_NAME="istio-proxy-debug-${SHA}.deb"
 SHA256_NAME="istio-proxy-debug${SHA}.sha256"
 bazel build -c dbg //:deb_version //tools/deb:istio-proxy
-BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy_0.3-dev_amd64.deb"
+BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy__amd64.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 

--- a/script/release-binary
+++ b/script/release-binary
@@ -36,23 +36,24 @@ gsutil stat "${DST}/${BINARY_NAME}" \
   || echo 'Building a new binary.'
 
 # Generate the version file
-bazel build :deb_version
-ls -ld bazel-genfiles/deb_version.txt
-cat bazel-genfiles/deb_version.txt
+#bazel build :deb_version
+#ls -ld bazel-genfiles/deb_version.txt
+#cat bazel-genfiles/deb_version.txt
 
 # Build the release binary
-bazel build --config=release //src/envoy:envoy_tar
-BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
-cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
-sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
+#bazel build --config=release //src/envoy:envoy_tar
+#BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
+#cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+#sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
 
 # Copy it to the bucket.
-echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+#echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+#gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 
 BINARY_NAME="istio-proxy-${SHA}.deb"
 SHA256_NAME="istio-proxy-${SHA}.sha256"
-bazel build --config=release //tools/deb:istio-proxy
+
+bazel build --config=release //:deb_version //tools/deb:istio-proxy || cat bazel-genfiles/deb_version.txt
 BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy_0.3-dev_amd64.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
@@ -76,7 +77,7 @@ gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 
 BINARY_NAME="istio-proxy-debug-${SHA}.deb"
 SHA256_NAME="istio-proxy-debug${SHA}.sha256"
-bazel build -c dbg //tools/deb:istio-proxy
+bazel build -c dbg //:deb_version //tools/deb:istio-proxy
 BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy_0.3-dev_amd64.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
 sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"

--- a/tools/deb/BUILD
+++ b/tools/deb/BUILD
@@ -68,20 +68,6 @@ pkg_deb(
     maintainer = "The Istio Authors <istio-dev@googlegroups.com>",
     package = "istio-proxy",
     postinst = "postinst.sh",
-    version = "0.3-dev",
-)
-
-pkg_deb(
-    name = "istio-proxy-release",
-    architecture = "amd64",
-    built_using = "bazel",
-    conffiles_file = "conffiles",
-    data = ":debian-data",
-    description_file = "description",
-    homepage = "http://istio.io",
-    maintainer = "The Istio Authors <istio-dev@googlegroups.com>",
-    package = "istio-proxy",
-    postinst = "postinst.sh",
     tags = ["manual"],
-    version_file = "version",
+    version_file = "//:deb_version",
 )


### PR DESCRIPTION
Last week I implemented a request to get rid of the behavior that was causing "-release" to get added to the basename of debian files.  I did this by unifying the release and non-release rules to use a version_file = "//:deb_version" in the pkg_deb() rules, whereby the top-level BUILD generates the version file using:

"echo $${ISTIO_VERSION:-\"0.3.0-dev\"} > \"$@\""

This seems to be causing the postsubmit to fail in proxy.  The issue is that script/release-binary expects a name like:

istio-proxy_0.3-dev_amd64.deb

but after my change the version part is not included in the filename:

istio-proxy__amd64.deb

I'm not sure if this is a bazel bug or intentional feature when the version goes from a static value to a file reference.  I've confirmed before (and reconfigured again) that the version # in the deb is appropriate.  I've also checked that the bazel-genfiles/deb_version.txt does contain valid contents.  I tried running "bazel build //:deb_version.txt" as a separate step in case there was a race in bazel, but this didn't change the behavior.

I was going to make a change to change the name references to "istio-proxy__amd64.deb", but the shorter "istio-proxy.deb" is just a symlink to that (and the shorter name seems to be what everyone else in istio is using) so that seems like the safer option for me to use.  I'm not sure why the amd64 version was used in the first place unless there is/was a cross-compilation case.

```release-note
NONE
```
