### PR TITLE
Support TCP filter to send periodical reports.

### DIFF
--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -51,9 +51,9 @@ void CreateEnvironment(Upstream::ClusterManager& cm,
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixer_client::Timer> {
-    return std::unique_ptr<::istio::mixer_client::Timer>(
-        new EnvoyTimer(dispatcher.createTimer(timer_cb)));
-  };
+        return std::unique_ptr<::istio::mixer_client::Timer>(
+            new EnvoyTimer(dispatcher.createTimer(timer_cb)));
+      };
 
   env->uuid_generate_func = [&random]() -> std::string {
     return random.uuid();

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -48,9 +48,9 @@ void CreateEnvironment(Upstream::ClusterManager& cm,
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixer_client::Timer> {
-        return std::unique_ptr<::istio::mixer_client::Timer>(
-            new EnvoyTimer(dispatcher.createTimer(timer_cb)));
-      };
+    return std::unique_ptr<::istio::mixer_client::Timer>(
+        new EnvoyTimer(dispatcher.createTimer(timer_cb)));
+  };
 
   env->uuid_generate_func = [&random]() -> std::string {
     return random.uuid();
@@ -78,20 +78,27 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
                                  Upstream::ClusterManager& cm,
                                  Event::Dispatcher& dispatcher,
                                  Runtime::RandomGenerator& random)
-    : options_(mixer_config.tcp_config) {
-  CreateEnvironment(cm, dispatcher, random, &options_.env);
+    : dispatcher_(dispatcher) {
+  ::istio::mixer_control::tcp::Controller::Options options(
+      mixer_config.tcp_config);
 
-  controller_ = ::istio::mixer_control::tcp::Controller::Create(options_);
+  CreateEnvironment(cm, dispatcher, random, &options.env);
 
-  if (mixer_config.tcp_config.report_interval().seconds() < 0 ||
-      mixer_config.tcp_config.report_interval().nanos() < 0 ||
-      (mixer_config.tcp_config.report_interval().seconds() == 0 &&
-       mixer_config.tcp_config.report_interval().nanos() == 0)) {
-    report_interval_ms_ = kDefaultReportIntervalMs;
-  } else {
-    report_interval_ms_ =
+  controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
+
+  if (mixer_config.tcp_config.has_report_interval() &&
+      mixer_config.tcp_config.report_interval().seconds() >= 0 &&
+      mixer_config.tcp_config.report_interval().nanos() >= 0) {
+    report_interval_ms_ = std::chrono::milliseconds(
         mixer_config.tcp_config.report_interval().seconds() * 1000 +
-        mixer_config.tcp_config.report_interval().nanos() / 1000000;
+        mixer_config.tcp_config.report_interval().nanos() / 1000000);
+    // If configured time interval is less than 1 millisecond, then set report
+    // interval to default value.
+    if (report_interval_ms_ == std::chrono::milliseconds::zero()) {
+      report_interval_ms_ = std::chrono::milliseconds(kDefaultReportIntervalMs);
+    }
+  } else {
+    report_interval_ms_ = std::chrono::milliseconds(kDefaultReportIntervalMs);
   }
 }
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -48,9 +48,9 @@ void CreateEnvironment(Upstream::ClusterManager& cm,
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixer_client::Timer> {
-    return std::unique_ptr<::istio::mixer_client::Timer>(
-        new EnvoyTimer(dispatcher.createTimer(timer_cb)));
-  };
+        return std::unique_ptr<::istio::mixer_client::Timer>(
+            new EnvoyTimer(dispatcher.createTimer(timer_cb)));
+      };
 
   env->uuid_generate_func = [&random]() -> std::string {
     return random.uuid();

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -77,14 +77,11 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
 TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
                                  Upstream::ClusterManager& cm,
                                  Event::Dispatcher& dispatcher,
-                                 Runtime::RandomGenerator& random) {
-  ::istio::mixer_control::tcp::Controller::Options options(
-      mixer_config.tcp_config);
+                                 Runtime::RandomGenerator& random)
+    : options_(mixer_config.tcp_config) {
+  CreateEnvironment(cm, dispatcher, random, &options_.env);
 
-  CreateEnvironment(cm, dispatcher, random, &options.env);
-  env_ = &options.env;
-
-  controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
+  controller_ = ::istio::mixer_control::tcp::Controller::Create(options_);
 
   if (mixer_config.tcp_config.report_interval().seconds() < 0 ||
       mixer_config.tcp_config.report_interval().nanos() < 0 ||

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -21,7 +21,6 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
-#include "include/environment.h"
 #include "src/envoy/mixer/config.h"
 
 namespace Envoy {
@@ -63,20 +62,20 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
     return controller_.get();
   }
 
-  int report_interval_ms() const { return report_interval_ms_; }
-
-  const ::istio::mixer_control::tcp::Controller::Options& options() const {
-    return options_;
+  std::chrono::milliseconds report_interval_ms() const {
+    return report_interval_ms_;
   }
+
+  Event::Dispatcher& dispatcher() { return dispatcher_; }
 
  private:
   // The mixer control
   std::unique_ptr<::istio::mixer_control::tcp::Controller> controller_;
 
   // Time interval in milliseconds for sending periodical delta reports.
-  int report_interval_ms_;
+  std::chrono::milliseconds report_interval_ms_;
 
-  ::istio::mixer_control::tcp::Controller::Options options_;
+  Event::Dispatcher& dispatcher_;
 };
 
 }  // namespace Mixer

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -65,7 +65,9 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
 
   int report_interval_ms() const { return report_interval_ms_; }
 
-  const ::istio::mixer_client::Environment* environment() const { return env_; }
+  const ::istio::mixer_control::tcp::Controller::Options& options() const {
+    return options_;
+  }
 
  private:
   // The mixer control
@@ -74,7 +76,7 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
   // Time interval in milliseconds for sending periodical delta reports.
   int report_interval_ms_;
 
-  const ::istio::mixer_client::Environment* env_;
+  ::istio::mixer_control::tcp::Controller::Options options_;
 };
 
 }  // namespace Mixer

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -21,6 +21,7 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
+#include "include/environment.h"
 #include "src/envoy/mixer/config.h"
 
 namespace Envoy {
@@ -62,9 +63,18 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
     return controller_.get();
   }
 
+  int report_interval_ms() const { return report_interval_ms_; }
+
+  const ::istio::mixer_client::Environment* environment() const { return env_; }
+
  private:
   // The mixer control
   std::unique_ptr<::istio::mixer_control::tcp::Controller> controller_;
+
+  // Time interval in milliseconds for sending periodical delta reports.
+  int report_interval_ms_;
+
+  const ::istio::mixer_client::Environment* env_;
 };
 
 }  // namespace Mixer

