### PR TITLE
Fix time interval setup.

### DIFF
--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -31,15 +31,15 @@ MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
                                    const std::string& name, Stats::Scope& scope,
                                    int update_interval_ms, GetStatsFunc func)
     : stats_{ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))},
-      get_stats_func_(func) {
+      get_stats_func_(func),
+      stats_update_interval_(update_interval_ms > 0
+                                 ? update_interval_ms
+                                 : kStatsUpdateIntervalInMs) {
   memset(&old_stats_, 0, sizeof(old_stats_));
 
-  // If stats update interval from config is 0, then set interval to 10 seconds.
-  int stats_update_interval =
-      update_interval_ms > 0 ? update_interval_ms : kStatsUpdateIntervalInMs;
   if (get_stats_func_) {
     timer_ = dispatcher.createTimer([this]() { OnTimer(); });
-    timer_->enableTimer(std::chrono::milliseconds(stats_update_interval));
+    timer_->enableTimer(std::chrono::milliseconds(stats_update_interval_));
   }
 }
 
@@ -49,7 +49,7 @@ void MixerStatsObject::OnTimer() {
   if (get_stats) {
     CheckAndUpdateStats(new_stats);
   }
-  timer_->enableTimer(std::chrono::milliseconds(kStatsUpdateIntervalInMs));
+  timer_->enableTimer(std::chrono::milliseconds(stats_update_interval_));
 }
 
 void MixerStatsObject::CheckAndUpdateStats(

--- a/src/envoy/mixer/stats.h
+++ b/src/envoy/mixer/stats.h
@@ -75,6 +75,11 @@ class MixerStatsObject {
   // These members are used for creating a timer which update Envoy stats
   // periodically.
   ::Envoy::Event::TimerPtr timer_;
+
+  // Time interval at which Envoy stats get updated. If stats update interval
+  // from config is larger than 0, then store configured interval here.
+  // Otherwise, set interval to 10 seconds.
+  const int stats_update_interval_;
 };
 
 }  // namespace Mixer


### PR DESCRIPTION
**What this PR does / why we need it**: Before this change, we always set stats update interval to 10s inside MixerStatsObject::OnTimer(). This PR uses configured stats interval if that interval is larger than zero.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
