### PR TITLE
Extract the subject field of a JWT

### DIFF
--- a/src/envoy/auth/jwt.cc
+++ b/src/envoy/auth/jwt.cc
@@ -270,6 +270,7 @@ Jwt::Jwt(const std::string &jwt) {
 
   iss_ = payload_->getString("iss", "");
   aud_ = payload_->getString("aud", "");
+  sub_ = payload_->getString("sub", "");
   exp_ = payload_->getInteger("exp", 0);
 
   // Set up signature
@@ -361,6 +362,7 @@ const std::string &Jwt::PayloadStr() { return payload_str_; }
 const std::string &Jwt::PayloadStrBase64Url() { return payload_str_base64url_; }
 const std::string &Jwt::Iss() { return iss_; }
 const std::string &Jwt::Aud() { return aud_; }
+const std::string &Jwt::Sub() { return sub_; }
 int64_t Jwt::Exp() { return exp_; }
 
 void Pubkeys::CreateFromPemCore(const std::string &pkey_pem) {

--- a/src/envoy/auth/jwt.h
+++ b/src/envoy/auth/jwt.h
@@ -259,8 +259,8 @@ class Pubkeys : public WithStatus {
   friend bool Verifier::Verify(const Jwt& jwt, const Pubkeys& pubkeys);
 };
 
-}  // Auth
-}  // Http
-}  // Envoy
+}  // namespace Auth
+}  // namespace Http
+}  // namespace Envoy
 
 #endif  // PROXY_JWT_H

