### PR TITLE
Update Envoy dependency to support transparent listeners

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,7 @@ git_repository(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "5fcc829e7800a77ea2703a1ead3f25915aae6d61"
+ENVOY_SHA = "3b5fb0e6c8cbbaba1944cb8d74af3f35c471bde2"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -13,6 +13,6 @@
 		"repoName": "envoyproxy/envoy",
 		"prodBranch": "master",
 		"file": "WORKSPACE",
-		"lastStableSHA": "4dd49d8809f7aaa580538b3c228dd99a2fae92a4"
+		"lastStableSHA": "3b5fb0e6c8cbbaba1944cb8d74af3f35c471bde2"
 	}
 ]


### PR DESCRIPTION
Use a version of Envoy that implements transparent listen sockets (https://github.com/envoyproxy/envoy/pull/2719).

Related: https://github.com/istio/istio/pull/4651
Required by: https://github.com/istio/istio/pull/4654

Signed-off-by: Romain Lenglet <romain@covalent.io>