### PR TITLE
New per route config

### DIFF
--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -22,6 +22,7 @@
 #include "envoy/registry/registry.h"
 #include "envoy/ssl/connection.h"
 #include "envoy/thread_local/thread_local.h"
+#include "google/protobuf/util/json_util.h"
 #include "server/config/network/http_connection_manager.h"
 #include "src/envoy/auth/jwt.h"
 #include "src/envoy/auth/jwt_authenticator.h"
@@ -62,11 +63,9 @@ const std::string kPrefixMixerAttributes("mixer_attributes.");
 
 // Per route opaque data for "destination.service".
 const std::string kPerRouteDestinationService("destination.service");
-// Per route opaque data name "mixer" is
-// base64(proto.SerailizeToString(ServiceConfig))
+// Per route opaque data name "mixer" is base64(JSON(ServiceConfig))
 const std::string kPerRouteMixer("mixer");
-// Per route opaque data name "mixer_sha" is
-// SHA(proto.SerailizeToString(ServiceConfig))
+// Per route opaque data name "mixer_sha" is SHA(JSON(ServiceConfig))
 const std::string kPerRouteMixerSha("mixer_sha");
 
 // The HTTP header to forward Istio attributes.
@@ -82,6 +81,17 @@ const std::set<std::string> RequestHeaderExclusives = {
 
 // Set of headers excluded from response.headers attribute.
 const std::set<std::string> ResponseHeaderExclusives = {};
+
+// Read a string value from a string map.
+bool ReadStringMap(const std::multimap<std::string, std::string>& string_map,
+                   const std::string& name, std::string* value) {
+  auto it = string_map.find(name);
+  if (it != string_map.end()) {
+    *value = it->second;
+    return true;
+  }
+  return false;
+}
 
 }  // namespace
 
@@ -405,20 +415,56 @@ class Instance : public Http::StreamDecoderFilter,
     return attrs;
   }
 
-  // Read a string attribute from per-route opaque data.
-  bool GetRouteStringAttribute(const std::string& name, std::string* value) {
+  void ReadPerRouteConfig(
+      ::istio::mixer_control::http::Controller::PerRouteConfig* config) {
     auto route = decoder_callbacks_->route();
-    if (route != nullptr) {
-      auto entry = route->routeEntry();
-      if (entry != nullptr) {
-        auto it = entry->opaqueConfig().find(name);
-        if (it != entry->opaqueConfig().end()) {
-          *value = it->second;
-          return true;
-        }
-      }
+    if (route == nullptr) {
+      return;
     }
-    return false;
+    auto entry = route->routeEntry();
+    if (entry == nullptr) {
+      return;
+    }
+
+    const auto& string_map = entry->opaqueConfig();
+    ReadStringMap(string_map, kPerRouteDestinationService,
+                  &config->destination_service);
+
+    std::string config_id;
+    if (!ReadStringMap(string_map, kPerRouteMixerSha, &config_id)) {
+      return;
+    }
+
+    if (mixer_control_.controller()->LookupServiceConfig(config_id)) {
+      return;
+    }
+
+    std::string config_base64;
+    if (!ReadStringMap(string_map, kPerRouteMixer, &config_base64)) {
+      ENVOY_LOG(warn, "Service {} missing [mixer] per-route attribute",
+                config->destination_service);
+      return;
+    }
+    std::string config_json = Base64::decode(config_base64);
+    if (config_json.empty()) {
+      ENVOY_LOG(warn, "Service {} invalid base64 config data",
+                config->destination_service);
+      return;
+    }
+    ServiceConfig config_pb;
+    auto status =
+        ::google::protobuf::util::JsonStringToMessage(config_json, &config_pb);
+    if (!status.ok()) {
+      ENVOY_LOG(
+          warn,
+          "Service {} failed to convert JSON config to protobuf, error: {}",
+          config->destination_service, status.ToString());
+      return;
+    }
+    mixer_control_.controller()->AddServiceConfig(config_id, config_pb);
+    config->service_config_id = config_id;
+    ENVOY_LOG(info, "Service {}, config_id {}, config: {}",
+              config->destination_service, config_id, config_pb.DebugString());
   }
 
  public:
@@ -435,28 +481,7 @@ class Instance : public Http::StreamDecoderFilter,
     ::istio::mixer_control::http::Controller::PerRouteConfig config;
     ServiceConfig legacy_config;
     if (mixer_control_.has_v2_config()) {
-      GetRouteStringAttribute(kPerRouteDestinationService,
-                              &config.destination_service);
-      std::string config_id;
-      GetRouteStringAttribute(kPerRouteMixerSha, &config_id);
-      if (!config_id.empty() &&
-          !mixer_control_.controller()->LookupServiceConfig(config_id)) {
-        std::string config_base64;
-        GetRouteStringAttribute(kPerRouteMixer, &config_base64);
-        if (!config_base64.empty()) {
-          std::string config_data = Base64::decode(config_base64);
-          if (!config_data.empty()) {
-            ServiceConfig config_pb;
-            if (config_pb.ParseFromString(config_data)) {
-              mixer_control_.controller()->AddServiceConfig(config_id,
-                                                            config_pb);
-              config.service_config_id = config_id;
-              ENVOY_LOG(info, "Per route service {} config: {}",
-                        config.destination_service, config_pb.DebugString());
-            }
-          }
-        }
-      }
+      ReadPerRouteConfig(&config);
     } else {
       bool check_disabled, report_disabled;
       check_mixer_route_flags(&check_disabled, &report_disabled);


### PR DESCRIPTION
**What this PR does / why we need it**:

Support reading service config from per-route opaque data

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
