### PR TITLE
Check quota cache hit

### DIFF
--- a/include/istio/mixerclient/BUILD
+++ b/include/istio/mixerclient/BUILD
@@ -18,6 +18,7 @@ cc_library(
     name = "headers_lib",
     hdrs = [
         "client.h",
+        "check_response.h",
         "environment.h",
         "options.h",
         "timer.h",

--- a/include/istio/mixerclient/check_response.h
+++ b/include/istio/mixerclient/check_response.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef PROXY_CHECK_RESPONSE_H
-#define PROXY_CHECK_RESPONSE_H
+#ifndef ISTIO_MIXERCLIENT_CHECK_RESPONSE_H
+#define ISTIO_MIXERCLIENT_CHECK_RESPONSE_H
 
 #include "google/protobuf/stubs/status.h"
 
@@ -23,22 +23,18 @@ namespace mixerclient {
 
 // The CheckResponseInfo holds response information in detail.
 struct CheckResponseInfo {
-  CheckResponseInfo()
-      : is_check_cache_hit(false),
-        is_quota_cache_hit(false),
-        response_status(::google::protobuf::util::Status::UNKNOWN) {}
-
   // Whether this check response is from cache.
-  bool is_check_cache_hit;
+  bool is_check_cache_hit{false};
 
   // Whether this quota response is from cache.
-  bool is_quota_cache_hit;
+  bool is_quota_cache_hit{false};
 
   // The check and quota response status.
-  ::google::protobuf::util::Status response_status;
+  ::google::protobuf::util::Status response_status{
+      ::google::protobuf::util::Status::UNKNOWN};
 };
 
 }  // namespace mixerclient
 }  // namespace istio
 
-#endif  // PROXY_CHECK_RESPONSE_H
+#endif  // ISTIO_MIXERCLIENT_CHECK_RESPONSE_H

--- a/include/istio/mixerclient/check_response.h
+++ b/include/istio/mixerclient/check_response.h
@@ -1,0 +1,42 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PROXY_CHECK_RESPONSE_H
+#define PROXY_CHECK_RESPONSE_H
+
+#include "google/protobuf/stubs/status.h"
+
+namespace istio {
+namespace mixerclient {
+
+// The CheckResponseInfo holds response information in detail.
+struct CheckResponseInfo {
+  CheckResponseInfo() : is_check_cache_hit(false), is_quota_cache_hit(false),
+      response_status(::google::protobuf::util::Status::UNKNOWN) {}
+
+  // Whether this check response is from cache.
+  bool is_check_cache_hit;
+
+  // Whether this quota response is from cache.
+  bool is_quota_cache_hit;
+
+  // The check and quota response status.
+  ::google::protobuf::util::Status response_status;
+};
+
+}  // namespace mixerclient
+}  // namespace istio
+
+#endif //PROXY_CHECK_RESPONSE_H

--- a/include/istio/mixerclient/check_response.h
+++ b/include/istio/mixerclient/check_response.h
@@ -23,8 +23,10 @@ namespace mixerclient {
 
 // The CheckResponseInfo holds response information in detail.
 struct CheckResponseInfo {
-  CheckResponseInfo() : is_check_cache_hit(false), is_quota_cache_hit(false),
-      response_status(::google::protobuf::util::Status::UNKNOWN) {}
+  CheckResponseInfo()
+      : is_check_cache_hit(false),
+        is_quota_cache_hit(false),
+        response_status(::google::protobuf::util::Status::UNKNOWN) {}
 
   // Whether this check response is from cache.
   bool is_check_cache_hit;
@@ -39,4 +41,4 @@ struct CheckResponseInfo {
 }  // namespace mixerclient
 }  // namespace istio
 
-#endif //PROXY_CHECK_RESPONSE_H
+#endif  // PROXY_CHECK_RESPONSE_H

--- a/include/istio/mixerclient/client.h
+++ b/include/istio/mixerclient/client.h
@@ -87,7 +87,7 @@ class MixerClient {
   virtual CancelFunc Check(
       const ::istio::mixer::v1::Attributes& attributes,
       const std::vector<::istio::quota_config::Requirement>& quotas,
-      TransportCheckFunc transport, DoneFunc on_done) = 0;
+      TransportCheckFunc transport, CheckDoneFunc on_done) = 0;
 
   // A report call.
   virtual void Report(const ::istio::mixer::v1::Attributes& attributes) = 0;

--- a/include/istio/mixerclient/environment.h
+++ b/include/istio/mixerclient/environment.h
@@ -16,6 +16,7 @@
 #ifndef ISTIO_MIXERCLIENT_ENVIRONMENT_H
 #define ISTIO_MIXERCLIENT_ENVIRONMENT_H
 
+#include "check_response.h"
 #include "google/protobuf/stubs/status.h"
 #include "mixer/v1/service.pb.h"
 #include "timer.h"
@@ -27,6 +28,10 @@ namespace mixerclient {
 // is completed.
 // Uses UNAVAILABLE status code to indicate network failure.
 using DoneFunc = std::function<void(const ::google::protobuf::util::Status&)>;
+
+// Defines a function prototype used when an asynchronous transport call is
+// completed, and passes response information in CheckResponse.
+using CheckDoneFunc = std::function<void(const CheckResponseInfo&)>;
 
 // Defines a function prototype used to cancel an asynchronous transport call.
 using CancelFunc = std::function<void()>;

--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -65,6 +65,10 @@ const char AttributeName::kContextTime[] = "context.time";
 const char AttributeName::kCheckErrorCode[] = "check.error_code";
 const char AttributeName::kCheckErrorMessage[] = "check.error_message";
 
+// Check and Quota cache hit
+const char AttributeName::kCheckCacheHit[] = "check.cache_hit";
+const char AttributeName::kQuotaCacheHit[] = "quota.cache_hit";
+
 // Authentication attributes
 const char AttributeName::kRequestAuthPrincipal[] = "request.auth.principal";
 const char AttributeName::kRequestAuthAudiences[] = "request.auth.audiences";

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -66,6 +66,10 @@ struct AttributeName {
   static const char kCheckErrorCode[];
   static const char kCheckErrorMessage[];
 
+  // Check and Quota cache hit
+  static const char kCheckCacheHit[];
+  static const char kQuotaCacheHit[];
+
   // Authentication attributes
   static const char kRequestAuthPrincipal[];
   static const char kRequestAuthAudiences[];

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -28,6 +28,7 @@ using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::config::client::HttpClientConfig;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::mixerclient::CancelFunc;
+using ::istio::mixerclient::CheckDoneFunc;
 using ::istio::mixerclient::DoneFunc;
 using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
@@ -179,7 +180,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["per-route-key"].string_value(), "per-route-value");
@@ -207,7 +208,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["route0-key"].string_value(), "route0-value");
@@ -236,7 +237,7 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["route1-key"].string_value(), "route1-value");
@@ -259,7 +260,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteQuota) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(quotas.size(), 1);
@@ -301,7 +302,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteApiSpec) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["api.name"].string_value(), "test-name");
@@ -361,7 +362,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultApiKey) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map[AttributeName::kRequestApiKey].string_value(),
                   "test-api-key");

