### PR TITLE
Remove 5 seconds sleep for integration tests.

### DIFF
--- a/src/envoy/mixer/BUILD
+++ b/src/envoy/mixer/BUILD
@@ -18,7 +18,6 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_cc_binary",
 )
 
 envoy_cc_library(
@@ -40,17 +39,7 @@ envoy_cc_library(
     deps = [
         "//external:mixer_http_control_lib",
         "//external:mixer_tcp_control_lib",
-	"//src/envoy/auth:http_filter_lib",
+        "//src/envoy/auth:http_filter_lib",
         "@envoy//source/exe:envoy_common_lib",
-    ],
-)
-
-envoy_cc_binary(
-    name = "envoy",
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":filter_lib",
-        "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/src/envoy/mixer/integration_test/envoy.go
+++ b/src/envoy/mixer/integration_test/envoy.go
@@ -87,8 +87,8 @@ func (s *Envoy) Start() error {
 	if err == nil {
 		url := fmt.Sprintf("http://localhost:%v/server_info", AdminPort)
 		WaitForHttpServer(url)
-		WaitForAPort(ClientProxyPort)
-		WaitForAPort(ServerProxyPort)
+		WaitForPort(ClientProxyPort)
+		WaitForPort(ServerProxyPort)
 	}
 	return err
 }

--- a/src/envoy/mixer/integration_test/envoy.go
+++ b/src/envoy/mixer/integration_test/envoy.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 )
 
 func getTestBinRootPath() string {
@@ -88,11 +87,8 @@ func (s *Envoy) Start() error {
 	if err == nil {
 		url := fmt.Sprintf("http://localhost:%v/server_info", AdminPort)
 		WaitForHttpServer(url)
-		// TODO: need a better way to detect listen ports are up.
-		// In tsan case, even admin port is up, other ports may not.
-		// Test program will crash with connection is refused error.
-		// Wait 2 seconds more for tsan
-		time.Sleep(time.Second * 5)
+		WaitForAPort(ClientProxyPort)
+		WaitForAPort(ServerProxyPort)
 	}
 	return err
 }

--- a/src/envoy/mixer/integration_test/http_client.go
+++ b/src/envoy/mixer/integration_test/http_client.go
@@ -133,7 +133,7 @@ func WaitForHttpServer(url string) {
 	log.Println("Give up the wait, continue the test...")
 }
 
-func WaitForAPort(port int) {
+func WaitForPort(port int) {
 	server_port := fmt.Sprintf("localhost:%v", port)
 	for i := 0; i < maxAttempts; i++ {
 		log.Println("Pinging port: ", server_port)

--- a/src/envoy/mixer/integration_test/http_client.go
+++ b/src/envoy/mixer/integration_test/http_client.go
@@ -15,8 +15,10 @@
 package test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -25,6 +27,9 @@ import (
 
 // HTTP client time out in second.
 const HttpTimeOut = 5
+
+// Maximum number of ping the server to wait.
+const maxAttempts = 30
 
 // Issue fast request, only care about network error.
 // Don't care about server response.
@@ -115,16 +120,30 @@ func HTTPGetWithHeaders(l string, headers map[string]string) (code int, resp_bod
 }
 
 func WaitForHttpServer(url string) {
-	const maxAttempts = 30
 	for i := 0; i < maxAttempts; i++ {
-		time.Sleep(time.Second)
-		log.Println("Pinging HTTP server...")
+		log.Println("Pinging URL: ", url)
 		code, _, err := HTTPGet(url)
 		if err == nil && code == http.StatusOK {
 			log.Println("Server is up and running...")
 			return
 		}
 		log.Println("Will wait a second and try again.")
+		time.Sleep(time.Second)
+	}
+	log.Println("Give up the wait, continue the test...")
+}
+
+func WaitForAPort(port int) {
+	server_port := fmt.Sprintf("localhost:%v", port)
+	for i := 0; i < maxAttempts; i++ {
+		log.Println("Pinging port: ", server_port)
+		_, err := net.Dial("tcp", server_port)
+		if err == nil {
+			log.Println("The port is up and running...")
+			return
+		}
+		log.Println("Wait a second and try again.")
+		time.Sleep(time.Second)
 	}
 	log.Println("Give up the wait, continue the test...")
 }

--- a/src/envoy/mixer/start_envoy
+++ b/src/envoy/mixer/start_envoy
@@ -36,7 +36,7 @@ EOF
   exit 2
 }
 
-ENVOY="$ROOT/bazel-bin/src/envoy/mixer/envoy"
+ENVOY="$ROOT/bazel-bin/src/envoy/envoy"
 TEMPLATE="$ROOT/src/envoy/mixer/envoy.conf.template"
 CONFIG="$ROOT/src/envoy/mixer/envoy.conf"
 DEBUG=''


### PR DESCRIPTION
**What this PR does / why we need it**:

To speed up integration tests.  It is taking too long for presubmit tests.
* sleep(5) is removed when detecting Envoy starting up.  Instead using net.dial to check the http ports.
* also removed "envoy" binary in src/envoy/mixer/BUILD which is only used by start_envoy script.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
