### PR TITLE
Switch to Skylark git_repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,6 +55,7 @@ go_register_toolchains()
 load("@io_bazel_rules_go//proto:def.bzl", "proto_register_toolchains")
 proto_register_toolchains()
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "org_pubref_rules_protobuf",
     commit = "563b674a2ce6650d459732932ea2bc98c9c9a9bf",  # Nov 28, 2017 (bazel 0.8.0 support)

--- a/cc_gogo_protobuf.bzl
+++ b/cc_gogo_protobuf.bzl
@@ -14,6 +14,9 @@
 #
 ################################################################################
 #
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
 def cc_gogoproto_repositories(bind=True):
     BUILD = """
 # Copyright 2017 Istio Authors. All Rights Reserved.
@@ -53,7 +56,7 @@ cc_proto_library(
     ],
 )
 """
-    native.new_git_repository(
+    new_git_repository(
         name = "gogoproto_git",
         commit = "100ba4e885062801d56799d78530b73b178a78f3",
         remote = "https://github.com/gogo/protobuf",

--- a/googleapis.bzl
+++ b/googleapis.bzl
@@ -15,6 +15,8 @@
 ################################################################################
 #
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
 def googleapis_repositories(bind=True):
     GOOGLEAPIS_BUILD_FILE = """
 package(default_visibility = ["//visibility:public"])
@@ -35,7 +37,7 @@ cc_proto_library(
 )
 
 """
-    native.new_git_repository(
+    new_git_repository(
         name = "com_github_googleapis_googleapis",
         build_file_content = GOOGLEAPIS_BUILD_FILE,
         commit = "13ac2436c5e3d568bd0e938f6ed58b77a48aba15", # Oct 21, 2016 (only release pre-dates sha)

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -14,10 +14,11 @@
 #
 ################################################################################
 #
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def protobuf_repositories(load_repo=True, bind=True):
     if load_repo:
-        native.git_repository(
+        git_repository(
             name = "com_google_protobuf",
             commit = "2761122b810fe8861004ae785cc3ab39f384d342",  # v3.5.0
             remote = "https://github.com/google/protobuf.git",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -14,8 +14,10 @@
 #
 ################################################################################
 #
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 def boringssl_repositories(bind=True):
-    native.git_repository(
+    git_repository(
         name = "boringssl",
         commit = "12c35d69008ae6b8486e435447445240509f7662",  # 2016-10-24
         remote = "https://boringssl.googlesource.com/boringssl",

--- a/x_tools_imports.bzl
+++ b/x_tools_imports.bzl
@@ -14,6 +14,7 @@
 #
 ################################################################################
 #
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 def go_x_tools_imports_repositories():
     BUILD_FILE = """
@@ -45,8 +46,8 @@ go_binary(
     # simple build rule that will build the binary for usage (and avoid
     # the need to project a more complicated BUILD file over the entire
     # tools repo.)
-    native.new_git_repository(
-	name = "org_golang_x_tools_imports",
+    new_git_repository(
+        name = "org_golang_x_tools_imports",
         build_file_content = BUILD_FILE,
         commit = "e6cb469339aef5b7be0c89de730d5f3cc8e47e50",  # Jun 23, 2017 (no releases)
         remote = "https://github.com/golang/tools.git",


### PR DESCRIPTION
**What this PR does / why we need it**:

Skylark Git uses native git command instead of JGit, which address CircleCI problems and support GitHub recent cipher removal better:
https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
