### PR TITLE
Use StopIterationAndWatermark instead of StopIterationAndBuffer

### DIFF
--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -90,7 +90,7 @@ FilterDataStatus AuthenticationFilter::decodeData(Buffer::Instance&, bool) {
             "Called AuthenticationFilter : {} FilterDataStatus::Continue;",
             __FUNCTION__);
   if (state_ == State::PROCESSING) {
-    return FilterDataStatus::StopIterationAndBuffer;
+    return FilterDataStatus::StopIterationAndWatermark;
   }
   return FilterDataStatus::Continue;
 }

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -80,7 +80,7 @@ void JwtVerificationFilter::onDone(const JwtAuth::Status& status) {
 FilterDataStatus JwtVerificationFilter::decodeData(Buffer::Instance&, bool) {
   ENVOY_LOG(debug, "Called JwtVerificationFilter : {}", __func__);
   if (state_ == Calling) {
-    return FilterDataStatus::StopIterationAndBuffer;
+    return FilterDataStatus::StopIterationAndWatermark;
   }
   return FilterDataStatus::Continue;
 }

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -133,7 +133,7 @@ FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {} ({}, {})", __func__,
             data.length(), end_stream);
   if (state_ == Calling) {
-    return FilterDataStatus::StopIterationAndBuffer;
+    return FilterDataStatus::StopIterationAndWatermark;
   }
   return FilterDataStatus::Continue;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:Do not buffer request body during Mixer Check() call. This is to avoid buffer overflow when POST request has large body and Mixer filter is waiting for Check() response.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1315 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
