### PR TITLE
Add the allow_missing_or_failed option to jwt-auth

### DIFF
--- a/src/envoy/http/jwt_auth/config.proto
+++ b/src/envoy/http/jwt_auth/config.proto
@@ -191,4 +191,11 @@ message AuthFilterConfig {
   //      path_exact: /healthz
   //
   repeated HttpPattern bypass_jwt = 3;
+
+  // From
+  // https://github.com/envoyproxy/data-plane-api/blob/11c750628bcaeeeca3f72f89fe5c99921aa727b1/envoy/config/filter/http/jwt_authn/v2alpha/config.proto
+  // If true, the request is allowed if JWT is missing or JWT verification
+  // fails. Default is false, a request without JWT or failed JWT verification
+  // is not allowed.
+  bool allow_missing_or_failed = 4;
 }

--- a/src/envoy/http/jwt_auth/config.proto
+++ b/src/envoy/http/jwt_auth/config.proto
@@ -197,5 +197,7 @@ message AuthFilterConfig {
   // If true, the request is allowed if JWT is missing or JWT verification
   // fails. Default is false, a request without JWT or failed JWT verification
   // is not allowed.
+  // Note: in current implementation, if token is not there, no rejection (401
+  // code) is sent.
   bool allow_missing_or_failed = 4;
 }

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -28,7 +28,7 @@ namespace Http {
 
 JwtVerificationFilter::JwtVerificationFilter(Upstream::ClusterManager& cm,
                                              JwtAuth::JwtAuthStore& store)
-    : jwt_auth_(cm, store) {}
+    : jwt_auth_(cm, store), store_(store) {}
 
 JwtVerificationFilter::~JwtVerificationFilter() {}
 
@@ -61,7 +61,8 @@ void JwtVerificationFilter::onDone(const JwtAuth::Status& status) {
   if (state_ == Responded) {
     return;
   }
-  if (status != JwtAuth::Status::OK) {
+  if (status != JwtAuth::Status::OK &&
+      !store_.config().allow_missing_or_failed()) {
     state_ = Responded;
     // verification failed
     Code code = Code(401);  // Unauthorized

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -28,7 +28,8 @@ namespace Http {
 
 JwtVerificationFilter::JwtVerificationFilter(Upstream::ClusterManager& cm,
                                              JwtAuth::JwtAuthStore& store)
-    : jwt_auth_(cm, store), store_(store) {}
+    : jwt_auth_(cm, store),
+      allow_missing_or_failed_(store.config().allow_missing_or_failed()) {}
 
 JwtVerificationFilter::~JwtVerificationFilter() {}
 
@@ -61,8 +62,7 @@ void JwtVerificationFilter::onDone(const JwtAuth::Status& status) {
   if (state_ == Responded) {
     return;
   }
-  if (status != JwtAuth::Status::OK &&
-      !store_.config().allow_missing_or_failed()) {
+  if (status != JwtAuth::Status::OK && !allow_missing_or_failed_) {
     state_ = Responded;
     // verification failed
     Code code = Code(401);  // Unauthorized

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -28,8 +28,7 @@ namespace Http {
 
 JwtVerificationFilter::JwtVerificationFilter(Upstream::ClusterManager& cm,
                                              JwtAuth::JwtAuthStore& store)
-    : jwt_auth_(cm, store),
-      allow_missing_or_failed_(store.config().allow_missing_or_failed()) {}
+    : jwt_auth_(cm, store) {}
 
 JwtVerificationFilter::~JwtVerificationFilter() {}
 
@@ -62,7 +61,7 @@ void JwtVerificationFilter::onDone(const JwtAuth::Status& status) {
   if (state_ == Responded) {
     return;
   }
-  if (status != JwtAuth::Status::OK && !allow_missing_or_failed_) {
+  if (status != JwtAuth::Status::OK) {
     state_ = Responded;
     // verification failed
     Code code = Code(401);  // Unauthorized

--- a/src/envoy/http/jwt_auth/http_filter.h
+++ b/src/envoy/http/jwt_auth/http_filter.h
@@ -51,9 +51,8 @@ class JwtVerificationFilter : public StreamDecoderFilter,
   StreamDecoderFilterCallbacks* decoder_callbacks_;
   // The auth object.
   JwtAuth::JwtAuthenticator jwt_auth_;
-  // The auth store object, which can be used to get the config
-  JwtAuth::JwtAuthStore& store_;
-
+  // The allow_missing_or_failed option in the jwt_auth config
+  bool allow_missing_or_failed_ = false;
   // The state of the request
   enum State { Init, Calling, Responded, Complete };
   State state_ = Init;

--- a/src/envoy/http/jwt_auth/http_filter.h
+++ b/src/envoy/http/jwt_auth/http_filter.h
@@ -51,6 +51,8 @@ class JwtVerificationFilter : public StreamDecoderFilter,
   StreamDecoderFilterCallbacks* decoder_callbacks_;
   // The auth object.
   JwtAuth::JwtAuthenticator jwt_auth_;
+  // The auth store object, which can be used to get the config
+  JwtAuth::JwtAuthStore& store_;
 
   // The state of the request
   enum State { Init, Calling, Responded, Complete };

--- a/src/envoy/http/jwt_auth/http_filter.h
+++ b/src/envoy/http/jwt_auth/http_filter.h
@@ -51,8 +51,6 @@ class JwtVerificationFilter : public StreamDecoderFilter,
   StreamDecoderFilterCallbacks* decoder_callbacks_;
   // The auth object.
   JwtAuth::JwtAuthenticator jwt_auth_;
-  // The allow_missing_or_failed option in the jwt_auth config
-  bool allow_missing_or_failed_ = false;
   // The state of the request
   enum State { Init, Calling, Responded, Complete };
   State state_ = Init;

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -227,6 +227,9 @@ bool JwtAuthenticator::OkToBypass() {
 void JwtAuthenticator::DoneWithStatus(const Status& status) {
   ENVOY_LOG(debug, "Jwt authentication completed with: {}",
             JwtAuth::StatusToString(status));
+  ENVOY_LOG(debug,
+            "The value of allow_missing_or_failed in AuthFilterConfig is: {}",
+            store_.config().allow_missing_or_failed());
   if (store_.config().allow_missing_or_failed()) {
     callback_->onDone(JwtAuth::Status::OK);
   } else {

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -227,7 +227,11 @@ bool JwtAuthenticator::OkToBypass() {
 void JwtAuthenticator::DoneWithStatus(const Status& status) {
   ENVOY_LOG(debug, "Jwt authentication completed with: {}",
             JwtAuth::StatusToString(status));
-  callback_->onDone(status);
+  if (store_.config().allow_missing_or_failed()) {
+    callback_->onDone(JwtAuth::Status::OK);
+  } else {
+    callback_->onDone(status);
+  }
   callback_ = nullptr;
 }
 

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -472,6 +472,7 @@ TEST_F(JwtAuthenticatorTest, TestMissedJWT) {
 }
 
 TEST_F(JwtAuthenticatorTest, TestAllowMissingOrFailedIsTrue) {
+  // When JWT is missing from the config, the status should be OK
   SetupConfig(kExampleConfigWithAllowMissingOrFailed);
   EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
   EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -114,6 +114,29 @@ const char kExampleConfigWithAllowMissingOrFailed[] = R"(
 }
 )";
 
+// An example JSON config with a good JWT config and allow_missing_or_failed
+// option enabled
+const char kExampleConfigWithJwtAndAllowMissingOrFailed[] = R"(
+{
+   "jwts": [
+      {
+         "issuer": "https://example.com",
+         "audiences": [
+            "example_service",
+            "http://example_service1",
+            "https://example_service2/"
+          ],
+         "jwks_uri": "https://pubkey_server/pubkey_path",
+         "jwks_uri_envoy_cluster": "pubkey_cluster",
+         "public_key_cache_duration": {
+            "seconds": 600
+         }
+      }
+   ],
+  "allow_missing_or_failed": true
+}
+)";
+
 // A JSON config for "other_issuer"
 const char kOtherIssuerConfig[] = R"(
 {
@@ -488,7 +511,7 @@ TEST_F(JwtAuthenticatorTest, TestAllowMissingOrFailedIsTrue) {
 TEST_F(JwtAuthenticatorTest, TestInValidJwtWhenAllowMissingOrFailedIsTrue) {
   // In this test, when JWT is invalid, the status should still be OK
   // because allow_missing_or_failed is true.
-  SetupConfig(kExampleConfigWithAllowMissingOrFailed);
+  SetupConfig(kExampleConfigWithJwtAndAllowMissingOrFailed);
   EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
   EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {
     ASSERT_EQ(status, Status::OK);

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -472,7 +472,8 @@ TEST_F(JwtAuthenticatorTest, TestMissedJWT) {
 }
 
 TEST_F(JwtAuthenticatorTest, TestAllowMissingOrFailedIsTrue) {
-  // When JWT is missing from the config, the status should be OK
+  // In this test, when JWT is missing, the status should still be OK
+  // because allow_missing_or_failed is true.
   SetupConfig(kExampleConfigWithAllowMissingOrFailed);
   EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
   EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -107,13 +107,6 @@ const char kExampleConfig[] = R"(
 }
 )";
 
-// An example JSON config with allow_missing_or_failed option enabled
-const char kExampleConfigWithAllowMissingOrFailed[] = R"(
-{
-  "allow_missing_or_failed": true
-}
-)";
-
 // An example JSON config with a good JWT config and allow_missing_or_failed
 // option enabled
 const char kExampleConfigWithJwtAndAllowMissingOrFailed[] = R"(
@@ -494,10 +487,10 @@ TEST_F(JwtAuthenticatorTest, TestMissedJWT) {
   auth_->Verify(headers, &mock_cb_);
 }
 
-TEST_F(JwtAuthenticatorTest, TestAllowMissingOrFailedIsTrue) {
+TEST_F(JwtAuthenticatorTest, TestMissingJwtWhenAllowMissingOrFailedIsTrue) {
   // In this test, when JWT is missing, the status should still be OK
   // because allow_missing_or_failed is true.
-  SetupConfig(kExampleConfigWithAllowMissingOrFailed);
+  SetupConfig(kExampleConfigWithJwtAndAllowMissingOrFailed);
   EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
   EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {
     ASSERT_EQ(status, Status::OK);

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -485,6 +485,20 @@ TEST_F(JwtAuthenticatorTest, TestAllowMissingOrFailedIsTrue) {
   auth_->Verify(headers, &mock_cb_);
 }
 
+TEST_F(JwtAuthenticatorTest, TestInValidJwtWhenAllowMissingOrFailedIsTrue) {
+  // In this test, when JWT is invalid, the status should still be OK
+  // because allow_missing_or_failed is true.
+  SetupConfig(kExampleConfigWithAllowMissingOrFailed);
+  EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
+  EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {
+    ASSERT_EQ(status, Status::OK);
+  }));
+
+  std::string token = "invalidToken";
+  auto headers = TestHeaderMapImpl{{"Authorization", "Bearer " + token}};
+  auth_->Verify(headers, &mock_cb_);
+}
+
 TEST_F(JwtAuthenticatorTest, TestBypassJWT) {
   SetupConfig(kBypassConfig);
 

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -107,6 +107,13 @@ const char kExampleConfig[] = R"(
 }
 )";
 
+// An example JSON config with allow_missing_or_failed option enabled
+const char kExampleConfigWithAllowMissingOrFailed[] = R"(
+{
+  "allow_missing_or_failed": true
+}
+)";
+
 // A JSON config for "other_issuer"
 const char kOtherIssuerConfig[] = R"(
 {
@@ -457,6 +464,18 @@ TEST_F(JwtAuthenticatorTest, TestMissedJWT) {
   EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
   EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {
     ASSERT_EQ(status, Status::JWT_MISSED);
+  }));
+
+  // Empty headers.
+  auto headers = TestHeaderMapImpl{};
+  auth_->Verify(headers, &mock_cb_);
+}
+
+TEST_F(JwtAuthenticatorTest, TestAllowMissingOrFailedIsTrue) {
+  SetupConfig(kExampleConfigWithAllowMissingOrFailed);
+  EXPECT_CALL(mock_cm_, httpAsyncClientForCluster(_)).Times(0);
+  EXPECT_CALL(mock_cb_, onDone(_)).WillOnce(Invoke([](const Status &status) {
+    ASSERT_EQ(status, Status::OK);
   }));
 
   // Empty headers.


### PR DESCRIPTION
**What this PR does / why we need it**: Add the allow_missing_or_failed option to jwt-auth so jwt-auth won't return 401 when jwt is missing or the jwt authentication fails.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1212 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
