### PR TITLE
use Envoy log component filter instead of http

### DIFF
--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -24,7 +24,7 @@ namespace Http {
 
 // The authentication filter.
 class AuthenticationFilter : public StreamDecoderFilter,
-                             public Logger::Loggable<Logger::Id::http> {
+                             public Logger::Loggable<Logger::Id::filter> {
  public:
   AuthenticationFilter(const istio::authentication::v1alpha1::Policy& config);
   ~AuthenticationFilter();

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -29,7 +29,7 @@ const std::string kAuthnFactoryName("istio_authn");
 }  // namespace
 
 class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
-                          public Logger::Loggable<Logger::Id::http> {
+                          public Logger::Loggable<Logger::Id::filter> {
  public:
   HttpFilterFactoryCb createFilterFactory(const Json::Object& config,
                                           const std::string&,

--- a/src/envoy/http/authn/mtls_authentication.h
+++ b/src/envoy/http/authn/mtls_authentication.h
@@ -19,7 +19,7 @@ namespace Envoy {
 namespace Http {
 
 // A class to handle mTLS authentication policy related operations.
-class MtlsAuthentication : public Logger::Loggable<Logger::Id::http> {
+class MtlsAuthentication : public Logger::Loggable<Logger::Id::filter> {
  public:
   MtlsAuthentication(const Network::Connection* connection);
   // This function gets the source IP and port.

--- a/src/envoy/http/jwt_auth/http_filter.h
+++ b/src/envoy/http/jwt_auth/http_filter.h
@@ -26,7 +26,7 @@ namespace Http {
 // The Envoy filter to process JWT auth.
 class JwtVerificationFilter : public StreamDecoderFilter,
                               public JwtAuth::JwtAuthenticator::Callbacks,
-                              public Logger::Loggable<Logger::Id::http> {
+                              public Logger::Loggable<Logger::Id::filter> {
  public:
   JwtVerificationFilter(Upstream::ClusterManager& cm,
                         JwtAuth::JwtAuthStore& store);

--- a/src/envoy/http/jwt_auth/jwt_authenticator.h
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.h
@@ -28,7 +28,7 @@ namespace JwtAuth {
 
 // A per-request JWT authenticator to handle all JWT authentication:
 // * fetch remote public keys and cache them.
-class JwtAuthenticator : public Logger::Loggable<Logger::Id::http>,
+class JwtAuthenticator : public Logger::Loggable<Logger::Id::filter>,
                          public AsyncClient::Callbacks {
  public:
   JwtAuthenticator(Upstream::ClusterManager& cm, JwtAuthStore& store);

--- a/src/envoy/http/mixer/check_data.h
+++ b/src/envoy/http/mixer/check_data.h
@@ -25,7 +25,7 @@ namespace Http {
 namespace Mixer {
 
 class CheckData : public ::istio::control::http::CheckData,
-                  public Logger::Loggable<Logger::Id::http> {
+                  public Logger::Loggable<Logger::Id::filter> {
  public:
   CheckData(const HeaderMap& headers, const Network::Connection* connection);
 

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -31,7 +31,7 @@ const std::string kHttpStatsPrefix("http_mixer_filter.");
 
 // This object is globally per listener.
 // HttpMixerControl is created per-thread by this object.
-class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
+class ControlFactory : public Logger::Loggable<Logger::Id::config> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -31,7 +31,7 @@ const std::string kHttpStatsPrefix("http_mixer_filter.");
 
 // This object is globally per listener.
 // HttpMixerControl is created per-thread by this object.
-class ControlFactory : public Logger::Loggable<Logger::Id::http> {
+class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -26,7 +26,7 @@ namespace Mixer {
 
 class Filter : public Http::StreamDecoderFilter,
                public AccessLog::Instance,
-               public Logger::Loggable<Logger::Id::http> {
+               public Logger::Loggable<Logger::Id::filter> {
  public:
   Filter(Control& control);
 

--- a/src/envoy/http/mixer/header_update.h
+++ b/src/envoy/http/mixer/header_update.h
@@ -25,7 +25,7 @@ namespace Http {
 namespace Mixer {
 
 class HeaderUpdate : public ::istio::control::http::HeaderUpdate,
-                     public Logger::Loggable<Logger::Id::http> {
+                     public Logger::Loggable<Logger::Id::filter> {
   HeaderMap* headers_;
 
  public:

--- a/src/envoy/utils/grpc_transport.h
+++ b/src/envoy/utils/grpc_transport.h
@@ -32,7 +32,7 @@ namespace Utils {
 // An object to use Envoy::Grpc::AsyncClient to make grpc call.
 template <class RequestType, class ResponseType>
 class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
-                      public Logger::Loggable<Logger::Id::http> {
+                      public Logger::Loggable<Logger::Id::filter> {
  public:
   using Func = std::function<istio::mixerclient::CancelFunc(
       const RequestType& request, ResponseType* response,

--- a/src/envoy/utils/grpc_transport.h
+++ b/src/envoy/utils/grpc_transport.h
@@ -32,7 +32,7 @@ namespace Utils {
 // An object to use Envoy::Grpc::AsyncClient to make grpc call.
 template <class RequestType, class ResponseType>
 class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
-                      public Logger::Loggable<Logger::Id::filter> {
+                      public Logger::Loggable<Logger::Id::grpc> {
  public:
   using Func = std::function<istio::mixerclient::CancelFunc(
       const RequestType& request, ResponseType* response,


### PR DESCRIPTION
**What this PR does / why we need it**:

Envoy allows to change logging level dynamically per component by
http:// :admin_port/logging?component=level

"http" component has too many debug log,  it is better to use "filter" which has much less.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
