### PR TITLE
Pass stats update interval

### DIFF
--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -67,14 +67,16 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
                                    Runtime::RandomGenerator& random,
                                    Stats::Scope& scope)
     : cm_(cm),
-      stats_obj_(dispatcher, kHttpStatsPrefix, scope,
-                 [this](Statistics* stat) -> bool {
-                   if (!controller_) {
-                     return false;
-                   }
-                   controller_->GetStatistics(stat);
-                   return true;
-                 }) {
+      stats_obj_(
+          dispatcher, kHttpStatsPrefix, scope,
+          mixer_config.http_config.transport().stats_update_interval_ms(),
+          [this](Statistics* stat) -> bool {
+            if (!controller_) {
+              return false;
+            }
+            controller_->GetStatistics(stat);
+            return true;
+          }) {
   ::istio::mixer_control::http::Controller::Options options(
       mixer_config.http_config, mixer_config.legacy_quotas);
 
@@ -91,6 +93,7 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
                                  Runtime::RandomGenerator& random,
                                  Stats::Scope& scope)
     : stats_obj_(dispatcher, kTcpStatsPrefix, scope,
+                 mixer_config.tcp_config.transport().stats_update_interval_ms(),
                  [this](Statistics* stat) -> bool {
                    if (!controller_) {
                      return false;

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -29,14 +29,17 @@ const int kStatsUpdateIntervalInMs = 10000;
 
 MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
                                    const std::string& name, Stats::Scope& scope,
-                                   GetStatsFunc func)
+                                   int update_interval_ms, GetStatsFunc func)
     : stats_{ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))},
       get_stats_func_(func) {
   memset(&old_stats_, 0, sizeof(old_stats_));
 
+  // If stats update interval in config is 0, set interval to 10 seconds.
+  int stats_update_interval =
+      update_interval > 0 ? update_interval : kStatsUpdateIntervalInMs;
   if (get_stats_func_) {
     timer_ = dispatcher.createTimer([this]() { OnTimer(); });
-    timer_->enableTimer(std::chrono::milliseconds(kStatsUpdateIntervalInMs));
+    timer_->enableTimer(std::chrono::milliseconds(stats_update_interval));
   }
 }
 

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -36,7 +36,7 @@ MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
 
   // If stats update interval in config is 0, set interval to 10 seconds.
   int stats_update_interval =
-      update_interval > 0 ? update_interval : kStatsUpdateIntervalInMs;
+      update_interval_ms > 0 ? update_interval_ms : kStatsUpdateIntervalInMs;
   if (get_stats_func_) {
     timer_ = dispatcher.createTimer([this]() { OnTimer(); });
     timer_->enableTimer(std::chrono::milliseconds(stats_update_interval));

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -34,7 +34,7 @@ MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
       get_stats_func_(func) {
   memset(&old_stats_, 0, sizeof(old_stats_));
 
-  // If stats update interval in config is 0, set interval to 10 seconds.
+  // If stats update interval from config is 0, then set interval to 10 seconds.
   int stats_update_interval =
       update_interval_ms > 0 ? update_interval_ms : kStatsUpdateIntervalInMs;
   if (get_stats_func_) {

--- a/src/envoy/mixer/stats.h
+++ b/src/envoy/mixer/stats.h
@@ -53,7 +53,8 @@ typedef std::function<bool(::istio::mixer_client::Statistics* s)> GetStatsFunc;
 class MixerStatsObject {
  public:
   MixerStatsObject(Event::Dispatcher& dispatcher, const std::string& name,
-                   Stats::Scope& scope, GetStatsFunc func);
+                   Stats::Scope& scope, int update_interval_ms,
+                   GetStatsFunc func);
 
  private:
   // This function is invoked when timer event fires.


### PR DESCRIPTION
**What this PR does / why we need it**:Pass stats update interval from config to proxy, so that we can control the frequency to update Envoy stats.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #132
https://github.com/istio/mixerclient/issues/132

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
