### PR TITLE
Enable IPv6 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,18 @@ jobs:
       - image: istio/ci:go1.9-bazel0.7
     resource_class: xlarge
     steps:
-     machine: true
-     steps:
-     - checkout
-     - run:
-         name: enable ipv6
-         command: |
-           cat <<'EOF' | sudo tee /etc/docker/daemon.json
-           {
-             "ipv6": true,
-             "fixed-cidr-v6": "2001:db8:1::/64"
-           }
-           EOF
+      machine: true
+      steps:
+      - checkout
+      - run:
+          name: enable ipv6
+          command: |
+            cat <<'EOF' | sudo tee /etc/docker/daemon.json
+            {
+              "ipv6": true,
+              "fixed-cidr-v6": "2001:db8:1::/64"
+            }
+            EOF
       - restore_cache:
           keys:
             - bazel-cache-{{ checksum "WORKSPACE" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,18 @@ jobs:
       - image: istio/ci:go1.9-bazel0.7
     resource_class: xlarge
     steps:
-      - checkout
+     machine: true
+     steps:
+     - checkout
+     - run:
+         name: enable ipv6
+         command: |
+           cat <<'EOF' | sudo tee /etc/docker/daemon.json
+           {
+             "ipv6": true,
+             "fixed-cidr-v6": "2001:db8:1::/64"
+           }
+           EOF
       - restore_cache:
           keys:
             - bazel-cache-{{ checksum "WORKSPACE" }}
@@ -32,9 +43,6 @@ jobs:
       - store_artifacts:
           path: /home/circleci/project/bazel-bin/src/envoy/mixer/envoy
           destination: /proxy/bin
-
-
-
 
 workflows:
   version: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

Envoy integration test fails on CircleCI since it doesn't have IPv6.

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
