### PR TITLE
make mixer cluster name configurable

### DIFF
--- a/src/envoy/mixer/config.cc
+++ b/src/envoy/mixer/config.cc
@@ -51,6 +51,12 @@ const std::string kDisableTcpCheckCalls("disable_tcp_check_calls");
 
 const std::string kV2Config("v2");
 
+// The name for the mixer server cluster.
+const std::string kDefaultMixerClusterName("mixer_server");
+// The Json object name for check_cluster and report_cluster
+const std::string kCheckCluster("check_cluster");
+const std::string kReportCluster("report_cluster");
+
 void ReadStringMap(const Json::Object& json, const std::string& name,
                    Attributes* attributes) {
   if (json.hasObject(name)) {
@@ -73,6 +79,9 @@ void ReadTransportConfig(const Json::Object& json, TransportConfig* config) {
   config->set_disable_check_cache(json.getBoolean(kDisableCheckCache, false));
   config->set_disable_quota_cache(json.getBoolean(kDisableQuotaCache, false));
   config->set_disable_report_batch(json.getBoolean(kDisableReportBatch, false));
+
+  config->set_check_cluster(json.getString(kCheckCluster, kDefaultMixerClusterName));
+  config->set_report_cluster(json.getString(kReportCluster, kDefaultMixerClusterName));
 }
 
 bool ReadV2Config(const Json::Object& json, Message* message) {

--- a/src/envoy/mixer/config.cc
+++ b/src/envoy/mixer/config.cc
@@ -123,10 +123,12 @@ void HttpMixerConfig::Load(const Json::Object& json) {
     legacy_quotas.clear();
   }
 
-  check_cluster = transport_config->check_cluster().empty() ? kDefaultMixerClusterName :
-                  transport_config->check_cluster();
-  report_cluster = transport_config->report_cluster().empty() ? kDefaultMixerClusterName :
-                   transport_config->report_cluster();
+  check_cluster = transport_config->check_cluster().empty()
+                      ? kDefaultMixerClusterName
+                      : transport_config->check_cluster();
+  report_cluster = transport_config->report_cluster().empty()
+                       ? kDefaultMixerClusterName
+                       : transport_config->report_cluster();
 }
 
 void HttpMixerConfig::CreateLegacyRouteConfig(
@@ -153,10 +155,12 @@ void TcpMixerConfig::Load(const Json::Object& json) {
 
   ReadV2Config(json, &tcp_config);
 
-  check_cluster = transport_config->check_cluster().empty() ? kDefaultMixerClusterName :
-                  transport_config->check_cluster();
-  report_cluster = transport_config->report_cluster().empty() ? kDefaultMixerClusterName :
-                   transport_config->report_cluster();
+  check_cluster = transport_config->check_cluster().empty()
+                      ? kDefaultMixerClusterName
+                      : transport_config->check_cluster();
+  report_cluster = transport_config->report_cluster().empty()
+                       ? kDefaultMixerClusterName
+                       : transport_config->report_cluster();
 }
 
 }  // namespace Mixer

--- a/src/envoy/mixer/config.cc
+++ b/src/envoy/mixer/config.cc
@@ -25,6 +25,9 @@ using ::istio::mixer_client::AttributesBuilder;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::mixer::v1::config::client::TransportConfig;
 
+#define PROTOBUF_GET_STRING_OR_DEFAULT(message, field_name, default_value)                        \
+  ((message).has_##field_name() ? (message).field_name() : (default_value))
+
 namespace Envoy {
 namespace Http {
 namespace Mixer {
@@ -53,9 +56,6 @@ const std::string kV2Config("v2");
 
 // The name for the mixer server cluster.
 const std::string kDefaultMixerClusterName("mixer_server");
-// The Json object name for check_cluster and report_cluster
-const std::string kCheckCluster("check_cluster");
-const std::string kReportCluster("report_cluster");
 
 void ReadStringMap(const Json::Object& json, const std::string& name,
                    Attributes* attributes) {
@@ -126,10 +126,8 @@ void HttpMixerConfig::Load(const Json::Object& json) {
     legacy_quotas.clear();
   }
 
-  transport_config->set_check_cluster(
-      json.getString(kCheckCluster, kDefaultMixerClusterName));
-  transport_config->set_report_cluster(
-      json.getString(kReportCluster, kDefaultMixerClusterName));
+  check_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, check_cluster, kDefaultMixerClusterName);
+  report_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, report_cluster, kDefaultMixerClusterName);
 }
 
 void HttpMixerConfig::CreateLegacyRouteConfig(
@@ -155,10 +153,8 @@ void TcpMixerConfig::Load(const Json::Object& json) {
       json.getBoolean(kDisableTcpCheckCalls, false));
 
   ReadV2Config(json, &tcp_config);
-  transport_config->set_check_cluster(
-      json.getString(kCheckCluster, kDefaultMixerClusterName));
-  transport_config->set_report_cluster(
-      json.getString(kReportCluster, kDefaultMixerClusterName));
+  check_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, check_cluster, kDefaultMixerClusterName);
+  report_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, report_cluster, kDefaultMixerClusterName);
 }
 
 }  // namespace Mixer

--- a/src/envoy/mixer/config.cc
+++ b/src/envoy/mixer/config.cc
@@ -25,9 +25,6 @@ using ::istio::mixer_client::AttributesBuilder;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::mixer::v1::config::client::TransportConfig;
 
-#define PROTOBUF_GET_STRING_OR_DEFAULT(message, field_name, default_value)                        \
-  ((message).has_##field_name() ? (message).field_name() : (default_value))
-
 namespace Envoy {
 namespace Http {
 namespace Mixer {
@@ -126,8 +123,10 @@ void HttpMixerConfig::Load(const Json::Object& json) {
     legacy_quotas.clear();
   }
 
-  check_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, check_cluster, kDefaultMixerClusterName);
-  report_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, report_cluster, kDefaultMixerClusterName);
+  check_cluster = transport_config->check_cluster().empty() ? kDefaultMixerClusterName :
+                  transport_config->check_cluster();
+  report_cluster = transport_config->report_cluster().empty() ? kDefaultMixerClusterName :
+                   transport_config->report_cluster();
 }
 
 void HttpMixerConfig::CreateLegacyRouteConfig(
@@ -153,8 +152,11 @@ void TcpMixerConfig::Load(const Json::Object& json) {
       json.getBoolean(kDisableTcpCheckCalls, false));
 
   ReadV2Config(json, &tcp_config);
-  check_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, check_cluster, kDefaultMixerClusterName);
-  report_cluster = PROTOBUF_GET_STRING_OR_DEFAULT(transport_config, report_cluster, kDefaultMixerClusterName);
+
+  check_cluster = transport_config->check_cluster().empty() ? kDefaultMixerClusterName :
+                  transport_config->check_cluster();
+  report_cluster = transport_config->report_cluster().empty() ? kDefaultMixerClusterName :
+                   transport_config->report_cluster();
 }
 
 }  // namespace Mixer

