### PR TITLE
Remove request.auth.user

### DIFF
--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -71,7 +71,6 @@ const char AttributeName::kQuotaCacheHit[] = "quota.cache_hit";
 
 // Authentication attributes
 const char AttributeName::kRequestAuthPrincipal[] = "request.auth.principal";
-const char AttributeName::kRequestAuthUser[] = "request.auth.user";
 const char AttributeName::kRequestAuthAudiences[] = "request.auth.audiences";
 const char AttributeName::kRequestAuthPresenter[] = "request.auth.presenter";
 const char AttributeName::kRequestAuthClaims[] = "request.auth.claims";

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -72,7 +72,6 @@ struct AttributeName {
 
   // Authentication attributes
   static const char kRequestAuthPrincipal[];
-  static const char kRequestAuthUser[];
   static const char kRequestAuthAudiences[];
   static const char kRequestAuthPresenter[];
   static const char kRequestAuthClaims[];

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -71,9 +71,6 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
     }
     if (authn_result.has_origin()) {
       const auto &origin = authn_result.origin();
-      if (!origin.user().empty()) {
-        builder.AddString(AttributeName::kRequestAuthUser, origin.user());
-      }
       if (!origin.audiences().empty()) {
         // TODO(diemtvu): this should be send as repeated field once mixer
         // support string_list (https://github.com/istio/istio/issues/2802) For


### PR DESCRIPTION
**What this PR does / why we need it**:

Per authN policy design discussion, we want to keep only 2 principals for now (one for peer, and one for consolidate principal). This PR is to remove the request.auth.user attribute that was intended to keep origin principal.

Also note the peer principal attribute will be changed to source.principal (https://github.com/istio/istio/issues/4689), but we will do it in separate PR.


`NONE`
