### PR TITLE
Fix a memory leak when a request is canceled.

### DIFF
--- a/src/envoy/mixer/grpc_transport.cc
+++ b/src/envoy/mixer/grpc_transport.cc
@@ -102,6 +102,12 @@ void GrpcTransport<RequestType, ResponseType>::onFailure(
 }
 
 template <class RequestType, class ResponseType>
+void GrpcTransport<RequestType, ResponseType>::Cancel() {
+  ENVOY_LOG(debug, "Cancel gRPC request {}", descriptor().name());
+  delete this;
+}
+
+template <class RequestType, class ResponseType>
 typename GrpcTransport<RequestType, ResponseType>::Func
 GrpcTransport<RequestType, ResponseType>::GetFunc(Upstream::ClusterManager& cm,
                                                   const HeaderMap* headers) {
@@ -113,7 +119,7 @@ GrpcTransport<RequestType, ResponseType>::GetFunc(Upstream::ClusterManager& cm,
             new Grpc::AsyncClientImpl<RequestType, ResponseType>(
                 cm, kMixerServerClusterName)),
         request, headers, response, on_done);
-    return [transport]() { transport->request_->cancel(); };
+    return [transport]() { transport->Cancel(); };
   };
 }
 

--- a/src/envoy/mixer/grpc_transport.h
+++ b/src/envoy/mixer/grpc_transport.h
@@ -58,6 +58,8 @@ class GrpcTransport : public Grpc::AsyncRequestCallbacks<ResponseType>,
   void onFailure(Grpc::Status::GrpcStatus status, const std::string& message,
                  Tracing::Span& span) override;
 
+  void Cancel();
+
  private:
   static const google::protobuf::MethodDescriptor& descriptor();
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When a request is canceled when it is waiting for Mixer Check call,  there is a memory leak.
This PR fixes this leak.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