--- a/src/envoy/mixer/tcp_filter.cc
+++ b/src/envoy/mixer/tcp_filter.cc
@@ -168,7 +168,7 @@ class TcpInstance : public Network::Filter,
       if (!calling_check_) {
         filter_callbacks_->continueReading();
       }
-      report_timer_ = mixer_control_.environment()->timer_create_func(
+      report_timer_ = mixer_control_.options().env.timer_create_func(
           [this]() { OnTimer(); });
       report_timer_->Start(mixer_control_.report_interval_ms());
     }

--- a/src/envoy/mixer/tcp_filter.cc
+++ b/src/envoy/mixer/tcp_filter.cc
@@ -44,11 +44,12 @@ class TcpConfig : public Logger::Loggable<Logger::Id::filter> {
         tls_(context.threadLocal().allocateSlot()) {
     mixer_config_.Load(config);
     Runtime::RandomGenerator& random = context.random();
-    tls_->set([this, &random](Event::Dispatcher& dispatcher)
-                  -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return ThreadLocal::ThreadLocalObjectSharedPtr(
-          new TcpMixerControl(mixer_config_, cm_, dispatcher, random));
-    });
+    tls_->set(
+        [this, &random](Event::Dispatcher& dispatcher)
+            -> ThreadLocal::ThreadLocalObjectSharedPtr {
+              return ThreadLocal::ThreadLocalObjectSharedPtr(
+                  new TcpMixerControl(mixer_config_, cm_, dispatcher, random));
+            });
   }
 
   TcpMixerControl& mixer_control() { return tls_->getTyped<TcpMixerControl>(); }


### PR DESCRIPTION
**What this PR does / why we need it**: Support TCP filter to send periodical reports for long TCP connections. The periodical reports contain delta information such as bytes received and sent during the recent period. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #539 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