--- a/src/envoy/mixer/config.cc
+++ b/src/envoy/mixer/config.cc
@@ -68,7 +68,8 @@ void ReadStringMap(const Json::Object& json, const std::string& name,
   }
 }
 
-void ReadLegacyTransportConfig(const Json::Object& json, TransportConfig* config) {
+void ReadLegacyTransportConfig(const Json::Object& json,
+                               TransportConfig* config) {
   // Default is open, unless it specifically set to "close"
   config->set_network_fail_policy(TransportConfig::FAIL_OPEN);
   if (json.hasObject(kNetworkFailPolicy) &&
@@ -125,8 +126,10 @@ void HttpMixerConfig::Load(const Json::Object& json) {
     legacy_quotas.clear();
   }
 
-  transport_config->set_check_cluster(json.getString(kCheckCluster, kDefaultMixerClusterName));
-  transport_config->set_report_cluster(json.getString(kReportCluster, kDefaultMixerClusterName));
+  transport_config->set_check_cluster(
+      json.getString(kCheckCluster, kDefaultMixerClusterName));
+  transport_config->set_report_cluster(
+      json.getString(kReportCluster, kDefaultMixerClusterName));
 }
 
 void HttpMixerConfig::CreateLegacyRouteConfig(
@@ -145,15 +148,17 @@ void HttpMixerConfig::CreateLegacyRouteConfig(
 void TcpMixerConfig::Load(const Json::Object& json) {
   ReadStringMap(json, kMixerAttributes, tcp_config.mutable_mixer_attributes());
 
-  TransportConfig *transport_config = tcp_config.mutable_transport();  
+  TransportConfig* transport_config = tcp_config.mutable_transport();
   ReadLegacyTransportConfig(json, transport_config);
 
   tcp_config.set_disable_check_calls(
       json.getBoolean(kDisableTcpCheckCalls, false));
 
   ReadV2Config(json, &tcp_config);
-  transport_config->set_check_cluster(json.getString(kCheckCluster, kDefaultMixerClusterName));
-  transport_config->set_report_cluster(json.getString(kReportCluster, kDefaultMixerClusterName));  
+  transport_config->set_check_cluster(
+      json.getString(kCheckCluster, kDefaultMixerClusterName));
+  transport_config->set_report_cluster(
+      json.getString(kReportCluster, kDefaultMixerClusterName));
 }
 
 }  // namespace Mixer

--- a/src/envoy/mixer/config.h
+++ b/src/envoy/mixer/config.h
@@ -39,6 +39,10 @@ struct HttpMixerConfig {
   std::vector<::istio::quota::Requirement> legacy_quotas;
   // If true, v2 config is valid.
   bool has_v2_config;
+  // check cluster
+  std::string check_cluster;
+  // report cluster
+  std::string report_cluster;
 
   // Create per route legacy config.
   static void CreateLegacyRouteConfig(
@@ -54,6 +58,10 @@ struct TcpMixerConfig {
 
   // The Tcp client config.
   ::istio::mixer::v1::config::client::TcpClientConfig tcp_config;
+  // check cluster
+  std::string check_cluster;
+  // report cluster
+  std::string report_cluster;
 };
 
 }  // namespace Mixer

--- a/src/envoy/mixer/grpc_transport.cc
+++ b/src/envoy/mixer/grpc_transport.cc
@@ -109,7 +109,7 @@ typename GrpcTransport<RequestType, ResponseType>::Func
 GrpcTransport<RequestType, ResponseType>::GetFunc(Upstream::ClusterManager& cm,
                                                   const std::string& cluster_name,
                                                   const HeaderMap* headers) {
-  return [&cm, &cluster_name, headers](const RequestType& request, ResponseType* response,
+  return [&cm, cluster_name, headers](const RequestType& request, ResponseType* response,
                         istio::mixer_client::DoneFunc on_done)
              -> istio::mixer_client::CancelFunc {
                auto transport = new GrpcTransport<RequestType, ResponseType>(

--- a/src/envoy/mixer/grpc_transport.cc
+++ b/src/envoy/mixer/grpc_transport.cc
@@ -106,11 +106,12 @@ void GrpcTransport<RequestType, ResponseType>::Cancel() {
 
 template <class RequestType, class ResponseType>
 typename GrpcTransport<RequestType, ResponseType>::Func
-GrpcTransport<RequestType, ResponseType>::GetFunc(Upstream::ClusterManager& cm,
-                                                  const std::string& cluster_name,
-                                                  const HeaderMap* headers) {
-  return [&cm, cluster_name, headers](const RequestType& request, ResponseType* response,
-                        istio::mixer_client::DoneFunc on_done)
+GrpcTransport<RequestType, ResponseType>::GetFunc(
+    Upstream::ClusterManager& cm, const std::string& cluster_name,
+    const HeaderMap* headers) {
+  return [&cm, cluster_name, headers](const RequestType& request,
+                                      ResponseType* response,
+                                      istio::mixer_client::DoneFunc on_done)
              -> istio::mixer_client::CancelFunc {
                auto transport = new GrpcTransport<RequestType, ResponseType>(
                    Grpc::AsyncClientPtr(
@@ -140,9 +141,11 @@ const google::protobuf::MethodDescriptor& ReportTransport::descriptor() {
 
 // explicitly instantiate CheckTransport and ReportTransport
 template CheckTransport::Func CheckTransport::GetFunc(
-    Upstream::ClusterManager& cm, const std::string& cluster_name, const HeaderMap* headers);
+    Upstream::ClusterManager& cm, const std::string& cluster_name,
+    const HeaderMap* headers);
 template ReportTransport::Func ReportTransport::GetFunc(
-    Upstream::ClusterManager& cm, const std::string& cluster_name, const HeaderMap* headers);
+    Upstream::ClusterManager& cm, const std::string& cluster_name,
+    const HeaderMap* headers);
 
 }  // namespace Mixer
 }  // namespace Http

--- a/src/envoy/mixer/grpc_transport.cc
+++ b/src/envoy/mixer/grpc_transport.cc
@@ -35,9 +35,6 @@ const LowerCaseString kB3Sampled("x-b3-sampled");
 const LowerCaseString kB3Flags("x-b3-flags");
 const LowerCaseString kOtSpanContext("x-ot-span-context");
 
-// The name for the mixer server cluster.
-const char* kMixerServerClusterName = "mixer_server";
-
 inline void CopyHeaderEntry(const HeaderEntry* entry,
                             const LowerCaseString& key,
                             Http::HeaderMap& headers) {
@@ -110,13 +107,14 @@ void GrpcTransport<RequestType, ResponseType>::Cancel() {
 template <class RequestType, class ResponseType>
 typename GrpcTransport<RequestType, ResponseType>::Func
 GrpcTransport<RequestType, ResponseType>::GetFunc(Upstream::ClusterManager& cm,
+                                                  const std::string& cluster_name,
                                                   const HeaderMap* headers) {
-  return [&cm, headers](const RequestType& request, ResponseType* response,
+  return [&cm, &cluster_name, headers](const RequestType& request, ResponseType* response,
                         istio::mixer_client::DoneFunc on_done)
              -> istio::mixer_client::CancelFunc {
                auto transport = new GrpcTransport<RequestType, ResponseType>(
                    Grpc::AsyncClientPtr(
-                       new Grpc::AsyncClientImpl(cm, kMixerServerClusterName)),
+                       new Grpc::AsyncClientImpl(cm, cluster_name.c_str())),
                    request, headers, response, on_done);
                return [transport]() { transport->Cancel(); };
              };
@@ -142,9 +140,9 @@ const google::protobuf::MethodDescriptor& ReportTransport::descriptor() {
 
 // explicitly instantiate CheckTransport and ReportTransport
 template CheckTransport::Func CheckTransport::GetFunc(
-    Upstream::ClusterManager& cm, const HeaderMap* headers);
+    Upstream::ClusterManager& cm, const std::string& cluster_name, const HeaderMap* headers);
 template ReportTransport::Func ReportTransport::GetFunc(
-    Upstream::ClusterManager& cm, const HeaderMap* headers);
+    Upstream::ClusterManager& cm, const std::string& cluster_name, const HeaderMap* headers);
 
 }  // namespace Mixer
 }  // namespace Http

--- a/src/envoy/mixer/grpc_transport.h
+++ b/src/envoy/mixer/grpc_transport.h
@@ -39,6 +39,7 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
       istio::mixer_client::DoneFunc on_done)>;
 
   static Func GetFunc(Upstream::ClusterManager& cm,
+                      const std::string& cluster_name,
                       const HeaderMap* headers = nullptr);
 
   GrpcTransport(Grpc::AsyncClientPtr async_client, const RequestType& request,

--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -438,7 +438,7 @@ class Instance : public Http::StreamDecoderFilter,
     HeaderUpdate header_update(&headers);
     cancel_check_ = handler_->Check(
         &check_data, &header_update,
-        CheckTransport::GetFunc(mixer_control_.cm(), &headers),
+        CheckTransport::GetFunc(mixer_control_.cm(), mixer_control_.check_cluster(), &headers),
         [this](const Status& status) { completeCheck(status); });
     initiating_call_ = false;
 

--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -438,7 +438,8 @@ class Instance : public Http::StreamDecoderFilter,
     HeaderUpdate header_update(&headers);
     cancel_check_ = handler_->Check(
         &check_data, &header_update,
-        CheckTransport::GetFunc(mixer_control_.cm(), mixer_control_.check_cluster(), &headers),
+        CheckTransport::GetFunc(mixer_control_.cm(),
+                                mixer_control_.check_cluster(), &headers),
         [this](const Status& status) { completeCheck(status); });
     initiating_call_ = false;
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -74,8 +74,7 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
 
   CreateEnvironment(cm, dispatcher, random,
                     mixer_config.transport().check_cluster(),
-                    mixer_config.transport().report_cluster(),
-                    &options.env);
+                    mixer_config.transport().report_cluster(), &options.env);
 
   controller_ = ::istio::mixer_control::http::Controller::Create(options);
 
@@ -92,8 +91,7 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
 
   CreateEnvironment(cm, dispatcher, random,
                     mixer_config.transport().check_cluster(),
-                    mixer_config.transport().report_cluster(),
-                    &options.env);
+                    mixer_config.transport().report_cluster(), &options.env);
 
   controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -72,14 +72,14 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
   ::istio::mixer_control::http::Controller::Options options(
       mixer_config.http_config, mixer_config.legacy_quotas);
 
-  check_cluster_  = mixer_config.check_cluster;
+  check_cluster_ = mixer_config.check_cluster;
   report_cluster_ = mixer_config.report_cluster;
 
-  CreateEnvironment(cm, dispatcher, random,
-                    check_cluster_, report_cluster_, &options.env);
+  CreateEnvironment(cm, dispatcher, random, check_cluster_, report_cluster_,
+                    &options.env);
 
   controller_ = ::istio::mixer_control::http::Controller::Create(options);
-  has_v2_config_  = mixer_config.has_v2_config;
+  has_v2_config_ = mixer_config.has_v2_config;
 }
 
 TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
@@ -90,11 +90,11 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
   ::istio::mixer_control::tcp::Controller::Options options(
       mixer_config.tcp_config);
 
-  check_cluster_  = mixer_config.check_cluster;
+  check_cluster_ = mixer_config.check_cluster;
   report_cluster_ = mixer_config.report_cluster;
 
-  CreateEnvironment(cm, dispatcher, random,
-                    check_cluster_, report_cluster_, &options.env);
+  CreateEnvironment(cm, dispatcher, random, check_cluster_, report_cluster_,
+                    &options.env);
 
   controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -72,14 +72,14 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
   ::istio::mixer_control::http::Controller::Options options(
       mixer_config.http_config, mixer_config.legacy_quotas);
 
+  check_cluster_  = mixer_config.check_cluster;
+  report_cluster_ = mixer_config.report_cluster;
+
   CreateEnvironment(cm, dispatcher, random,
-                    mixer_config.http_config.transport().check_cluster(),
-                    mixer_config.http_config.transport().report_cluster(),
-                    &options.env);
+                    check_cluster_, report_cluster_, &options.env);
 
   controller_ = ::istio::mixer_control::http::Controller::Create(options);
-
-  has_v2_config_ = mixer_config.has_v2_config;
+  has_v2_config_  = mixer_config.has_v2_config;
 }
 
 TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
@@ -90,10 +90,11 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
   ::istio::mixer_control::tcp::Controller::Options options(
       mixer_config.tcp_config);
 
+  check_cluster_  = mixer_config.check_cluster;
+  report_cluster_ = mixer_config.report_cluster;
+
   CreateEnvironment(cm, dispatcher, random,
-                    mixer_config.tcp_config.transport().check_cluster(),
-                    mixer_config.tcp_config.transport().report_cluster(),
-                    &options.env);
+                    check_cluster_, report_cluster_, &options.env);
 
   controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -73,8 +73,9 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
       mixer_config.http_config, mixer_config.legacy_quotas);
 
   CreateEnvironment(cm, dispatcher, random,
-                    mixer_config.transport().check_cluster(),
-                    mixer_config.transport().report_cluster(), &options.env);
+                    mixer_config.http_config.transport().check_cluster(),
+                    mixer_config.http_config.transport().report_cluster(),
+                    &options.env);
 
   controller_ = ::istio::mixer_control::http::Controller::Create(options);
 
@@ -90,8 +91,9 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
       mixer_config.tcp_config);
 
   CreateEnvironment(cm, dispatcher, random,
-                    mixer_config.transport().check_cluster(),
-                    mixer_config.transport().report_cluster(), &options.env);
+                    mixer_config.tcp_config.transport().check_cluster(),
+                    mixer_config.tcp_config.transport().report_cluster(),
+                    &options.env);
 
   controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -45,9 +45,11 @@ class EnvoyTimer : public ::istio::mixer_client::Timer {
 void CreateEnvironment(Upstream::ClusterManager& cm,
                        Event::Dispatcher& dispatcher,
                        Runtime::RandomGenerator& random,
+                       const std::string& check_cluster,
+                       const std::string& report_cluster,
                        ::istio::mixer_client::Environment* env) {
-  env->check_transport = CheckTransport::GetFunc(cm, nullptr);
-  env->report_transport = ReportTransport::GetFunc(cm);
+  env->check_transport = CheckTransport::GetFunc(cm, check_cluster, nullptr);
+  env->report_transport = ReportTransport::GetFunc(cm, report_cluster);
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixer_client::Timer> {
@@ -70,7 +72,10 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
   ::istio::mixer_control::http::Controller::Options options(
       mixer_config.http_config, mixer_config.legacy_quotas);
 
-  CreateEnvironment(cm, dispatcher, random, &options.env);
+  CreateEnvironment(cm, dispatcher, random,
+                    mixer_config.transport().check_cluster(),
+                    mixer_config.transport().report_cluster(),
+                    &options.env);
 
   controller_ = ::istio::mixer_control::http::Controller::Create(options);
 
@@ -85,7 +90,10 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
   ::istio::mixer_control::tcp::Controller::Options options(
       mixer_config.tcp_config);
 
-  CreateEnvironment(cm, dispatcher, random, &options.env);
+  CreateEnvironment(cm, dispatcher, random,
+                    mixer_config.transport().check_cluster(),
+                    mixer_config.transport().report_cluster(),
+                    &options.env);
 
   controller_ = ::istio::mixer_control::tcp::Controller::Create(options);
 

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -36,11 +36,11 @@ class HttpMixerControl final : public ThreadLocal::ThreadLocalObject {
 
   Upstream::ClusterManager& cm() { return cm_; }
 
-  std::string& check_cluster() const {
+  const std::string& check_cluster() const {
     return check_cluster_;
   }
 
-  std::string& report_cluster() const {
+  const std::string& report_cluster() const {
     return report_cluster_;
   }
 
@@ -78,11 +78,11 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
     return report_interval_ms_;
   }
 
-  std::string& check_cluster() const {
+  const std::string& check_cluster() const {
     return check_cluster_;
   }
 
-  std::string& report_cluster() const {
+  const std::string& report_cluster() const {
     return report_cluster_;
   }
 

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -36,13 +36,9 @@ class HttpMixerControl final : public ThreadLocal::ThreadLocalObject {
 
   Upstream::ClusterManager& cm() { return cm_; }
 
-  const std::string& check_cluster() const {
-    return check_cluster_;
-  }
+  const std::string& check_cluster() const { return check_cluster_; }
 
-  const std::string& report_cluster() const {
-    return report_cluster_;
-  }
+  const std::string& report_cluster() const { return report_cluster_; }
 
   ::istio::mixer_control::http::Controller* controller() {
     return controller_.get();
@@ -78,13 +74,9 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
     return report_interval_ms_;
   }
 
-  const std::string& check_cluster() const {
-    return check_cluster_;
-  }
+  const std::string& check_cluster() const { return check_cluster_; }
 
-  const std::string& report_cluster() const {
-    return report_cluster_;
-  }
+  const std::string& report_cluster() const { return report_cluster_; }
 
   Event::Dispatcher& dispatcher() { return dispatcher_; }
 

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -36,6 +36,14 @@ class HttpMixerControl final : public ThreadLocal::ThreadLocalObject {
 
   Upstream::ClusterManager& cm() { return cm_; }
 
+  std::string& check_cluster() const {
+    return check_cluster_;
+  }
+
+  std::string& report_cluster() const {
+    return report_cluster_;
+  }
+
   ::istio::mixer_control::http::Controller* controller() {
     return controller_.get();
   }
@@ -49,6 +57,10 @@ class HttpMixerControl final : public ThreadLocal::ThreadLocalObject {
   std::unique_ptr<::istio::mixer_control::http::Controller> controller_;
   // has v2 config;
   bool has_v2_config_;
+  // check cluster
+  std::string check_cluster_;
+  // report cluster
+  std::string report_cluster_;
 };
 
 class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
@@ -66,6 +78,14 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
     return report_interval_ms_;
   }
 
+  std::string& check_cluster() const {
+    return check_cluster_;
+  }
+
+  std::string& report_cluster() const {
+    return report_cluster_;
+  }
+
   Event::Dispatcher& dispatcher() { return dispatcher_; }
 
  private:
@@ -76,6 +96,11 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
   std::chrono::milliseconds report_interval_ms_;
 
   Event::Dispatcher& dispatcher_;
+
+  // check cluster
+  std::string check_cluster_;
+  // report cluster
+  std::string report_cluster_;
 };
 
 }  // namespace Mixer


### PR DESCRIPTION
Please see https://github.com/istio/api/pull/358 for context.
Essentially remove hardcoded "mixer_server" and allow users to override the name, in addition to allowing separate clusters for check vs reports so that it makes it easier to load balance/manage the system.
