### PR TITLE
Bring back accidentally deleted build options in #736

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -46,3 +46,11 @@ build:clang-msan --copt -fsanitize-memory-track-origins=2
 
 # Test options
 test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
+
+# Release builds
+build:release -c opt
+
+# Add compile option for all C++ files
+build --cxxopt -Wnon-virtual-dtor
+build --cxxopt -Wformat
+build --cxxopt -Wformat-security


### PR DESCRIPTION
**What this PR does / why we need it**:

#736 accidentally remove `-c opt` from release build and a couple of compile options, bring them back.

cc @costinm @ldemailly 

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