--- a/src/istio/control/mock_mixer_client.h
+++ b/src/istio/control/mock_mixer_client.h
@@ -30,7 +30,7 @@ class MockMixerClient : public ::istio::mixerclient::MixerClient {
                  const ::istio::mixer::v1::Attributes& attributes,
                  const std::vector<::istio::quota_config::Requirement>& quotas,
                  ::istio::mixerclient::TransportCheckFunc transport,
-                 ::istio::mixerclient::DoneFunc on_done));
+                 ::istio::mixerclient::CheckDoneFunc on_done));
   MOCK_METHOD1(Report, void(const ::istio::mixer::v1::Attributes& attributes));
   MOCK_CONST_METHOD1(GetStatistics,
                      void(::istio::mixerclient::Statistics* stat));

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -24,6 +24,7 @@ using ::google::protobuf::util::Status;
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::config::client::TcpClientConfig;
 using ::istio::mixerclient::CancelFunc;
+using ::istio::mixerclient::CheckDoneFunc;
 using ::istio::mixerclient::DoneFunc;
 using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
@@ -85,7 +86,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
       .WillOnce(Invoke([](const Attributes& attributes,
                           const std::vector<Requirement>& quotas,
                           TransportCheckFunc transport,
-                          DoneFunc on_done) -> CancelFunc {
+                          CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
         EXPECT_EQ(map["key1"].string_value(), "value1");
         EXPECT_EQ(quotas.size(), 1);

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -61,12 +61,12 @@ CancelFunc MixerClientImpl::Check(
       new CheckCache::CheckResult);
   check_cache_->Check(attributes, check_result.get());
 
-  std::unique_ptr<CheckResponseInfo> check_response_info(new CheckResponseInfo);
-  check_response_info->is_check_cache_hit = check_result->IsCacheHit();
-  check_response_info->response_status = check_result->status();
+  CheckResponseInfo check_response_info;
+  check_response_info.is_check_cache_hit = check_result->IsCacheHit();
+  check_response_info.response_status = check_result->status();
 
   if (check_result->IsCacheHit() && !check_result->status().ok()) {
-    on_done(*check_response_info);
+    on_done(check_response_info);
     return nullptr;
   }
 
@@ -83,10 +83,10 @@ CancelFunc MixerClientImpl::Check(
 
   CheckRequest request;
   bool quota_call = quota_result->BuildRequest(&request);
-  check_response_info->is_quota_cache_hit = quota_result->IsCacheHit();
-  check_response_info->response_status = check_result->status();
+  check_response_info.is_quota_cache_hit = quota_result->IsCacheHit();
+  check_response_info.response_status = check_result->status();
   if (check_result->IsCacheHit() && quota_result->IsCacheHit()) {
-    on_done(*check_response_info);
+    on_done(check_response_info);
     on_done = nullptr;
     if (!quota_call) {
       return nullptr;
@@ -126,16 +126,13 @@ CancelFunc MixerClientImpl::Check(
         raw_check_result->SetResponse(status, *request_copy, *response);
         raw_quota_result->SetResponse(status, *request_copy, *response);
         CheckResponseInfo check_response_info;
-        check_response_info.is_check_cache_hit = false;
-        check_response_info.is_quota_cache_hit = false;
         if (on_done) {
           if (!raw_check_result->status().ok()) {
             check_response_info.response_status = raw_check_result->status();
-            on_done(check_response_info);
           } else {
             check_response_info.response_status = raw_quota_result->status();
-            on_done(check_response_info);
           }
+          on_done(check_response_info);
         }
         delete raw_check_result;
         delete raw_quota_result;

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #include "src/istio/mixerclient/client_impl.h"
+#include "include/istio/mixerclient/check_response.h"
 #include "include/istio/utils/protobuf.h"
 
 using ::google::protobuf::util::Status;
@@ -53,14 +54,19 @@ MixerClientImpl::~MixerClientImpl() {}
 CancelFunc MixerClientImpl::Check(
     const Attributes &attributes,
     const std::vector<::istio::quota_config::Requirement> &quotas,
-    TransportCheckFunc transport, DoneFunc on_done) {
+    TransportCheckFunc transport, CheckDoneFunc on_done) {
   ++total_check_calls_;
 
   std::unique_ptr<CheckCache::CheckResult> check_result(
       new CheckCache::CheckResult);
   check_cache_->Check(attributes, check_result.get());
+
+  std::unique_ptr<CheckResponseInfo> check_response_info(new CheckResponseInfo);
+  check_response_info->is_check_cache_hit = check_result->IsCacheHit();
+  check_response_info->response_status = check_result->status();
+
   if (check_result->IsCacheHit() && !check_result->status().ok()) {
-    on_done(check_result->status());
+    on_done(*check_response_info);
     return nullptr;
   }
 
@@ -77,8 +83,10 @@ CancelFunc MixerClientImpl::Check(
 
   CheckRequest request;
   bool quota_call = quota_result->BuildRequest(&request);
+  check_response_info->is_quota_cache_hit = quota_result->IsCacheHit();
+  check_response_info->response_status = check_result->status();
   if (check_result->IsCacheHit() && quota_result->IsCacheHit()) {
-    on_done(quota_result->status());
+    on_done(*check_response_info);
     on_done = nullptr;
     if (!quota_call) {
       return nullptr;
@@ -117,11 +125,16 @@ CancelFunc MixerClientImpl::Check(
        on_done](const Status &status) {
         raw_check_result->SetResponse(status, *request_copy, *response);
         raw_quota_result->SetResponse(status, *request_copy, *response);
+        CheckResponseInfo check_response_info;
+        check_response_info.is_check_cache_hit = false;
+        check_response_info.is_quota_cache_hit = false;
         if (on_done) {
           if (!raw_check_result->status().ok()) {
-            on_done(raw_check_result->status());
+            check_response_info.response_status = raw_check_result->status();
+            on_done(check_response_info);
           } else {
-            on_done(raw_quota_result->status());
+            check_response_info.response_status = raw_quota_result->status();
+            on_done(check_response_info);
           }
         }
         delete raw_check_result;

--- a/src/istio/mixerclient/client_impl.h
+++ b/src/istio/mixerclient/client_impl.h
@@ -38,7 +38,7 @@ class MixerClientImpl : public MixerClient {
   CancelFunc Check(
       const ::istio::mixer::v1::Attributes& attributes,
       const std::vector<::istio::quota_config::Requirement>& quotas,
-      TransportCheckFunc transport, DoneFunc on_done) override;
+      TransportCheckFunc transport, CheckDoneFunc on_done) override;
   void Report(const ::istio::mixer::v1::Attributes& attributes) override;
 
   void GetStatistics(Statistics* stat) const override;

--- a/src/istio/mixerclient/client_impl_test.cc
+++ b/src/istio/mixerclient/client_impl_test.cc
@@ -15,6 +15,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "include/istio/mixerclient/check_response.h"
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "src/istio/mixerclient/status_test_util.h"
@@ -24,6 +25,7 @@ using ::google::protobuf::util::error::Code;
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::CheckRequest;
 using ::istio::mixer::v1::CheckResponse;
+using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::quota_config::Requirement;
 using ::testing::Invoke;
 using ::testing::_;
@@ -81,17 +83,22 @@ TEST_F(MixerClientImplTest, TestSuccessCheck) {
 
   // Not to test quota
   std::vector<Requirement> empty_quotas;
-  Status done_status = Status::UNKNOWN;
+  CheckResponseInfo check_response_info;
   client_->Check(request_, empty_quotas, empty_transport_,
-                 [&done_status](Status status) { done_status = status; });
-  EXPECT_TRUE(done_status.ok());
+                 [&check_response_info](const CheckResponseInfo& info) {
+                   check_response_info.response_status = info.response_status;
+                 });
+  EXPECT_TRUE(check_response_info.response_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls should be cached.
-    Status done_status1 = Status::UNKNOWN;
+    CheckResponseInfo check_response_info1;
     client_->Check(request_, empty_quotas, empty_transport_,
-                   [&done_status1](Status status) { done_status1 = status; });
-    EXPECT_TRUE(done_status1.ok());
+                   [&check_response_info1](const CheckResponseInfo& info) {
+                     check_response_info1.response_status =
+                         info.response_status;
+                   });
+    EXPECT_TRUE(check_response_info1.response_status.ok());
   }
 
   Statistics stat;
@@ -121,17 +128,22 @@ TEST_F(MixerClientImplTest, TestPerRequestTransport) {
 
   // Not to test quota
   std::vector<Requirement> empty_quotas;
-  Status done_status = Status::UNKNOWN;
+  CheckResponseInfo check_response_info;
   client_->Check(request_, empty_quotas, local_check_transport.GetFunc(),
-                 [&done_status](Status status) { done_status = status; });
-  EXPECT_TRUE(done_status.ok());
+                 [&check_response_info](const CheckResponseInfo& info) {
+                   check_response_info.response_status = info.response_status;
+                 });
+  EXPECT_TRUE(check_response_info.response_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls should be cached.
-    Status done_status1 = Status::UNKNOWN;
+    CheckResponseInfo check_response_info1;
     client_->Check(request_, empty_quotas, local_check_transport.GetFunc(),
-                   [&done_status1](Status status) { done_status1 = status; });
-    EXPECT_TRUE(done_status1.ok());
+                   [&check_response_info1](const CheckResponseInfo& info) {
+                     check_response_info1.response_status =
+                         info.response_status;
+                   });
+    EXPECT_TRUE(check_response_info1.response_status.ok());
   }
 
   Statistics stat;
@@ -162,17 +174,22 @@ TEST_F(MixerClientImplTest, TestNoCheckCache) {
         on_done(Status::OK);
       }));
 
-  Status done_status = Status::UNKNOWN;
+  CheckResponseInfo check_response_info;
   client_->Check(request_, quotas_, empty_transport_,
-                 [&done_status](Status status) { done_status = status; });
-  EXPECT_TRUE(done_status.ok());
+                 [&check_response_info](const CheckResponseInfo& info) {
+                   check_response_info.response_status = info.response_status;
+                 });
+  EXPECT_TRUE(check_response_info.response_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls are not cached.
-    Status done_status1 = Status::UNKNOWN;
+    CheckResponseInfo check_response_info1;
     client_->Check(request_, quotas_, empty_transport_,
-                   [&done_status1](Status status) { done_status1 = status; });
-    EXPECT_TRUE(done_status1.ok());
+                   [&check_response_info1](const CheckResponseInfo& info) {
+                     check_response_info1.response_status =
+                         info.response_status;
+                   });
+    EXPECT_TRUE(check_response_info1.response_status.ok());
   }
   // Call count 11 since check is not cached.
   EXPECT_EQ(call_counts, 11);
@@ -203,17 +220,22 @@ TEST_F(MixerClientImplTest, TestNoQuotaCache) {
         on_done(Status::OK);
       }));
 
-  Status done_status = Status::UNKNOWN;
+  CheckResponseInfo check_response_info;
   client_->Check(request_, quotas_, empty_transport_,
-                 [&done_status](Status status) { done_status = status; });
-  EXPECT_TRUE(done_status.ok());
+                 [&check_response_info](const CheckResponseInfo& info) {
+                   check_response_info.response_status = info.response_status;
+                 });
+  EXPECT_TRUE(check_response_info.response_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls should be cached.
-    Status done_status1 = Status::UNKNOWN;
+    CheckResponseInfo check_response_info1;
     client_->Check(request_, quotas_, empty_transport_,
-                   [&done_status1](Status status) { done_status1 = status; });
-    EXPECT_TRUE(done_status1.ok());
+                   [&check_response_info1](const CheckResponseInfo& info) {
+                     check_response_info1.response_status =
+                         info.response_status;
+                   });
+    EXPECT_TRUE(check_response_info1.response_status.ok());
   }
   // Call count 11 since quota is not cached.
   EXPECT_EQ(call_counts, 11);
@@ -242,17 +264,22 @@ TEST_F(MixerClientImplTest, TestSuccessCheckAndQuota) {
         on_done(Status::OK);
       }));
 
