### PR TITLE
Change mixer filter to use authn result data if available

### DIFF
--- a/include/istio/control/http/BUILD
+++ b/include/istio/control/http/BUILD
@@ -23,4 +23,5 @@ cc_library(
         "request_handler.h",
     ],
     visibility = ["//visibility:public"],
+    deps = ["//src/istio/authn:context_proto"],
 )

--- a/include/istio/control/http/check_data.h
+++ b/include/istio/control/http/check_data.h
@@ -82,6 +82,8 @@ class CheckData {
   virtual bool GetJWTPayload(
       std::map<std::string, std::string> *payload) const = 0;
 
+  // If the request has authentication result in header, parses data into the
+  // output result; returns true if success. Otherwise, returns false.
   virtual bool GetAuthenticationResult(istio::authn::Result *result) const = 0;
 };
 

--- a/include/istio/control/http/check_data.h
+++ b/include/istio/control/http/check_data.h
@@ -19,6 +19,8 @@
 #include <map>
 #include <string>
 
+#include "src/istio/authn/context.pb.h"
+
 namespace istio {
 namespace control {
 namespace http {
@@ -79,6 +81,8 @@ class CheckData {
   // string map, and return true. Otherwise return false.
   virtual bool GetJWTPayload(
       std::map<std::string, std::string> *payload) const = 0;
+
+  virtual bool GetAuthenticationResult(istio::authn::Result *result) const = 0;
 };
 
 // An interfact to update request HTTP headers with Istio attributes.

--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <string>
 
+#include "google/protobuf/map.h"
 #include "mixer/v1/attributes.pb.h"
 
 namespace istio {
@@ -77,6 +78,21 @@ class AttributesBuilder {
   void AddStringMap(const std::string& key,
                     const std::map<std::string, std::string>& string_map) {
     if (string_map.size() == 0) {
+      return;
+    }
+    auto entries = (*attributes_->mutable_attributes())[key]
+                       .mutable_string_map_value()
+                       ->mutable_entries();
+    entries->clear();
+    for (const auto& map_it : string_map) {
+      (*entries)[map_it.first] = map_it.second;
+    }
+  }
+
+  void AddProtobufStringMap(
+      const std::string& key,
+      const google::protobuf::Map<std::string, ::std::string>& string_map) {
+    if (string_map.empty()) {
       return;
     }
     auto entries = (*attributes_->mutable_attributes())[key]

--- a/src/envoy/http/authn/BUILD
+++ b/src/envoy/http/authn/BUILD
@@ -62,6 +62,7 @@ envoy_cc_library(
     deps = [
         ":authenticator",
         "//external:authentication_policy_config_cc_proto",
+        "//src/envoy/utils:authn_lib",
         "//src/envoy/utils:utils_lib",
         "//src/istio/authn:context_proto",
         "@envoy//source/exe:envoy_common_lib",

--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -43,9 +43,6 @@ class AuthenticationFilter : public StreamDecoderFilter,
   void setDecoderFilterCallbacks(
       StreamDecoderFilterCallbacks& callbacks) override;
 
-  // The HTTP header to pass verified authentication payload.
-  static const LowerCaseString kOutputHeaderLocation;
-
  protected:
   // Callback for peer authenticator.
   void onPeerAuthenticationDone(bool success);

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include "src/envoy/http/authn/authenticator_base.h"
 #include "src/envoy/http/authn/test_utils.h"
+#include "src/envoy/utils/authn.h"
 #include "test/mocks/http/mocks.h"
 #include "test/test_common/utility.h"
 
@@ -119,8 +120,7 @@ TEST_F(AuthenticationFilterTest, PeerFail) {
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers_, true));
-  EXPECT_FALSE(
-      request_headers_.has(AuthenticationFilter::kOutputHeaderLocation));
+  EXPECT_FALSE(Utils::Authentication::HasResultInHeader(request_headers_));
 }
 
 TEST_F(AuthenticationFilterTest, PeerPassOrginFail) {
@@ -139,8 +139,7 @@ TEST_F(AuthenticationFilterTest, PeerPassOrginFail) {
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_.decodeHeaders(request_headers_, true));
-  EXPECT_FALSE(
-      request_headers_.has(AuthenticationFilter::kOutputHeaderLocation));
+  EXPECT_FALSE(Utils::Authentication::HasResultInHeader(request_headers_));
 }
 
 TEST_F(AuthenticationFilterTest, AllPass) {
@@ -153,8 +152,8 @@ TEST_F(AuthenticationFilterTest, AllPass) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter_.decodeHeaders(request_headers_, true));
   Result authn;
-  EXPECT_TRUE(authn.ParseFromString(Base64::decode(
-      request_headers_.get_(AuthenticationFilter::kOutputHeaderLocation))));
+  EXPECT_TRUE(
+      Utils::Authentication::FetchResultFromHeader(request_headers_, &authn));
   EXPECT_TRUE(TestUtility::protoEqual(
       TestUtilities::AuthNResultFromString(R"(peer_user: "foo")"), authn));
 }

--- a/src/envoy/http/mixer/BUILD
+++ b/src/envoy/http/mixer/BUILD
@@ -40,9 +40,9 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/envoy/http/jwt_auth:http_filter_lib",
+        "//src/envoy/utils:authn_lib",
         "//src/envoy/utils:utils_lib",
         "//src/istio/control/http:control_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )
-

--- a/src/envoy/http/mixer/BUILD
+++ b/src/envoy/http/mixer/BUILD
@@ -45,3 +45,4 @@ envoy_cc_library(
         "@envoy//source/exe:envoy_common_lib",
     ],
 )
+

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -17,6 +17,7 @@
 #include "common/common/base64.h"
 #include "src/envoy/http/jwt_auth/jwt.h"
 #include "src/envoy/http/jwt_auth/jwt_authenticator.h"
+#include "src/envoy/utils/authn.h"
 #include "src/envoy/utils/utils.h"
 
 using HttpCheckData = ::istio::control::http::CheckData;
@@ -189,6 +190,10 @@ bool CheckData::GetJWTPayload(
     return false;
   }
   return true;
+}
+
+bool CheckData::GetAuthenticationResult(istio::authn::Result* result) const {
+  return Utils::Authentication::FetchResultFromHeader(headers_, result);
 }
 
 }  // namespace Mixer

--- a/src/envoy/http/mixer/check_data.h
+++ b/src/envoy/http/mixer/check_data.h
@@ -19,6 +19,7 @@
 #include "common/http/utility.h"
 #include "envoy/http/header_map.h"
 #include "include/istio/control/http/controller.h"
+#include "src/istio/authn/context.pb.h"
 
 namespace Envoy {
 namespace Http {
@@ -55,6 +56,8 @@ class CheckData : public ::istio::control::http::CheckData,
 
   bool GetJWTPayload(
       std::map<std::string, std::string>* payload) const override;
+
+  bool GetAuthenticationResult(istio::authn::Result* result) const override;
 
   static const LowerCaseString& IstioAttributeHeader();
 

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -22,6 +22,22 @@ load(
 )
 
 envoy_cc_library(
+    name = "authn_lib",
+    srcs = [
+        "authn.cc",
+    ],
+    hdrs = [
+        "authn.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/istio/authn:context_proto",
+        "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_library(
     name = "utils_lib",
     srcs = [
         "config.cc",
@@ -43,6 +59,18 @@ envoy_cc_library(
         "//external:mixer_client_config_cc_proto",
         "//src/istio/mixerclient:mixerclient_lib",
         "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "authn_test",
+    srcs = [
+        "authn_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":authn_lib",
+        "@envoy//test/test_common:utility_lib",
     ],
 )
 

--- a/src/envoy/utils/authn.cc
+++ b/src/envoy/utils/authn.cc
@@ -1,0 +1,69 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/utils/authn.h"
+#include "common/common/base64.h"
+#include "src/istio/authn/context.pb.h"
+
+using istio::authn::Result;
+
+namespace Envoy {
+namespace Utils {
+namespace {
+
+// The HTTP header to save authentication result.
+const Http::LowerCaseString kAuthenticationOutputHeaderLocation(
+    "sec-istio-authn-payload");
+}  // namespace
+
+bool Authentication::SaveResultToHeader(const istio::authn::Result& result,
+                                        Http::HeaderMap* headers) {
+  if (HasResultInHeader(*headers)) {
+    ENVOY_LOG(warn,
+              "Authentication result already exist in header. Cannot save");
+    return false;
+  }
+
+  std::string payload_data;
+  result.SerializeToString(&payload_data);
+  headers->addCopy(kAuthenticationOutputHeaderLocation,
+                   Base64::encode(payload_data.c_str(), payload_data.size()));
+  return true;
+}
+
+bool Authentication::FetchResultFromHeader(const Http::HeaderMap& headers,
+                                           istio::authn::Result* result) {
+  const auto entry = headers.get(kAuthenticationOutputHeaderLocation);
+  if (entry == nullptr) {
+    return false;
+  }
+  std::string value(entry->value().c_str(), entry->value().size());
+  return result->ParseFromString(Base64::decode(value));
+}
+
+void Authentication::ClearResultInHeader(Http::HeaderMap* headers) {
+  headers->remove(kAuthenticationOutputHeaderLocation);
+}
+
+bool Authentication::HasResultInHeader(const Http::HeaderMap& headers) {
+  return headers.get(kAuthenticationOutputHeaderLocation) != nullptr;
+}
+
+const Http::LowerCaseString& Authentication::GetHeaderLocation() {
+  return kAuthenticationOutputHeaderLocation;
+}
+
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/envoy/utils/authn.h
+++ b/src/envoy/utils/authn.h
@@ -38,8 +38,9 @@ class Authentication : public Logger::Loggable<Logger::Id::filter> {
   // Clears authentication result in header, if exist.
   static void ClearResultInHeader(Http::HeaderMap* headers);
 
-  // Returns true if there is header entry at thelocation that is used to store authentication result.
-  // (function does not check for validity of the data though).
+  // Returns true if there is header entry at thelocation that is used to store
+  // authentication result. (function does not check for validity of the data
+  // though).
   static bool HasResultInHeader(const Http::HeaderMap& headers);
 
  private:

--- a/src/envoy/utils/authn.h
+++ b/src/envoy/utils/authn.h
@@ -1,0 +1,53 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/common/logger.h"
+#include "envoy/http/header_map.h"
+#include "src/istio/authn/context.pb.h"
+
+namespace Envoy {
+namespace Utils {
+
+class Authentication : public Logger::Loggable<Logger::Id::filter> {
+ public:
+  // Saves (authentication) result to header with proper encoding (base64). The
+  // location is internal implementation detail, and is chosen to avoid possible
+  // collision. If header already contains data in that location, function will
+  // returns false and data is *not* overwritten.
+  static bool SaveResultToHeader(const istio::authn::Result& result,
+                                 Http::HeaderMap* headers);
+
+  // Looks up authentication result data in the header. If data is available,
+  // decodes and output result proto. Returns false if data is not available, or
+  // in bad format.
+  static bool FetchResultFromHeader(const Http::HeaderMap& headers,
+                                    istio::authn::Result* result);
+
+  // Clears authentication result in header, if exist.
+  static void ClearResultInHeader(Http::HeaderMap* headers);
+
+  // Returns true if there is header entry at thelocation that is used to store authentication result.
+  // (function does not check for validity of the data though).
+  static bool HasResultInHeader(const Http::HeaderMap& headers);
+
+ private:
+  // Return the header location key. For testing purpose only.
+  static const Http::LowerCaseString& GetHeaderLocation();
+
+  friend class AuthenticationTest;
+};
+
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/envoy/utils/authn_test.cc
+++ b/src/envoy/utils/authn_test.cc
@@ -26,10 +26,10 @@ namespace Utils {
 
 class AuthenticationTest : public testing::Test {
  protected:
-   void SetUp() override {
-     test_result_.set_principal("foo");
-     test_result_.set_peer_user("bar");
-   }
+  void SetUp() override {
+    test_result_.set_principal("foo");
+    test_result_.set_peer_user("bar");
+  }
 
   const Http::LowerCaseString& GetHeaderLocation() {
     return Authentication::GetHeaderLocation();
@@ -43,14 +43,15 @@ TEST_F(AuthenticationTest, SaveEmptyResult) {
   EXPECT_TRUE(Authentication::SaveResultToHeader(Result{}, &request_headers_));
   EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
   const auto entry = request_headers_.get(GetHeaderLocation());
-  EXPECT_TRUE (entry != nullptr);
+  EXPECT_TRUE(entry != nullptr);
   EXPECT_EQ("", entry->value().getString());
 }
 
 TEST_F(AuthenticationTest, SaveSomeResult) {
-  EXPECT_TRUE(Authentication::SaveResultToHeader(test_result_, &request_headers_));
+  EXPECT_TRUE(
+      Authentication::SaveResultToHeader(test_result_, &request_headers_));
   const auto entry = request_headers_.get(GetHeaderLocation());
-  EXPECT_TRUE (entry != nullptr);
+  EXPECT_TRUE(entry != nullptr);
   EXPECT_EQ("CgNmb28SA2Jhcg==", entry->value().getString());
 }
 
@@ -60,26 +61,30 @@ TEST_F(AuthenticationTest, ResultAlreadyExist) {
   EXPECT_FALSE(Authentication::SaveResultToHeader(Result{}, &request_headers_));
   EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
   const auto entry = request_headers_.get(GetHeaderLocation());
-  EXPECT_TRUE (entry != nullptr);
+  EXPECT_TRUE(entry != nullptr);
   EXPECT_EQ("somedata", entry->value().getString());
 }
 
 TEST_F(AuthenticationTest, FetchResultNotExit) {
   Result result;
-  EXPECT_FALSE(Authentication::FetchResultFromHeader(request_headers_, &result));
+  EXPECT_FALSE(
+      Authentication::FetchResultFromHeader(request_headers_, &result));
 }
 
 TEST_F(AuthenticationTest, FetchResultBadFormat) {
   request_headers_.addCopy(GetHeaderLocation(), "somedata");
   EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
   Result result;
-  EXPECT_FALSE(Authentication::FetchResultFromHeader(request_headers_, &result));
+  EXPECT_FALSE(
+      Authentication::FetchResultFromHeader(request_headers_, &result));
 }
 
 TEST_F(AuthenticationTest, FetchResult) {
-  EXPECT_TRUE(Authentication::SaveResultToHeader(test_result_, &request_headers_));
+  EXPECT_TRUE(
+      Authentication::SaveResultToHeader(test_result_, &request_headers_));
   Result fetch_result;
-  EXPECT_TRUE(Authentication::FetchResultFromHeader(request_headers_, &fetch_result));
+  EXPECT_TRUE(
+      Authentication::FetchResultFromHeader(request_headers_, &fetch_result));
   EXPECT_TRUE(TestUtility::protoEqual(test_result_, fetch_result));
 }
 

--- a/src/envoy/utils/authn_test.cc
+++ b/src/envoy/utils/authn_test.cc
@@ -1,0 +1,87 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/utils/authn.h"
+#include "common/protobuf/protobuf.h"
+#include "envoy/http/header_map.h"
+#include "src/istio/authn/context.pb.h"
+#include "test/test_common/utility.h"
+
+using istio::authn::Result;
+
+namespace Envoy {
+namespace Utils {
+
+class AuthenticationTest : public testing::Test {
+ protected:
+   void SetUp() override {
+     test_result_.set_principal("foo");
+     test_result_.set_peer_user("bar");
+   }
+
+  const Http::LowerCaseString& GetHeaderLocation() {
+    return Authentication::GetHeaderLocation();
+  }
+  Http::TestHeaderMapImpl request_headers_{};
+  Result test_result_;
+};
+
+TEST_F(AuthenticationTest, SaveEmptyResult) {
+  EXPECT_FALSE(Authentication::HasResultInHeader(request_headers_));
+  EXPECT_TRUE(Authentication::SaveResultToHeader(Result{}, &request_headers_));
+  EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
+  const auto entry = request_headers_.get(GetHeaderLocation());
+  EXPECT_TRUE (entry != nullptr);
+  EXPECT_EQ("", entry->value().getString());
+}
+
+TEST_F(AuthenticationTest, SaveSomeResult) {
+  EXPECT_TRUE(Authentication::SaveResultToHeader(test_result_, &request_headers_));
+  const auto entry = request_headers_.get(GetHeaderLocation());
+  EXPECT_TRUE (entry != nullptr);
+  EXPECT_EQ("CgNmb28SA2Jhcg==", entry->value().getString());
+}
+
+TEST_F(AuthenticationTest, ResultAlreadyExist) {
+  request_headers_.addCopy(GetHeaderLocation(), "somedata");
+  EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
+  EXPECT_FALSE(Authentication::SaveResultToHeader(Result{}, &request_headers_));
+  EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
+  const auto entry = request_headers_.get(GetHeaderLocation());
+  EXPECT_TRUE (entry != nullptr);
+  EXPECT_EQ("somedata", entry->value().getString());
+}
+
+TEST_F(AuthenticationTest, FetchResultNotExit) {
+  Result result;
+  EXPECT_FALSE(Authentication::FetchResultFromHeader(request_headers_, &result));
+}
+
+TEST_F(AuthenticationTest, FetchResultBadFormat) {
+  request_headers_.addCopy(GetHeaderLocation(), "somedata");
+  EXPECT_TRUE(Authentication::HasResultInHeader(request_headers_));
+  Result result;
+  EXPECT_FALSE(Authentication::FetchResultFromHeader(request_headers_, &result));
+}
+
+TEST_F(AuthenticationTest, FetchResult) {
+  EXPECT_TRUE(Authentication::SaveResultToHeader(test_result_, &request_headers_));
+  Result fetch_result;
+  EXPECT_TRUE(Authentication::FetchResultFromHeader(request_headers_, &fetch_result));
+  EXPECT_TRUE(TestUtility::protoEqual(test_result_, fetch_result));
+}
+
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -71,6 +71,7 @@ const char AttributeName::kQuotaCacheHit[] = "quota.cache_hit";
 
 // Authentication attributes
 const char AttributeName::kRequestAuthPrincipal[] = "request.auth.principal";
+const char AttributeName::kRequestAuthUser[] = "request.auth.user";
 const char AttributeName::kRequestAuthAudiences[] = "request.auth.audiences";
 const char AttributeName::kRequestAuthPresenter[] = "request.auth.presenter";
 const char AttributeName::kRequestAuthClaims[] = "request.auth.claims";

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -72,6 +72,7 @@ struct AttributeName {
 
   // Authentication attributes
   static const char kRequestAuthPrincipal[];
+  static const char kRequestAuthUser[];
   static const char kRequestAuthAudiences[];
   static const char kRequestAuthPresenter[];
   static const char kRequestAuthClaims[];

--- a/src/istio/control/http/BUILD
+++ b/src/istio/control/http/BUILD
@@ -32,6 +32,7 @@ cc_library(
     deps = [
         "//include/istio/control/http:headers_lib",
         "//src/istio/api_spec:api_spec_lib",
+        "//src/istio/authn:context_proto",
         "//src/istio/control:common_lib",
         "//src/istio/utils:utils_lib",
     ],

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -75,9 +75,9 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
         builder.AddString(AttributeName::kRequestAuthUser, origin.user());
       }
       if (!origin.audiences().empty()) {
-        // TODO(diemtvu): this should be send as repeated field once mixer support string_list
-        // (https://github.com/istio/istio/issues/2802)
-        // For now, just use the first value.
+        // TODO(diemtvu): this should be send as repeated field once mixer
+        // support string_list (https://github.com/istio/istio/issues/2802) For
+        // now, just use the first value.
         builder.AddString(AttributeName::kRequestAuthAudiences,
                           origin.audiences(0));
       }

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -17,6 +17,7 @@
 
 #include "include/istio/utils/attributes_builder.h"
 #include "include/istio/utils/status.h"
+#include "src/istio/authn/context.pb.h"
 #include "src/istio/control/attribute_names.h"
 
 using ::istio::mixer::v1::Attributes;
@@ -57,11 +58,46 @@ void AttributesBuilder::ExtractRequestHeaderAttributes(CheckData *check_data) {
   }
 }
 
-void AttributesBuilder::ExtractRequestAuthAttributes(CheckData *check_data) {
+void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
+  istio::authn::Result authn_result;
+  if (check_data->GetAuthenticationResult(&authn_result)) {
+    utils::AttributesBuilder builder(&request_->attributes);
+    if (!authn_result.principal().empty()) {
+      builder.AddString(AttributeName::kRequestAuthPrincipal,
+                        authn_result.principal());
+    }
+    if (!authn_result.peer_user().empty()) {
+      builder.AddString(AttributeName::kSourceUser, authn_result.peer_user());
+    }
+    if (authn_result.has_origin()) {
+      const auto &origin = authn_result.origin();
+      if (!origin.user().empty()) {
+        builder.AddString(AttributeName::kRequestAuthUser, origin.user());
+      }
+      if (!origin.audiences().empty()) {
+        // TODO(diemtvu): what to do with multiple aud ?. For now, just send the
+        // first one.
+        builder.AddString(AttributeName::kRequestAuthAudiences,
+                          origin.audiences(0));
+      }
+      if (!origin.presenter().empty()) {
+        builder.AddString(AttributeName::kRequestAuthPresenter,
+                          origin.presenter());
+      }
+      if (!origin.claims().empty()) {
+        builder.AddProtobufStringMap(AttributeName::kRequestAuthClaims,
+                                     origin.claims());
+      }
+    }
+    return;
+  }
+
+  // Fallback to extract from jwt filter directly. This can be removed once
+  // authn filter is in place.
   std::map<std::string, std::string> payload;
+  utils::AttributesBuilder builder(&request_->attributes);
   if (check_data->GetJWTPayload(&payload) && !payload.empty()) {
     // Populate auth attributes.
-    utils::AttributesBuilder builder(&request_->attributes);
     if (payload.count("iss") > 0 && payload.count("sub") > 0) {
       builder.AddString(AttributeName::kRequestAuthPrincipal,
                         payload["iss"] + "/" + payload["sub"]);
@@ -74,7 +110,11 @@ void AttributesBuilder::ExtractRequestAuthAttributes(CheckData *check_data) {
     }
     builder.AddStringMap(AttributeName::kRequestAuthClaims, payload);
   }
-}
+  std::string source_user;
+  if (check_data->GetSourceUser(&source_user)) {
+    builder.AddString(AttributeName::kSourceUser, source_user);
+  }
+}  // namespace http
 
 void AttributesBuilder::ExtractForwardedAttributes(CheckData *check_data) {
   std::string forwarded_data;
@@ -90,7 +130,7 @@ void AttributesBuilder::ExtractForwardedAttributes(CheckData *check_data) {
 
 void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
   ExtractRequestHeaderAttributes(check_data);
-  ExtractRequestAuthAttributes(check_data);
+  ExtractAuthAttributes(check_data);
 
   utils::AttributesBuilder builder(&request_->attributes);
 
@@ -102,10 +142,6 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
   }
   builder.AddBool(AttributeName::kConnectionMtls, check_data->IsMutualTLS());
 
-  std::string source_user;
-  if (check_data->GetSourceUser(&source_user)) {
-    builder.AddString(AttributeName::kSourceUser, source_user);
-  }
   builder.AddTimestamp(AttributeName::kRequestTime,
                        std::chrono::system_clock::now());
   builder.AddString(AttributeName::kContextProtocol, "http");

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -75,8 +75,9 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
         builder.AddString(AttributeName::kRequestAuthUser, origin.user());
       }
       if (!origin.audiences().empty()) {
-        // TODO(diemtvu): what to do with multiple aud ?. For now, just send the
-        // first one.
+        // TODO(diemtvu): this should be send as repeated field once mixer support string_list
+        // (https://github.com/istio/istio/issues/2802)
+        // For now, just use the first value.
         builder.AddString(AttributeName::kRequestAuthAudiences,
                           origin.audiences(0));
       }

--- a/src/istio/control/http/attributes_builder.h
+++ b/src/istio/control/http/attributes_builder.h
@@ -44,8 +44,13 @@ class AttributesBuilder {
  private:
   // Extract HTTP header attributes
   void ExtractRequestHeaderAttributes(CheckData* check_data);
-  // Extract authentication attributes for Check call.
-  void ExtractRequestAuthAttributes(CheckData* check_data);
+  // Extract authentication attributes for Check call. Going forward, this
+  // function will use authentication result (from authn filter), which will set
+  // all authenticated attributes (including source_user, request.auth.*).
+  // During the transition (i.e authn filter is not added to sidecar), this
+  // function will also look up the (jwt) payload when authentication result is
+  // not available.
+  void ExtractAuthAttributes(CheckData* check_data);
 
   // The request context object.
   RequestContext* request_;

--- a/src/istio/control/http/mock_check_data.h
+++ b/src/istio/control/http/mock_check_data.h
@@ -41,6 +41,8 @@ class MockCheckData : public CheckData {
                      bool(const std::string &name, std::string *value));
   MOCK_CONST_METHOD1(GetJWTPayload,
                      bool(std::map<std::string, std::string> *payload));
+  MOCK_CONST_METHOD1(GetAuthenticationResult,
+                     bool(istio::authn::Result *result));
   MOCK_CONST_METHOD0(IsMutualTLS, bool());
 };
 

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -32,6 +32,8 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
     builder.AddInt64(AttributeName::kSourcePort, source_port);
   }
 
+  // TODO(diemtvu): add TCP authn filter similar to http case, and use authn
+  // result output here instead.
   std::string source_user;
   if (check_data->GetSourceUser(&source_user)) {
     builder.AddString(AttributeName::kSourceUser, source_user);


### PR DESCRIPTION
The new authn filter will be placed before mixer filter in the filter change. This filter will consolidate identities and attributes from x509 and JWTs (if any) and output the authenticated result into header. Mixer should consume these information for the check request.

For backward compatible (i.e when authn filter is not in used), the code still fallback to fetch attributes directly from X509 and Jwt payload as of today, when result data is not found. This fallback will be removed once authn filter released.

Issue: https://github.com/istio/istio/issues/4337