### PR TITLE
Fix crash with invalid sec-istio-auth-userinfo header

### DIFF
--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -287,18 +287,32 @@ class CheckData : public HttpCheckData,
     if (!entry) {
       return false;
     }
-    std::string payload_str = Auth::Base64UrlDecode(
-        std::string(entry->value().c_str(), entry->value().size()));
-    auto json_obj = Json::Factory::loadFromString(payload_str);
-    json_obj->iterate(
-        [payload](const std::string& key, const Json::Object& obj) -> bool {
-          // will throw execption if value type is not string.
-          try {
-            (*payload)[key] = obj.asString();
-          } catch (...) {
-          }
-          return true;
-        });
+    std::string value(entry->value().c_str(), entry->value().size());
+    std::string payload_str = Auth::Base64UrlDecode(value);
+    // Return is an empty string if Base64 decode fails.
+    if (payload_str.empty()) {
+      ENVOY_LOG(error, "Invalid {} header, invalid base64: {}",
+                Http::JwtVerificationFilter::AuthorizedHeaderKey().get(),
+                value);
+      return false;
+    }
+    try {
+      auto json_obj = Json::Factory::loadFromString(payload_str);
+      json_obj->iterate(
+          [payload](const std::string& key, const Json::Object& obj) -> bool {
+            // will throw execption if value type is not string.
+            try {
+              (*payload)[key] = obj.asString();
+            } catch (...) {
+            }
+            return true;
+          });
+    } catch (...) {
+      ENVOY_LOG(error, "Invalid {} header, invalid json: {}",
+                Http::JwtVerificationFilter::AuthorizedHeaderKey().get(),
+                payload_str);
+      return false;
+    }
     return true;
   }
 };

--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -289,7 +289,7 @@ class CheckData : public HttpCheckData,
     }
     std::string value(entry->value().c_str(), entry->value().size());
     std::string payload_str = Auth::Base64UrlDecode(value);
-    // Return is an empty string if Base64 decode fails.
+    // Return an empty string if Base64 decode fails.
     if (payload_str.empty()) {
       ENVOY_LOG(error, "Invalid {} header, invalid base64: {}",
                 Http::JwtVerificationFilter::AuthorizedHeaderKey().get(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix proxy crash with invalid sec-istio-auth-userinfo header

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
