### PR TITLE
Add an option in Envoy filter to output JWT sub for authentication

### DIFF
--- a/src/envoy/auth/config.cc
+++ b/src/envoy/auth/config.cc
@@ -173,6 +173,7 @@ JwtAuthConfig::JwtAuthConfig(
   // TODO: public key expiration should be per issuer.
   pubkey_cache_expiration_sec_ = 600;
   user_info_type_ = UserInfoType::kPayloadBase64Url;
+  authn_output_jwt_sub_ = false;
 }
 
 /*
@@ -191,6 +192,8 @@ JwtAuthConfig::JwtAuthConfig(const Json::Object &config,
   } else {
     user_info_type_ = UserInfoType::kPayloadBase64Url;
   }
+  // By default, the subject field of a JWT is not outputted
+  authn_output_jwt_sub_ = config.getBoolean("authn_output_jwt_sub", false);
 
   pubkey_cache_expiration_sec_ =
       config.getInteger("pubkey_cache_expiration_sec", 600);

--- a/src/envoy/auth/config.h
+++ b/src/envoy/auth/config.h
@@ -22,7 +22,6 @@
 #include "common/http/message_impl.h"
 #include "envoy/http/async_client.h"
 #include "envoy/json/json_object.h"
-#include "envoy/json/json_object.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "server/config/network/http_connection_manager.h"
 
@@ -110,6 +109,7 @@ struct JwtAuthConfig : public Logger::Loggable<Logger::Id::http> {
     kHeaderPayloadBase64Url  // JWT with signature
   };
   UserInfoType user_info_type_;
+  bool authn_output_jwt_sub_;  // whether output the subject of a JWT
 
   // Time to expire a cached public key (sec).
   int64_t pubkey_cache_expiration_sec_;

--- a/src/envoy/auth/http_filter.cc
+++ b/src/envoy/auth/http_filter.cc
@@ -33,6 +33,12 @@ const LowerCaseString& JwtVerificationFilter::AuthorizedHeaderKey() {
   return *key;
 }
 
+const LowerCaseString& JwtVerificationFilter::AuthnJwtSubHeaderKey() {
+  static LowerCaseString* key =
+      new LowerCaseString("sec-istio-authentication-jwt-sub");
+  return *key;
+}
+
 JwtVerificationFilter::JwtVerificationFilter(
     std::shared_ptr<Auth::JwtAuthConfig> config)
     : config_(config) {}
@@ -198,6 +204,11 @@ std::string JwtVerificationFilter::Verify(HeaderMap& headers) {
               jwt.HeaderStrBase64Url() + "." + jwt.PayloadStrBase64Url();
       }
       headers.addReferenceKey(AuthorizedHeaderKey(), str_to_add);
+      if (config_->authn_output_jwt_sub_) {
+        // Add the sub attribute of the JWT to the header for the authentication
+        // purpose
+        headers.addReferenceKey(AuthnJwtSubHeaderKey(), jwt.Sub());
+      }
 
       // Remove JWT from headers.
       headers.remove(kAuthorizationHeaderKey);
@@ -230,5 +241,5 @@ void JwtVerificationFilter::CompleteVerification(HeaderMap& headers) {
   }
 }
 
-}  // Http
-}  // Envoy
+}  // namespace Http
+}  // namespace Envoy

--- a/src/envoy/auth/http_filter.h
+++ b/src/envoy/auth/http_filter.h
@@ -47,6 +47,7 @@ class JwtVerificationFilter : public StreamDecoderFilter,
       LowerCaseString("Authorization");
   const std::string kAuthorizationHeaderTokenPrefix = "Bearer ";
   static const LowerCaseString& AuthorizedHeaderKey();
+  static const LowerCaseString& AuthnJwtSubHeaderKey();
 
  private:
   StreamDecoderFilterCallbacks* decoder_callbacks_;
@@ -72,5 +73,5 @@ class JwtVerificationFilter : public StreamDecoderFilter,
   void CompleteVerification(HeaderMap& headers);
 };
 
-}  // Http
-}  // Envoy
+}  // namespace Http
+}  // namespace Envoy

--- a/src/envoy/auth/integration_test/envoy.conf.jwk
+++ b/src/envoy/auth/integration_test/envoy.conf.jwk
@@ -35,6 +35,7 @@
                 "name": "jwt-auth",
                 "config": {
                   "userinfo_type": "payload",
+                  "authn_output_jwt_sub": true,
                   "pubkey_cache_expiration_sec": 100,
                   "issuers": [
                     {

--- a/src/envoy/auth/integration_test/http_filter_integration_test.cc
+++ b/src/envoy/auth/integration_test/http_filter_integration_test.cc
@@ -232,6 +232,8 @@ TEST_P(JwtVerificationFilterIntegrationTestWithJwks, Success1) {
                            "{\"iss\":\"https://"
                            "example.com\",\"sub\":\"test@example.com\",\"aud\":"
                            "\"example_service\",\"exp\":2001001001}");
+  expected_headers.addCopy("sec-istio-authentication-jwt-sub",
+                           "test@example.com");
 
   TestVerification(createHeaders(kJwtNoKid), "", createIssuerHeaders(),
                    kPublicKey, true, expected_headers, "");
@@ -285,4 +287,4 @@ TEST_P(JwtVerificationFilterIntegrationTestWithJwks, Fail1) {
  * TODO: add tests
  */
 
-}  // Envoy
+}  // namespace Envoy

--- a/src/envoy/auth/sample/envoy.conf
+++ b/src/envoy/auth/sample/envoy.conf
@@ -34,6 +34,7 @@
                 "type": "decoder",
                 "name": "jwt-auth",
                 "config": {
+                  "authn_output_jwt_sub": true,
                   "issuers": [
                     {
                       "name": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",


### PR DESCRIPTION
Add an option in Envoy filter config to output the JWT sub attribute for the authentication purpose.
When the option "authn_output_jwt_sub" is true, the JWT sub attribute is outputted.
To test, run: "bazel test //src/envoy/auth:jwt_test" or
"bazel test //src/envoy/auth:http_filter_integration_test"

**What this PR does / why we need it**: add an option in Envoy filter config to output the JWT sub attribute for the authentication purpose.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #976

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
