### PR TITLE
Let tests build on macOS.

### DIFF
--- a/src/envoy/http/authn/testdata/envoy_empty.conf
+++ b/src/envoy/http/authn/testdata/envoy_empty.conf
@@ -26,7 +26,7 @@
             },
             "access_log": [
               {
-                "path": "/dev/stdout"
+                "path": "/dev/null"
               }
             ],
             "filters": [
@@ -47,7 +47,7 @@
     }
   ],
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": "tcp://{{ ip_loopback_address }}:0"
   },
   "cluster_manager": {

--- a/src/envoy/http/authn/testdata/envoy_peer_mtls.conf
+++ b/src/envoy/http/authn/testdata/envoy_peer_mtls.conf
@@ -26,7 +26,7 @@
             },
             "access_log": [
               {
-                "path": "/dev/stdout"
+                "path": "/dev/null"
               }
             ],
             "filters": [
@@ -54,7 +54,7 @@
     }
   ],
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": "tcp://{{ ip_loopback_address }}:0"
   },
   "cluster_manager": {

--- a/src/envoy/http/jwt_auth/integration_test/envoy.conf.jwk
+++ b/src/envoy/http/jwt_auth/integration_test/envoy.conf.jwk
@@ -26,7 +26,7 @@
             },
             "access_log": [
               {
-                "path": "/dev/stdout"
+                "path": "/dev/null"
               }
             ],
             "filters": [
@@ -58,7 +58,7 @@
     }
   ],
   "admin": {
-    "access_log_path": "/dev/stdout",
+    "access_log_path": "/dev/null",
     "address": "tcp://{{ ip_loopback_address }}:0"
   },
   "cluster_manager": {

--- a/src/istio/mixerclient/BUILD
+++ b/src/istio/mixerclient/BUILD
@@ -145,11 +145,14 @@ cc_test(
     name = "client_impl_test",
     size = "small",
     srcs = ["client_impl_test.cc"],
-    linkopts = [
-        "-lm",
-        "-lpthread",
-        "-lrt",
-    ],
+    linkopts = select({
+        "//:darwin": [],
+        "//conditions:default": [
+            "-lm",
+            "-lpthread",
+            "-lrt",
+        ],
+    }),
     linkstatic = 1,
     deps = [
         ":mixerclient_lib",


### PR DESCRIPTION
Access logs in tests were changed from /dev/stdout to /dev/null,
because opening /dev/stdout results in "Permission Denied" error
on macOS when running as an unprivileged user.