### PR TITLE
Add authentication result to header if authentication success.

### DIFF
--- a/src/envoy/http/authn/BUILD
+++ b/src/envoy/http/authn/BUILD
@@ -135,6 +135,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":filter_lib",
+        ":test_utils",
         "//external:authentication_policy_config_cc_proto",
         "@envoy//source/common/http:header_map_lib",
         "@envoy//test/mocks/http:http_mocks",

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -82,7 +82,7 @@ void AuthenticationFilter::onOriginAuthenticationDone(bool success) {
       filter_context_->authenticationResult().SerializeToString(&payload_data);
       const std::string base64_data =
           Base64::encode(payload_data.c_str(), payload_data.size());
-      filter_context_->headers()->addReferenceKey(kAuthenticationPayloadKey,
+      filter_context_->headers()->addReferenceKey(kOutputHeaderLocation,
                                                   base64_data);
     }
 

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/http_filter.h"
+#include "common/common/base64.h"
 #include "common/http/utility.h"
 #include "src/envoy/http/authn/origin_authenticator.h"
 #include "src/envoy/http/authn/peer_authenticator.h"
@@ -25,6 +26,10 @@ namespace Envoy {
 namespace Http {
 namespace Istio {
 namespace AuthN {
+
+// The HTTP header to pass verified authentication payload.
+const LowerCaseString AuthenticationFilter::kOutputHeaderLocation(
+    "sec-istio-authn-payload");
 
 AuthenticationFilter::AuthenticationFilter(
     const istio::authentication::v1alpha1::Policy& policy)
@@ -71,6 +76,16 @@ void AuthenticationFilter::onPeerAuthenticationDone(bool success) {
 void AuthenticationFilter::onOriginAuthenticationDone(bool success) {
   ENVOY_LOG(debug, "{}: success = {}", __func__, success);
   if (success) {
+    // Put authentication result to headers.
+    if (filter_context_ != nullptr) {
+      std::string payload_data;
+      filter_context_->authenticationResult().SerializeToString(&payload_data);
+      const std::string base64_data =
+          Base64::encode(payload_data.c_str(), payload_data.size());
+      filter_context_->headers()->addReferenceKey(kAuthenticationPayloadKey,
+                                                  base64_data);
+    }
+
     continueDecoding();
   } else {
     rejectRequest("Origin authentication failed.");

--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -43,6 +43,9 @@ class AuthenticationFilter : public StreamDecoderFilter,
   void setDecoderFilterCallbacks(
       StreamDecoderFilterCallbacks& callbacks) override;
 
+  // The HTTP header to pass verified authentication payload.
+  static const LowerCaseString kOutputHeaderLocation;
+
  protected:
   // Callback for peer authenticator.
   void onPeerAuthenticationDone(bool success);


### PR DESCRIPTION
**What this PR does / why we need it**:

We want istio_authn filter to output authenticated attributes so they can be used by the next filters (i.e mixer). This PR do this by putting result data to header. This can be changed in future to pass the objects directly between filter via some common context.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
`NONE`