-  Status done_status = Status::UNKNOWN;
+  CheckResponseInfo check_response_info;
   client_->Check(request_, quotas_, empty_transport_,
-                 [&done_status](Status status) { done_status = status; });
-  EXPECT_TRUE(done_status.ok());
+                 [&check_response_info](const CheckResponseInfo& info) {
+                   check_response_info.response_status = info.response_status;
+                 });
+  EXPECT_TRUE(check_response_info.response_status.ok());
 
   for (int i = 0; i < 10; i++) {
     // Other calls should be cached.
-    Status done_status1 = Status::UNKNOWN;
+    CheckResponseInfo check_response_info1;
     client_->Check(request_, quotas_, empty_transport_,
-                   [&done_status1](Status status) { done_status1 = status; });
-    EXPECT_TRUE(done_status1.ok());
+                   [&check_response_info1](const CheckResponseInfo& info) {
+                     check_response_info1.response_status =
+                         info.response_status;
+                   });
+    EXPECT_TRUE(check_response_info1.response_status.ok());
   }
   // Call count should be less than 4
   EXPECT_LE(call_counts, 3);
@@ -282,17 +309,24 @@ TEST_F(MixerClientImplTest, TestFailedCheckAndQuota) {
         on_done(Status::OK);
       }));
 
-  Status done_status = Status::UNKNOWN;
+  CheckResponseInfo check_response_info;
   client_->Check(request_, quotas_, empty_transport_,
-                 [&done_status](Status status) { done_status = status; });
-  EXPECT_ERROR_CODE(Code::FAILED_PRECONDITION, done_status);
+                 [&check_response_info](const CheckResponseInfo& info) {
+                   check_response_info.response_status = info.response_status;
+                 });
+  EXPECT_ERROR_CODE(Code::FAILED_PRECONDITION,
+                    check_response_info.response_status);
 
   for (int i = 0; i < 10; i++) {
     // Other calls should be cached.
-    Status done_status1 = Status::UNKNOWN;
+    CheckResponseInfo check_response_info1;
     client_->Check(request_, quotas_, empty_transport_,
-                   [&done_status1](Status status) { done_status1 = status; });
-    EXPECT_ERROR_CODE(Code::FAILED_PRECONDITION, done_status1);
+                   [&check_response_info1](const CheckResponseInfo& info) {
+                     check_response_info1.response_status =
+                         info.response_status;
+                   });
+    EXPECT_ERROR_CODE(Code::FAILED_PRECONDITION,
+                      check_response_info1.response_status);
   }
   Statistics stat;
   client_->GetStatistics(&stat);


### PR DESCRIPTION
**What this PR does / why we need it**: When Check() is enabled, Mixer filter sends attributes check.cache_hit and quota.cache_hit in Report() call. When Check() is disabled, Mixer filter does not send these attributes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1181 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
