### PR TITLE
Sanitize JWT verification result in HTTP headers

### DIFF
--- a/src/envoy/http/jwt_auth/BUILD
+++ b/src/envoy/http/jwt_auth/BUILD
@@ -97,6 +97,7 @@ envoy_cc_test(
     srcs = [":integration_test/http_filter_integration_test.cc"],
     data = [
         "integration_test/envoy.conf.jwk",
+        "integration_test/envoy_allow_missing_or_failed_jwt.conf.jwk",
     ],
     repository = "@envoy",
     deps = [

--- a/src/envoy/http/jwt_auth/integration_test/envoy_allow_missing_or_failed_jwt.conf.jwk
+++ b/src/envoy/http/jwt_auth/integration_test/envoy_allow_missing_or_failed_jwt.conf.jwk
@@ -1,0 +1,97 @@
+{
+  "listeners": [
+    {
+      "address": "tcp://{{ ip_loopback_address }}:0",
+      "bind_to_port": true,
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "ingress_http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "backend",
+                  "domains": ["*"],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "service1"
+                    }
+                  ]
+                }
+              ]
+            },
+            "access_log": [
+              {
+                "path": "/dev/null"
+              }
+            ],
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "jwt-auth",
+                "config": {
+                   "jwts": [
+                     {
+                        "issuer": "https://example.com",
+                        "audiences": [
+                           "example_service"
+                         ],
+                        "jwks_uri": "http://example.com/foobar_cert",
+                        "jwks_uri_envoy_cluster": "example_issuer"
+                     }
+                   ],
+                   "allow_missing_or_failed": true
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": "tcp://{{ ip_loopback_address }}:0"
+  },
+  "cluster_manager": {
+    "clusters": [
+      {
+        "name": "service1",
+        "connect_timeout_ms": 5000,
+        "type": "static",
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://{{ ip_loopback_address }}:{{ upstream_0 }}"
+          }
+        ]
+      },
+      {
+        "name": "example_issuer",
+        "connect_timeout_ms": 5000,
+        "type": "static",
+      	"circuit_breakers": {
+         "default": {
+          "max_pending_requests": 10000,
+          "max_requests": 10000
+         }
+      	},
+        "lb_type": "round_robin",
+        "hosts": [
+          {
+            "url": "tcp://{{ ip_loopback_address }}:{{ upstream_1 }}"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/envoy/http/jwt_auth/integration_test/http_filter_integration_test.cc
+++ b/src/envoy/http/jwt_auth/integration_test/http_filter_integration_test.cc
@@ -18,6 +18,17 @@
 
 namespace Envoy {
 
+namespace {
+// The HTTP header key for the JWT verification result
+const Http::LowerCaseString kJwtVerificationResultHeaderKey(
+    "sec-istio-auth-userinfo");
+// {"iss":"https://example.com","sub":"test@example.com","aud":"example_service","exp":2001001001}
+const std::string kJwtVerificationResult =
+    "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVz"
+    "dEBleGFtcGxlLmNvbSIsImF1ZCI6ImV4YW1wbGVfc2VydmljZSIs"
+    "ImV4cCI6MjAwMTAwMTAwMX0";
+}  // namespace
+
 // Base class JWT filter integration tests.
 class JwtVerificationFilterIntegrationTest
     : public HttpIntegrationTest,
@@ -329,6 +340,56 @@ TEST_P(JwtVerificationFilterIntegrationTestWithJwks, Fail1) {
   TestVerification(createHeaders(token), "", createIssuerHeaders(), pubkey,
                    false, Http::TestHeaderMapImpl{{":status", "401"}},
                    "JWT_BAD_FORMAT");
+}
+
+class JwtVerificationFilterIntegrationTestWithInjectedJwtResult
+    : public JwtVerificationFilterIntegrationTestWithJwks {
+  // With allow_missing_or_failed option being true,
+  // a request without JWT will reach the backend.
+  // This is to test the injected JWT result.
+  std::string ConfigPath() override {
+    return "src/envoy/http/jwt_auth/integration_test/"
+           "envoy_allow_missing_or_failed_jwt.conf.jwk";
+  }
+};
+
+INSTANTIATE_TEST_CASE_P(
+    IpVersions, JwtVerificationFilterIntegrationTestWithInjectedJwtResult,
+    testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(JwtVerificationFilterIntegrationTestWithInjectedJwtResult,
+       InjectedJwtResultSanitized) {
+  // Issuer is not called by passing empty pubkey.
+  std::string pubkey = "";
+  // A request without JWT
+  auto headers = BaseRequestHeaders();
+  // Inject a header of JWT verification result
+  headers.addCopy(kJwtVerificationResultHeaderKey, kJwtVerificationResult);
+
+  IntegrationCodecClientPtr codec_client;
+  FakeHttpConnectionPtr fake_upstream_connection_backend;
+  IntegrationStreamDecoderPtr response(
+      new IntegrationStreamDecoder(*dispatcher_));
+  FakeStreamPtr request_stream_backend;
+  codec_client = makeHttpConnection(lookupPort("http"));
+  // Send a request to Envoy.
+  codec_client->makeHeaderOnlyRequest(headers, *response);
+  fake_upstream_connection_backend =
+      fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
+  request_stream_backend =
+      fake_upstream_connection_backend->waitForNewStream(*dispatcher_);
+  request_stream_backend->waitForEndStream(*dispatcher_);
+  EXPECT_TRUE(request_stream_backend->complete());
+
+  // With sanitization, the headers received by the backend should not
+  // contain the injected JWT verification header.
+  EXPECT_TRUE(request_stream_backend->headers().get(
+                  kJwtVerificationResultHeaderKey) == nullptr);
+
+  response->waitForEndStream();
+  codec_client->close();
+  fake_upstream_connection_backend->close();
+  fake_upstream_connection_backend->waitForDisconnect();
 }
 
 }  // namespace Envoy


### PR DESCRIPTION
**What this PR does / why we need it**: To defend the attack of injecting forged JWT verification results in HTTP headers, sanitize the JWT verification result when jwt_auth filter starts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1321

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
