### PR TITLE
refactor: Lazy initialize mixer filter by route config

### DIFF
--- a/src/envoy/common/BUILD
+++ b/src/envoy/common/BUILD
@@ -21,26 +21,13 @@ load(
 )
 
 envoy_cc_library(
-    name = "filter_lib",
+    name = "per_route_filter_lib",
     srcs = [
-        "config.cc",
-        "config.h",
-        "grpc_transport.cc",
-        "grpc_transport.h",
-        "http_filter.cc",
-        "mixer_control.cc",
-        "mixer_control.h",
-        "tcp_filter.cc",
-        "utils.cc",
-        "utils.h",
+        "per_route_http_filter.h",
     ],
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//external:mixer_http_control_lib",
-        "//external:mixer_tcp_control_lib",
-        "//src/envoy/auth:http_filter_lib",
-        "//src/envoy/common:per_route_filter_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/src/envoy/common/per_route_http_filter.h
+++ b/src/envoy/common/per_route_http_filter.h
@@ -1,0 +1,170 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PROXY_PER_ROUTE_FILTER_H
+#define PROXY_PER_ROUTE_FILTER_H
+
+#include "envoy/http/filter.h"
+#include "envoy/router/router.h"
+
+#include <functional>
+#include <memory>
+
+namespace Envoy {
+namespace Http {
+
+template <typename InnerFilter>
+class PerRouteFilter : public Http::StreamFilter, public AccessLog::Instance {
+ public:
+  typedef std::unique_ptr<InnerFilter> InnerFilterPtr;
+  typedef std::function<InnerFilterPtr(const Envoy::Router::RouteEntry *)>
+      Constructor;
+
+  PerRouteFilter(Constructor constructor)
+      : constructor_(constructor), inner_filter_(nullptr) {}
+
+  void log(const Http::HeaderMap *request_headers,
+           const Http::HeaderMap *response_headers,
+           const RequestInfo::RequestInfo &request_info) override {
+    if (constructor_) {
+      Constructor constructor;
+      constructor.swap(constructor_);
+      inner_filter_ = constructor(request_info.routeEntry());
+    }
+    auto filter = dynamic_cast<AccessLog::Instance *>(inner_filter_.get());
+    if (filter) {
+      filter->log(request_headers, response_headers, request_info);
+    }
+  }
+
+  void onDestroy() override {
+    auto filter = dynamic_cast<Http::StreamFilterBase *>(inner_filter_.get());
+    if (filter) {
+      filter->onDestroy();
+    }
+  }
+
+  FilterHeadersStatus decodeHeaders(HeaderMap &headers,
+                                    bool end_stream) override {
+    if (decoder_callbacks_ && constructor_) {
+      Constructor constructor;
+      constructor.swap(constructor_);
+      inner_filter_ = constructor(entry(decoder_callbacks_->route()));
+    }
+    auto filter =
+        dynamic_cast<Http::StreamDecoderFilter *>(inner_filter_.get());
+    if (filter) {
+      if (decoder_callbacks_) {
+        filter->setDecoderFilterCallbacks(*decoder_callbacks_);
+        decoder_callbacks_ = nullptr;
+      }
+      return filter->decodeHeaders(headers, end_stream);
+    }
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterDataStatus decodeData(Buffer::Instance &data,
+                              bool end_stream) override {
+    auto filter =
+        dynamic_cast<Http::StreamDecoderFilter *>(inner_filter_.get());
+    if (filter) {
+      return filter->decodeData(data, end_stream);
+    }
+    return FilterDataStatus::Continue;
+  }
+
+  FilterTrailersStatus decodeTrailers(HeaderMap &trailers) override {
+    auto filter =
+        dynamic_cast<Http::StreamDecoderFilter *>(inner_filter_.get());
+    if (filter) {
+      return filter->decodeTrailers(trailers);
+    }
+    return FilterTrailersStatus::Continue;
+  }
+
+  void setDecoderFilterCallbacks(
+      StreamDecoderFilterCallbacks &callbacks) override {
+    decoder_callbacks_ = &callbacks;
+  }
+
+  FilterHeadersStatus encodeHeaders(HeaderMap &headers,
+                                    bool end_stream) override {
+    if (encoder_callbacks_ && constructor_) {
+      Constructor constructor;
+      constructor.swap(constructor_);
+      inner_filter_ = constructor(entry(encoder_callbacks_->route()));
+    }
+    auto filter =
+        dynamic_cast<Http::StreamEncoderFilter *>(inner_filter_.get());
+    if (filter) {
+      if (encoder_callbacks_) {
+        filter->setEncoderFilterCallbacks(*encoder_callbacks_);
+        encoder_callbacks_ = nullptr;
+      }
+      return filter->encodeHeaders(headers, end_stream);
+    }
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterHeadersStatus encode100ContinueHeaders(HeaderMap &headers) override {
+    auto filter =
+        dynamic_cast<Http::StreamEncoderFilter *>(inner_filter_.get());
+    if (filter) {
+      return filter->encode100ContinueHeaders(headers);
+    }
+    return FilterHeadersStatus::Continue;
+  }
+
+  FilterDataStatus encodeData(Buffer::Instance &data,
+                              bool end_stream) override {
+    auto filter =
+        dynamic_cast<Http::StreamEncoderFilter *>(inner_filter_.get());
+    if (filter) {
+      return filter->encodeData(data, end_stream);
+    }
+    return FilterDataStatus::Continue;
+  }
+
+  FilterTrailersStatus encodeTrailers(HeaderMap &trailers) override {
+    auto filter =
+        dynamic_cast<Http::StreamEncoderFilter *>(inner_filter_.get());
+    if (filter) {
+      return filter->encodeTrailers(trailers);
+    }
+    return FilterTrailersStatus::Continue;
+  }
+
+  void setEncoderFilterCallbacks(
+      StreamEncoderFilterCallbacks &callbacks) override {
+    encoder_callbacks_ = &callbacks;
+  }
+
+ private:
+  Constructor constructor_;
+  InnerFilterPtr inner_filter_;
+  StreamDecoderFilterCallbacks *decoder_callbacks_{nullptr};
+  StreamEncoderFilterCallbacks *encoder_callbacks_{nullptr};
+
+  const Router::RouteEntry *entry(const Router::RouteConstSharedPtr &route) {
+    if (route) {
+      return route->routeEntry();
+    }
+    return nullptr;
+  }
+};
+}
+}
+
+#endif  // PROXY_PER_ROUTE_FILTER_H

--- a/src/envoy/mixer/http_filter.cc
+++ b/src/envoy/mixer/http_filter.cc
@@ -26,6 +26,7 @@
 #include "server/config/network/http_connection_manager.h"
 #include "src/envoy/auth/jwt.h"
 #include "src/envoy/auth/jwt_authenticator.h"
+#include "src/envoy/common/per_route_http_filter.h"
 #include "src/envoy/mixer/config.h"
 #include "src/envoy/mixer/grpc_transport.h"
 #include "src/envoy/mixer/mixer_control.h"
@@ -349,79 +350,12 @@ class ReportData : public HttpReportData {
   }
 };
 
-class Instance : public Http::StreamDecoderFilter,
-                 public AccessLog::Instance,
-                 public Logger::Loggable<Logger::Id::http> {
- private:
-  HttpMixerControl& mixer_control_;
-  std::unique_ptr<::istio::mixer_control::http::RequestHandler> handler_;
-  istio::mixer_client::CancelFunc cancel_check_;
-
-  enum State { NotStarted, Calling, Complete, Responded };
-  State state_;
-
-  StreamDecoderFilterCallbacks* decoder_callbacks_;
-
-  bool initiating_call_;
-
-  // check mixer on/off flags in route opaque data
-  void check_mixer_route_flags(bool* check_disabled, bool* report_disabled) {
-    // Both check and report are disabled by default.
-    *check_disabled = true;
-    *report_disabled = true;
-    auto route = decoder_callbacks_->route();
-    if (route != nullptr) {
-      auto entry = route->routeEntry();
-      if (entry != nullptr) {
-        auto control_key = entry->opaqueConfig().find(kJsonNameMixerControl);
-        if (control_key != entry->opaqueConfig().end() &&
-            control_key->second == "on") {
-          *check_disabled = false;
-          *report_disabled = false;
-        }
-        auto check_key = entry->opaqueConfig().find(kJsonNameMixerCheck);
-        if (check_key != entry->opaqueConfig().end() &&
-            check_key->second == "on") {
-          *check_disabled = false;
-        }
-        auto report_key = entry->opaqueConfig().find(kJsonNameMixerReport);
-        if (report_key != entry->opaqueConfig().end() &&
-            report_key->second == "on") {
-          *report_disabled = false;
-        }
-      }
-    }
-  }
-
-  // Extract a prefixed string map from route opaque config.
-  // Route opaque config only supports flat name value pair, have to use
-  // prefix to create a sub string map. such as:
-  //    prefix.key1 = value1
-  std::map<std::string, std::string> GetRouteStringMap(
-      const std::string& prefix) {
-    std::map<std::string, std::string> attrs;
-    auto route = decoder_callbacks_->route();
-    if (route != nullptr) {
-      auto entry = route->routeEntry();
-      if (entry != nullptr) {
-        for (const auto& it : entry->opaqueConfig()) {
-          if (it.first.substr(0, prefix.size()) == prefix) {
-            attrs[it.first.substr(prefix.size(), std::string::npos)] =
-                it.second;
-          }
-        }
-      }
-    }
-    return attrs;
-  }
-
-  void ReadPerRouteConfig(
+class RouteUtil : public Logger::Loggable<Logger::Id::config> {
+ public:
+  static void ReadPerRouteConfig(
+      const Router::RouteEntry* entry,
+      ::istio::mixer_control::http::Controller& controller,
       ::istio::mixer_control::http::Controller::PerRouteConfig* config) {
-    auto route = decoder_callbacks_->route();
-    if (route == nullptr) {
-      return;
-    }
-    auto entry = route->routeEntry();
     if (entry == nullptr) {
       return;
     }
@@ -436,8 +370,7 @@ class Instance : public Http::StreamDecoderFilter,
       return;
     }
 
-    if (mixer_control_.controller()->LookupServiceConfig(
-            config->service_config_id)) {
+    if (controller.LookupServiceConfig(config->service_config_id)) {
       return;
     }
 
@@ -463,42 +396,88 @@ class Instance : public Http::StreamDecoderFilter,
           config->destination_service, status.ToString());
       return;
     }
-    mixer_control_.controller()->AddServiceConfig(config->service_config_id,
-                                                  config_pb);
+    controller.AddServiceConfig(config->service_config_id, config_pb);
     ENVOY_LOG(info, "Service {}, config_id {}, config: {}",
               config->destination_service, config->service_config_id,
               config_pb.DebugString());
   }
 
+  // check mixer on/off flags in route opaque data
+  static void MixerRouteFlags(const Router::RouteEntry* entry,
+                              bool* check_disabled, bool* report_disabled) {
+    // Both check and report are disabled by default.
+    *check_disabled = true;
+    *report_disabled = true;
+    if (entry != nullptr) {
+      auto control_key = entry->opaqueConfig().find(kJsonNameMixerControl);
+      if (control_key != entry->opaqueConfig().end() &&
+          control_key->second == "on") {
+        *check_disabled = false;
+        *report_disabled = false;
+      }
+      auto check_key = entry->opaqueConfig().find(kJsonNameMixerCheck);
+      if (check_key != entry->opaqueConfig().end() &&
+          check_key->second == "on") {
+        *check_disabled = false;
+      }
+      auto report_key = entry->opaqueConfig().find(kJsonNameMixerReport);
+      if (report_key != entry->opaqueConfig().end() &&
+          report_key->second == "on") {
+        *report_disabled = false;
+      }
+    }
+  }
+
+  // Extract a prefixed string map from route opaque config.
+  // Route opaque config only supports flat name value pair, have to use
+  // prefix to create a sub string map. such as:
+  //    prefix.key1 = value1
+  static std::map<std::string, std::string> GetRouteStringMap(
+      const Router::RouteEntry* entry, const std::string& prefix) {
+    std::map<std::string, std::string> attrs;
+    if (entry != nullptr) {
+      for (const auto& it : entry->opaqueConfig()) {
+        if (it.first.substr(0, prefix.size()) == prefix) {
+          attrs[it.first.substr(prefix.size(), std::string::npos)] = it.second;
+        }
+      }
+    }
+    return attrs;
+  }
+};
+
+class Instance : public Http::StreamDecoderFilter,
+                 public AccessLog::Instance,
+                 public Logger::Loggable<Logger::Id::http> {
+ private:
+  HttpMixerControl& mixer_control_;
+  std::unique_ptr<::istio::mixer_control::http::RequestHandler> handler_;
+  istio::mixer_client::CancelFunc cancel_check_;
+
+  enum State { NotStarted, Calling, Complete, Responded };
+  State state_{NotStarted};
+
+  StreamDecoderFilterCallbacks* decoder_callbacks_;
+
+  bool initiating_call_{false};
+  bool check_data_extracted_{false};
+
  public:
-  Instance(ConfigPtr config)
-      : mixer_control_(config->mixer_control()),
-        state_(NotStarted),
-        initiating_call_(false) {
-    ENVOY_LOG(debug, "Called Mixer::Instance : {}", __func__);
+  Instance(
+      HttpMixerControl& mixer_control,
+      std::unique_ptr<::istio::mixer_control::http::RequestHandler> handler)
+      : mixer_control_(mixer_control), handler_(std::move(handler)) {
+    ENVOY_LOG(debug, "Called Mixer::Instance per route constructor: {}",
+              __func__);
   }
 
   FilterHeadersStatus decodeHeaders(HeaderMap& headers, bool) override {
     ENVOY_LOG(debug, "Called Mixer::Instance : {}", __func__);
 
-    ::istio::mixer_control::http::Controller::PerRouteConfig config;
-    ServiceConfig legacy_config;
-    if (mixer_control_.has_v2_config()) {
-      ReadPerRouteConfig(&config);
-    } else {
-      bool check_disabled, report_disabled;
-      check_mixer_route_flags(&check_disabled, &report_disabled);
-
-      HttpMixerConfig::CreateLegacyRouteConfig(
-          check_disabled, report_disabled,
-          GetRouteStringMap(kPrefixMixerAttributes), &legacy_config);
-      config.legacy_config = &legacy_config;
-    }
-    handler_ = mixer_control_.controller()->CreateRequestHandler(config);
-
     state_ = Calling;
     initiating_call_ = true;
     CheckData check_data(headers, decoder_callbacks_->connection());
+    check_data_extracted_ = true;
     HeaderUpdate header_update(&headers);
     cancel_check_ = handler_->Check(
         &check_data, &header_update, mixer_control_.GetCheckTransport(&headers),
@@ -575,7 +554,7 @@ class Instance : public Http::StreamDecoderFilter,
                    const HeaderMap* response_headers,
                    const RequestInfo::RequestInfo& request_info) override {
     ENVOY_LOG(debug, "Called Mixer::Instance : {}", __func__);
-    if (!handler_) {
+    if (!check_data_extracted_) {
       if (request_headers == nullptr) {
         return;
       }
@@ -585,9 +564,6 @@ class Instance : public Http::StreamDecoderFilter,
       // But at this stage, not sure if callback_->connection is safe to call.
       // Similarly, it is better to get per-route attributes, but not sure if
       // it is safe to call callback_->route().
-      ::istio::mixer_control::http::Controller::PerRouteConfig config;
-      handler_ = mixer_control_.controller()->CreateRequestHandler(config);
-
       CheckData check_data(*request_headers, nullptr);
       handler_->ExtractRequestAttributes(&check_data);
     }
@@ -626,8 +602,36 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
       if (auth_filter_cb) {
         auth_filter_cb(callbacks);
       }
-      std::shared_ptr<Http::Mixer::Instance> instance =
-          std::make_shared<Http::Mixer::Instance>(mixer_config);
+
+      std::shared_ptr<Http::PerRouteFilter<Http::Mixer::Instance>> instance{
+          new Http::PerRouteFilter<Http::Mixer::Instance>(
+              [mixer_config](
+                  const Router::RouteEntry*
+                      entry) -> std::unique_ptr<Http::Mixer::Instance> {
+                ::istio::mixer_control::http::Controller::PerRouteConfig config;
+                ServiceConfig legacy_config;
+                auto& control = mixer_config->mixer_control();
+                if (control.has_v2_config()) {
+                  Http::Mixer::RouteUtil::ReadPerRouteConfig(
+                      entry, *control.controller(), &config);
+                } else {
+                  bool check_disabled, report_disabled;
+                  Http::Mixer::RouteUtil::MixerRouteFlags(
+                      entry, &check_disabled, &report_disabled);
+
+                  Http::Mixer::HttpMixerConfig::CreateLegacyRouteConfig(
+                      check_disabled, report_disabled,
+                      Http::Mixer::RouteUtil::GetRouteStringMap(
+                          entry, Http::Mixer::kPrefixMixerAttributes),
+                      &legacy_config);
+                  config.legacy_config = &legacy_config;
+                }
+
+                return std::unique_ptr<Http::Mixer::Instance>{
+                    new Http::Mixer::Instance(
+                        control,
+                        control.controller()->CreateRequestHandler(config))};
+              })};
       callbacks.addStreamDecoderFilter(
           Http::StreamDecoderFilterSharedPtr(instance));
       callbacks.addAccessLogHandler(AccessLog::InstanceSharedPtr(instance));


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add a filter wrapper to lazy initialize filters until it knows route
- Modify mixer filter to use it

Tested with latest istio/istio integration test manually.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