--- a/src/envoy/auth/jwt.h
+++ b/src/envoy/auth/jwt.h
@@ -193,6 +193,10 @@ class Jwt : public WithStatus {
   // "aud" claim does not exist.
   const std::string& Aud();
 
+  // It returns the "sub" claim value of the given JWT, or an empty string if
+  // "sub" claim does not exist.
+  const std::string& Sub();
+
   // It returns the "exp" claim value of the given JWT, or 0 if "exp" claim does
   // not exist.
   int64_t Exp();
@@ -211,6 +215,7 @@ class Jwt : public WithStatus {
   std::string kid_;
   std::string iss_;
   std::string aud_;
+  std::string sub_;
   int64_t exp_;
 
   /*

--- a/src/envoy/auth/jwt_test.cc
+++ b/src/envoy/auth/jwt_test.cc
@@ -41,6 +41,7 @@ class DatasetPem {
       "N09hdvlCtAF87Fu1qqfwEQ93A-J7m08bZJoyIPcNmTcYGHwfMR4-lcI5cC_93C_"
       "5BGE1FHPLOHpNghLuM6-rhOtgwZc9ywupn_bBK3QzuAoDnYwpqQhgQL_CdUD_bSHcmWFkw";
 
+  const std::string kJwtSub = "test@example.com";
   const std::string kJwtHeaderEncoded = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9";
   const std::string kJwtPayloadEncoded =
       "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
@@ -363,6 +364,18 @@ class JwtTest : public testing::Test {
       EXPECT_TRUE(EqJson(payload, jwt.Payload()));
     }
   }
+
+  //Test whether the sub field in the JWT is as expected
+  void DoJwtSubEqualTest(std::string jwt_str, std::string sub_expected,
+          bool expect_equal) {
+    Jwt jwt(jwt_str);
+    std::string sub = jwt.Sub();
+    if(expect_equal) {
+      EXPECT_EQ(sub, sub_expected);
+    } else {
+      EXPECT_NE(sub, sub_expected);
+    }
+  }
 };
 
 // Test cases w/ PEM-formatted public key
@@ -457,6 +470,22 @@ TEST_F(JwtTestPem, AlgIsNotString) {
 TEST_F(JwtTestPem, InvalidAlg) {
   DoTest(ds.kJwtWithInvalidAlg, ds.kPublicKey, "pem", false,
          Status::ALG_NOT_IMPLEMENTED, nullptr);
+}
+
+TEST_F(JwtTestPem, NonEmptyJwtSubEqual) {
+  DoJwtSubEqualTest(ds.kJwt, ds.kJwtSub, true);
+}
+
+TEST_F(JwtTestPem, NonEmptyJwtSubNotEqual) {
+  DoJwtSubEqualTest(ds.kJwt, "", false);
+}
+
+TEST_F(JwtTestPem, EmptyJwtSubEqual) {
+  DoJwtSubEqualTest("", "", true);
+}
+
+TEST_F(JwtTestPem, EmptyJwtSubNotEqual) {
+  DoJwtSubEqualTest("", ds.kJwtSub, false);
 }
 
 // Test cases w/ JWKs-formatted public key

--- a/src/envoy/auth/jwt_test.cc
+++ b/src/envoy/auth/jwt_test.cc
@@ -467,7 +467,6 @@ TEST(JwtSubExtractionTest, NonEmptyJwtSubShouldEqual) {
 }
 
 TEST(JwtSubExtractionTest, EmptyJwtSubShouldEqual) {
-  DatasetPem ds;
   Jwt jwt("");
   EXPECT_EQ(jwt.Sub(), "");
 }

--- a/src/envoy/auth/jwt_test.cc
+++ b/src/envoy/auth/jwt_test.cc
@@ -466,22 +466,10 @@ TEST(JwtSubExtractionTest, NonEmptyJwtSubShouldEqual) {
   EXPECT_EQ(jwt.Sub(), ds.kJwtSub);
 }
 
-TEST(JwtSubExtractionTest, NonEmptyJwtSubShouldNotEqual) {
-  DatasetPem ds;
-  Jwt jwt(ds.kJwt);
-  EXPECT_NE(jwt.Sub(), "");
-}
-
 TEST(JwtSubExtractionTest, EmptyJwtSubShouldEqual) {
   DatasetPem ds;
   Jwt jwt("");
   EXPECT_EQ(jwt.Sub(), "");
-}
-
-TEST(JwtSubExtractionTest, EmptyJwtSubShouldNotEqual) {
-  DatasetPem ds;
-  Jwt jwt("");
-  EXPECT_NE(jwt.Sub(), ds.kJwtSub);
 }
 
 // Test cases w/ JWKs-formatted public key

--- a/src/envoy/auth/jwt_test.cc
+++ b/src/envoy/auth/jwt_test.cc
@@ -341,7 +341,7 @@ namespace {
 bool EqJson(Json::ObjectSharedPtr p1, Json::ObjectSharedPtr p2) {
   return p1->asJsonString() == p2->asJsonString();
 }
-}
+}  // namespace
 
 class JwtTest : public testing::Test {
  protected:
@@ -362,18 +362,6 @@ class JwtTest : public testing::Test {
     if (verified) {
       ASSERT_TRUE(jwt.Payload());
       EXPECT_TRUE(EqJson(payload, jwt.Payload()));
-    }
-  }
-
-  //Test whether the sub field in the JWT is as expected
-  void DoJwtSubEqualTest(std::string jwt_str, std::string sub_expected,
-          bool expect_equal) {
-    Jwt jwt(jwt_str);
-    std::string sub = jwt.Sub();
-    if(expect_equal) {
-      EXPECT_EQ(sub, sub_expected);
-    } else {
-      EXPECT_NE(sub, sub_expected);
     }
   }
 };
@@ -472,20 +460,28 @@ TEST_F(JwtTestPem, InvalidAlg) {
          Status::ALG_NOT_IMPLEMENTED, nullptr);
 }
 
-TEST_F(JwtTestPem, NonEmptyJwtSubEqual) {
-  DoJwtSubEqualTest(ds.kJwt, ds.kJwtSub, true);
+TEST(JwtSubExtractionTest, NonEmptyJwtSubShouldEqual) {
+  DatasetPem ds;
+  Jwt jwt(ds.kJwt);
+  EXPECT_EQ(jwt.Sub(), ds.kJwtSub);
 }
 
-TEST_F(JwtTestPem, NonEmptyJwtSubNotEqual) {
-  DoJwtSubEqualTest(ds.kJwt, "", false);
+TEST(JwtSubExtractionTest, NonEmptyJwtSubShouldNotEqual) {
+  DatasetPem ds;
+  Jwt jwt(ds.kJwt);
+  EXPECT_NE(jwt.Sub(), "");
 }
 
-TEST_F(JwtTestPem, EmptyJwtSubEqual) {
-  DoJwtSubEqualTest("", "", true);
+TEST(JwtSubExtractionTest, EmptyJwtSubShouldEqual) {
+  DatasetPem ds;
+  Jwt jwt("");
+  EXPECT_EQ(jwt.Sub(), "");
 }
 
-TEST_F(JwtTestPem, EmptyJwtSubNotEqual) {
-  DoJwtSubEqualTest("", ds.kJwtSub, false);
+TEST(JwtSubExtractionTest, EmptyJwtSubShouldNotEqual) {
+  DatasetPem ds;
+  Jwt jwt("");
+  EXPECT_NE(jwt.Sub(), ds.kJwtSub);
 }
 
 // Test cases w/ JWKs-formatted public key


### PR DESCRIPTION
Extract the subject field (i.e., sub) of a JWT, which is used during the authentication.
To run the tests: bazel test //src/envoy/auth:jwt_test

**What this PR does / why we need it**:
Extract the subject field (i.e., sub) of a JWT, which is used during the authentication.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #966

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
