### PR TITLE
Add back mixerclient stats

### DIFF
--- a/src/envoy/mixer/BUILD
+++ b/src/envoy/mixer/BUILD
@@ -30,6 +30,8 @@ envoy_cc_library(
         "http_filter.cc",
         "mixer_control.cc",
         "mixer_control.h",
+        "stats.cc",
+        "stats.h",
         "tcp_filter.cc",
         "utils.cc",
         "utils.h",

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -54,9 +54,9 @@ void CreateEnvironment(Upstream::ClusterManager& cm,
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixer_client::Timer> {
-    return std::unique_ptr<::istio::mixer_client::Timer>(
-        new EnvoyTimer(dispatcher.createTimer(timer_cb)));
-  };
+        return std::unique_ptr<::istio::mixer_client::Timer>(
+            new EnvoyTimer(dispatcher.createTimer(timer_cb)));
+      };
 
   env->uuid_generate_func = [&random]() -> std::string {
     return random.uuid();

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -54,9 +54,9 @@ void CreateEnvironment(Upstream::ClusterManager& cm,
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixer_client::Timer> {
-        return std::unique_ptr<::istio::mixer_client::Timer>(
-            new EnvoyTimer(dispatcher.createTimer(timer_cb)));
-      };
+    return std::unique_ptr<::istio::mixer_client::Timer>(
+        new EnvoyTimer(dispatcher.createTimer(timer_cb)));
+  };
 
   env->uuid_generate_func = [&random]() -> std::string {
     return random.uuid();
@@ -72,7 +72,7 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
                                    MixerFilterStats& stats)
     : config_(mixer_config),
       cm_(cm),
-      stats_obj_(dispatcher,
+      stats_obj_(dispatcher, stats,
                  mixer_config.http_config.transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool {
                    if (!controller_) {
@@ -80,8 +80,7 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
                    }
                    controller_->GetStatistics(stat);
                    return true;
-                 },
-                 stats) {
+                 }) {
   ::istio::mixer_control::http::Controller::Options options(
       mixer_config.http_config);
 
@@ -98,7 +97,7 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
                                  MixerFilterStats& stats)
     : config_(mixer_config),
       dispatcher_(dispatcher),
-      stats_obj_(dispatcher,
+      stats_obj_(dispatcher, stats,
                  mixer_config.tcp_config.transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool {
                    if (!controller_) {
@@ -106,8 +105,7 @@ TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
                    }
                    controller_->GetStatistics(stat);
                    return true;
-                 },
-                 stats) {
+                 }) {
   ::istio::mixer_control::tcp::Controller::Options options(
       mixer_config.tcp_config);
 

--- a/src/envoy/mixer/mixer_control.cc
+++ b/src/envoy/mixer/mixer_control.cc
@@ -15,6 +15,8 @@
 
 #include "src/envoy/mixer/mixer_control.h"
 
+using ::istio::mixer_client::Statistics;
+
 namespace Envoy {
 namespace Http {
 namespace Mixer {
@@ -66,8 +68,20 @@ void CreateEnvironment(Upstream::ClusterManager& cm,
 HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
                                    Upstream::ClusterManager& cm,
                                    Event::Dispatcher& dispatcher,
-                                   Runtime::RandomGenerator& random)
-    : config_(mixer_config), cm_(cm) {
+                                   Runtime::RandomGenerator& random,
+                                   MixerFilterStats& stats)
+    : config_(mixer_config),
+      cm_(cm),
+      stats_obj_(dispatcher,
+                 mixer_config.http_config.transport().stats_update_interval(),
+                 [this](Statistics* stat) -> bool {
+                   if (!controller_) {
+                     return false;
+                   }
+                   controller_->GetStatistics(stat);
+                   return true;
+                 },
+                 stats) {
   ::istio::mixer_control::http::Controller::Options options(
       mixer_config.http_config);
 
@@ -80,8 +94,20 @@ HttpMixerControl::HttpMixerControl(const HttpMixerConfig& mixer_config,
 TcpMixerControl::TcpMixerControl(const TcpMixerConfig& mixer_config,
                                  Upstream::ClusterManager& cm,
                                  Event::Dispatcher& dispatcher,
-                                 Runtime::RandomGenerator& random)
-    : config_(mixer_config), dispatcher_(dispatcher) {
+                                 Runtime::RandomGenerator& random,
+                                 MixerFilterStats& stats)
+    : config_(mixer_config),
+      dispatcher_(dispatcher),
+      stats_obj_(dispatcher,
+                 mixer_config.tcp_config.transport().stats_update_interval(),
+                 [this](Statistics* stat) -> bool {
+                   if (!controller_) {
+                     return false;
+                   }
+                   controller_->GetStatistics(stat);
+                   return true;
+                 },
+                 stats) {
   ::istio::mixer_control::tcp::Controller::Options options(
       mixer_config.tcp_config);
 

--- a/src/envoy/mixer/mixer_control.h
+++ b/src/envoy/mixer/mixer_control.h
@@ -23,6 +23,7 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "src/envoy/mixer/config.h"
 #include "src/envoy/mixer/grpc_transport.h"
+#include "src/envoy/mixer/stats.h"
 
 namespace Envoy {
 namespace Http {
@@ -33,7 +34,7 @@ class HttpMixerControl final : public ThreadLocal::ThreadLocalObject {
   // The constructor.
   HttpMixerControl(const HttpMixerConfig& mixer_config,
                    Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-                   Runtime::RandomGenerator& random);
+                   Runtime::RandomGenerator& random, MixerFilterStats& stats);
 
   ::istio::mixer_control::http::Controller* controller() {
     return controller_.get();
@@ -50,6 +51,8 @@ class HttpMixerControl final : public ThreadLocal::ThreadLocalObject {
   Upstream::ClusterManager& cm_;
   // The mixer control
   std::unique_ptr<::istio::mixer_control::http::Controller> controller_;
+
+  MixerStatsObject stats_obj_;
 };
 
 class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
@@ -57,7 +60,7 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
   // The constructor.
   TcpMixerControl(const TcpMixerConfig& mixer_config,
                   Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
-                  Runtime::RandomGenerator& random);
+                  Runtime::RandomGenerator& random, MixerFilterStats& stats);
 
   ::istio::mixer_control::tcp::Controller* controller() {
     return controller_.get();
@@ -79,6 +82,8 @@ class TcpMixerControl final : public ThreadLocal::ThreadLocalObject {
   std::chrono::milliseconds report_interval_ms_;
 
   Event::Dispatcher& dispatcher_;
+
+  MixerStatsObject stats_obj_;
 };
 
 }  // namespace Mixer

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -28,8 +28,9 @@ const int kStatsUpdateIntervalInMs = 10000;
 }  // namespace
 
 MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
+                                   MixerFilterStats& stats,
                                    ::google::protobuf::Duration update_interval,
-                                   GetStatsFunc func, MixerFilterStats& stats)
+                                   GetStatsFunc func)
     : stats_(stats), get_stats_func_(func) {
   stats_update_interval_ =
       update_interval.seconds() * 1000 + update_interval.nanos() / 1000000;

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -28,11 +28,9 @@ const int kStatsUpdateIntervalInMs = 10000;
 }  // namespace
 
 MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
-                                   const std::string& name, Stats::Scope& scope,
                                    ::google::protobuf::Duration update_interval,
-                                   GetStatsFunc func)
-    : stats_{ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))},
-      get_stats_func_(func) {
+                                   GetStatsFunc func, MixerFilterStats& stats)
+    : stats_(stats), get_stats_func_(func) {
   stats_update_interval_ =
       update_interval.seconds() * 1000 + update_interval.nanos() / 1000000;
   if (stats_update_interval_ <= 0) {

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -1,0 +1,106 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <chrono>
+
+#include "src/envoy/mixer/stats.h"
+
+namespace Envoy {
+namespace Http {
+namespace Mixer {
+namespace {
+
+// The time interval for envoy stats update.
+const int kStatsUpdateIntervalInMs = 10000;
+
+}  // namespace
+
+MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
+                                   const std::string& name, Stats::Scope& scope,
+                                   ::google::protobuf::Duration update_interval,
+                                   GetStatsFunc func)
+    : stats_{ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))},
+      get_stats_func_(func) {
+  stats_update_interval_ = update_interval.seconds() * 1000 +
+      update_interval.nanos() / 1000000;
+  if (stats_update_interval_ <= 0) {
+    stats_update_interval_ = kStatsUpdateIntervalInMs;
+  }
+  memset(&old_stats_, 0, sizeof(old_stats_));
+
+  if (get_stats_func_) {
+    timer_ = dispatcher.createTimer([this]() { OnTimer(); });
+    timer_->enableTimer(std::chrono::milliseconds(stats_update_interval_));
+  }
+}
+
+void MixerStatsObject::OnTimer() {
+  ::istio::mixer_client::Statistics new_stats;
+  bool get_stats = get_stats_func_(&new_stats);
+  if (get_stats) {
+    CheckAndUpdateStats(new_stats);
+  }
+  timer_->enableTimer(std::chrono::milliseconds(stats_update_interval_));
+}
+
+void MixerStatsObject::CheckAndUpdateStats(
+    const ::istio::mixer_client::Statistics& new_stats) {
+  if (new_stats.total_check_calls > old_stats_.total_check_calls) {
+    stats_.total_check_calls_.add(new_stats.total_check_calls -
+                                  old_stats_.total_check_calls);
+  }
+  if (new_stats.total_remote_check_calls >
+      old_stats_.total_remote_check_calls) {
+    stats_.total_remote_check_calls_.add(new_stats.total_remote_check_calls -
+                                         old_stats_.total_remote_check_calls);
+  }
+  if (new_stats.total_blocking_remote_check_calls >
+      old_stats_.total_blocking_remote_check_calls) {
+    stats_.total_blocking_remote_check_calls_.add(
+        new_stats.total_blocking_remote_check_calls -
+        old_stats_.total_blocking_remote_check_calls);
+  }
+  if (new_stats.total_quota_calls > old_stats_.total_quota_calls) {
+    stats_.total_quota_calls_.add(new_stats.total_quota_calls -
+                                  old_stats_.total_quota_calls);
+  }
+  if (new_stats.total_remote_quota_calls >
+      old_stats_.total_remote_quota_calls) {
+    stats_.total_remote_quota_calls_.add(new_stats.total_remote_quota_calls -
+                                         old_stats_.total_remote_quota_calls);
+  }
+  if (new_stats.total_blocking_remote_quota_calls >
+      old_stats_.total_blocking_remote_quota_calls) {
+    stats_.total_blocking_remote_quota_calls_.add(
+        new_stats.total_blocking_remote_quota_calls -
+        old_stats_.total_blocking_remote_quota_calls);
+  }
+  if (new_stats.total_report_calls > old_stats_.total_report_calls) {
+    stats_.total_report_calls_.add(new_stats.total_report_calls -
+                                   old_stats_.total_report_calls);
+  }
+  if (new_stats.total_remote_report_calls >
+      old_stats_.total_remote_report_calls) {
+    stats_.total_remote_report_calls_.add(new_stats.total_remote_report_calls -
+                                          old_stats_.total_remote_report_calls);
+  }
+
+  // Copy new_stats to old_stats_ for next stats update.
+  old_stats_ = new_stats;
+}
+
+}  // namespace Mixer
+}  // namespace Http
+}  // namespace Envoy

--- a/src/envoy/mixer/stats.cc
+++ b/src/envoy/mixer/stats.cc
@@ -33,8 +33,8 @@ MixerStatsObject::MixerStatsObject(Event::Dispatcher& dispatcher,
                                    GetStatsFunc func)
     : stats_{ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))},
       get_stats_func_(func) {
-  stats_update_interval_ = update_interval.seconds() * 1000 +
-      update_interval.nanos() / 1000000;
+  stats_update_interval_ =
+      update_interval.seconds() * 1000 + update_interval.nanos() / 1000000;
   if (stats_update_interval_ <= 0) {
     stats_update_interval_ = kStatsUpdateIntervalInMs;
   }

--- a/src/envoy/mixer/stats.h
+++ b/src/envoy/mixer/stats.h
@@ -52,10 +52,9 @@ typedef std::function<bool(::istio::mixer_client::Statistics* s)> GetStatsFunc;
 // calls issued by a mixer filter.
 class MixerStatsObject {
  public:
-  MixerStatsObject(Event::Dispatcher& dispatcher, const std::string& name,
-                   Stats::Scope& scope,
+  MixerStatsObject(Event::Dispatcher& dispatcher,
                    ::google::protobuf::Duration update_interval,
-                   GetStatsFunc func);
+                   GetStatsFunc func, MixerFilterStats& stats);
 
  private:
   // This function is invoked when timer event fires.

--- a/src/envoy/mixer/stats.h
+++ b/src/envoy/mixer/stats.h
@@ -52,9 +52,9 @@ typedef std::function<bool(::istio::mixer_client::Statistics* s)> GetStatsFunc;
 // calls issued by a mixer filter.
 class MixerStatsObject {
  public:
-  MixerStatsObject(Event::Dispatcher& dispatcher,
+  MixerStatsObject(Event::Dispatcher& dispatcher, MixerFilterStats& stats,
                    ::google::protobuf::Duration update_interval,
-                   GetStatsFunc func, MixerFilterStats& stats);
+                   GetStatsFunc func);
 
  private:
   // This function is invoked when timer event fires.

--- a/src/envoy/mixer/stats.h
+++ b/src/envoy/mixer/stats.h
@@ -1,0 +1,88 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/event/timer.h"
+#include "envoy/stats/stats_macros.h"
+#include "include/client.h"
+
+namespace Envoy {
+namespace Http {
+namespace Mixer {
+
+/**
+ * All mixer filter stats. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_MIXER_FILTER_STATS(COUNTER)                                       \
+  COUNTER(total_check_calls)                                                  \
+  COUNTER(total_remote_check_calls)                                           \
+  COUNTER(total_blocking_remote_check_calls)                                  \
+  COUNTER(total_quota_calls)                                                  \
+  COUNTER(total_remote_quota_calls)                                           \
+  COUNTER(total_blocking_remote_quota_calls)                                  \
+  COUNTER(total_report_calls)                                                 \
+  COUNTER(total_remote_report_calls)
+// clang-format on
+
+/**
+ * Struct definition for all mixer filter stats. @see stats_macros.h
+ */
+struct MixerFilterStats {
+  ALL_MIXER_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+typedef std::function<bool(::istio::mixer_client::Statistics* s)> GetStatsFunc;
+
+// MixerStatsObject maintains statistics for number of check, quota and report
+// calls issued by a mixer filter.
+class MixerStatsObject {
+ public:
+  MixerStatsObject(Event::Dispatcher& dispatcher, const std::string& name,
+                   Stats::Scope& scope,
+                   ::google::protobuf::Duration update_interval,
+                   GetStatsFunc func);
+
+ private:
+  // This function is invoked when timer event fires.
+  void OnTimer();
+
+  // Compares old stats with new stats and updates envoy stats.
+  void CheckAndUpdateStats(const ::istio::mixer_client::Statistics& new_stats);
+
+  // A set of Envoy stats for the number of check, quota and report calls.
+  MixerFilterStats stats_;
+  // Stores a function which gets statistics from mixer controller.
+  GetStatsFunc get_stats_func_;
+
+  // stats from last call to get_stats_func_. This is needed to calculate the
+  // variances of stats and update envoy stats.
+  ::istio::mixer_client::Statistics old_stats_;
+
+  // These members are used for creating a timer which update Envoy stats
+  // periodically.
+  ::Envoy::Event::TimerPtr timer_;
+
+  // Time interval at which Envoy stats get updated. If stats update interval
+  // from config is larger than 0, then store configured interval here.
+  // Otherwise, set interval to 10 seconds.
+  int stats_update_interval_;
+};
+
+}  // namespace Mixer
+}  // namespace Http
+}  // namespace Envoy

--- a/src/envoy/mixer/stats.h
+++ b/src/envoy/mixer/stats.h
@@ -64,7 +64,7 @@ class MixerStatsObject {
   void CheckAndUpdateStats(const ::istio::mixer_client::Statistics& new_stats);
 
   // A set of Envoy stats for the number of check, quota and report calls.
-  MixerFilterStats stats_;
+  MixerFilterStats& stats_;
   // Stores a function which gets statistics from mixer controller.
   GetStatsFunc get_stats_func_;
 

--- a/src/envoy/mixer/tcp_filter.cc
+++ b/src/envoy/mixer/tcp_filter.cc
@@ -54,12 +54,12 @@ class TcpConfig : public Logger::Loggable<Logger::Id::filter> {
     mixer_config_.Load(config);
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
-    tls_->set([this, &random, &scope](Event::Dispatcher& dispatcher)
-                  -> ThreadLocal::ThreadLocalObjectSharedPtr {
-                    return ThreadLocal::ThreadLocalObjectSharedPtr(
-                        new TcpMixerControl(mixer_config_, cm_, dispatcher,
-                                            random));
-                  });
+    tls_->set(
+        [this, &random, &scope](Event::Dispatcher& dispatcher)
+            -> ThreadLocal::ThreadLocalObjectSharedPtr {
+              return ThreadLocal::ThreadLocalObjectSharedPtr(
+                  new TcpMixerControl(mixer_config_, cm_, dispatcher, random));
+            });
     stats_obj_ = std::unique_ptr<MixerStatsObject>(new MixerStatsObject(
         context.dispatcher(), kTcpStatsPrefix, context.scope(),
         mixer_config_.tcp_config.transport().stats_update_interval(),


### PR DESCRIPTION
**What this PR does / why we need it**:Revert Mixerclient stats back.
Move Envoy stats into Mixer filter config object.
Keep MixerStatsObject in HttpMixerControl and TcpMixerControl, and pass Envoy stats into MixerStatsObject for periodical stats update.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
