### PR TITLE
Update Envoy SHA to version 1.6.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "9d4ca6dbc8808daf8dc4d8fdf52094191444af98"
+ENVOY_SHA = "4dd49d8809f7aaa580538b3c228dd99a2fae92a4"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"repoName": "envoyproxy/envoy",
 		"prodBranch": "master",
 		"file": "WORKSPACE",
-		"lastStableSHA": "9d4ca6dbc8808daf8dc4d8fdf52094191444af98"
+		"lastStableSHA": "4dd49d8809f7aaa580538b3c228dd99a2fae92a4"
 	}
 ]


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

**What this PR does / why we need it**:
This PR updates the Envoy SHA to use the commit associated with version 1.6.0. This version includes an update to propagate the B3 sampled header value.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
