### PR TITLE
Fixed a bug in reading per-route config.

### DIFF
--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -430,12 +430,14 @@ class Instance : public Http::StreamDecoderFilter,
     ReadStringMap(string_map, kPerRouteDestinationService,
                   &config->destination_service);
 
-    std::string config_id;
-    if (!ReadStringMap(string_map, kPerRouteMixerSha, &config_id)) {
+    if (!ReadStringMap(string_map, kPerRouteMixerSha,
+                       &config->service_config_id) ||
+        config->service_config_id.empty()) {
       return;
     }
 
-    if (mixer_control_.controller()->LookupServiceConfig(config_id)) {
+    if (mixer_control_.controller()->LookupServiceConfig(
+            config->service_config_id)) {
       return;
     }
 
@@ -461,10 +463,11 @@ class Instance : public Http::StreamDecoderFilter,
           config->destination_service, status.ToString());
       return;
     }
-    mixer_control_.controller()->AddServiceConfig(config_id, config_pb);
-    config->service_config_id = config_id;
+    mixer_control_.controller()->AddServiceConfig(config->service_config_id,
+                                                  config_pb);
     ENVOY_LOG(info, "Service {}, config_id {}, config: {}",
-              config->destination_service, config_id, config_pb.DebugString());
+              config->destination_service, config->service_config_id,
+              config_pb.DebugString());
   }
 
  public:


### PR DESCRIPTION
**What this PR does / why we need it**:

config_id was not set if it is in the cache.  the per-route config will not be used

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
