### PR TITLE
Add the support of forward_payload_header to jwt_auth

### DIFF
--- a/src/envoy/http/authn/authenticator_base_test.cc
+++ b/src/envoy/http/authn/authenticator_base_test.cc
@@ -151,7 +151,7 @@ TEST_F(AuthenticatorBaseTest,
 // TODO: more tests for Jwt.
 TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoIstioAuthnConfig) {
   iaapi::Jwt jwt;
-  *jwt.mutable_issuer() = "issuer@foo.com";
+  jwt.set_issuer("issuer@foo.com");
   // authenticator_ has empty Istio authn config
   authenticator_.validateJwt(jwt, [](const Payload* payload, bool success) {
     // When there is empty Istio authn config, validateJwt() should return
@@ -189,7 +189,7 @@ TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoIssuer) {
 
 TEST_F(AuthenticatorBaseTest, ValidateJwtWithEmptyJwtOutputPayloadLocations) {
   iaapi::Jwt jwt;
-  *jwt.mutable_issuer() = "issuer@foo.com";
+  jwt.set_issuer("issuer@foo.com");
   Http::TestHeaderMapImpl request_headers_with_jwt = CreateTestHeaderMap(
       kSecIstioAuthUserInfoHeaderKey, kSecIstioAuthUserinfoHeaderValue);
   google::protobuf::util::JsonParseOptions options;
@@ -216,7 +216,7 @@ TEST_F(AuthenticatorBaseTest, ValidateJwtWithEmptyJwtOutputPayloadLocations) {
 
 TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoJwtInHeader) {
   iaapi::Jwt jwt;
-  *jwt.mutable_issuer() = "issuer@foo.com";
+  jwt.set_issuer("issuer@foo.com");
   google::protobuf::util::JsonParseOptions options;
   FilterConfig filter_config;
   JsonStringToMessage(
@@ -242,7 +242,7 @@ TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoJwtInHeader) {
 
 TEST_F(AuthenticatorBaseTest, ValidateJwtWithJwtInHeader) {
   iaapi::Jwt jwt;
-  *jwt.mutable_issuer() = "issuer@foo.com";
+  jwt.set_issuer("issuer@foo.com");
   Http::TestHeaderMapImpl request_headers_with_jwt = CreateTestHeaderMap(
       kSecIstioAuthUserInfoHeaderKey, kSecIstioAuthUserinfoHeaderValue);
   google::protobuf::util::JsonParseOptions options;

--- a/src/envoy/http/authn/authenticator_base_test.cc
+++ b/src/envoy/http/authn/authenticator_base_test.cc
@@ -16,6 +16,7 @@
 #include "src/envoy/http/authn/authenticator_base.h"
 #include "common/common/base64.h"
 #include "common/protobuf/protobuf.h"
+#include "envoy/config/filter/http/authn/v2alpha1/config.pb.h"
 #include "gmock/gmock.h"
 #include "src/envoy/http/authn/test_utils.h"
 #include "test/mocks/network/mocks.h"
@@ -23,6 +24,7 @@
 
 using google::protobuf::util::MessageDifferencer;
 using istio::authn::Payload;
+using istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig;
 using testing::NiceMock;
 using testing::Return;
 
@@ -61,9 +63,21 @@ class AuthenticatorBaseTest : public testing::Test,
   Http::TestHeaderMapImpl request_headers_{};
   NiceMock<Envoy::Network::MockConnection> connection_{};
   NiceMock<Envoy::Ssl::MockConnection> ssl_{};
-  FilterContext filter_context_{&request_headers_, &connection_};
+  FilterConfig filter_config_{};
+  FilterContext filter_context_{&request_headers_, &connection_,
+                                &filter_config_};
   MockAuthenticatorBase authenticator_{&filter_context_};
 };
+
+Http::TestHeaderMapImpl CreateTestHeaderMap(const std::string& header_key,
+                                            const std::string& header_value) {
+  // The base64 encoding is done through Base64::encode().
+  // If the test input has special chars, may need to use the counterpart of
+  // Base64UrlDecode().
+  std::string value_base64 =
+      Base64::encode(header_value.c_str(), header_value.size());
+  return Http::TestHeaderMapImpl{{header_key, value_base64}};
+}
 
 TEST_F(AuthenticatorBaseTest, ValidateX509OnPlaintextConnection) {
   iaapi::MutualTls mTlsParams;
@@ -135,9 +149,90 @@ TEST_F(AuthenticatorBaseTest,
 }
 
 // TODO: more tests for Jwt.
+TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoIstioAuthnConfig) {
+  iaapi::Jwt jwt;
+  *jwt.mutable_issuer() = "issuer@foo.com";
+  // authenticator_ has empty Istio authn config
+  authenticator_.validateJwt(jwt, [](const Payload* payload, bool success) {
+    // When there is empty Istio authn config, validateJwt() should return
+    // nullptr and failure.
+    EXPECT_TRUE(payload == nullptr);
+    EXPECT_FALSE(success);
+  });
+}
+
+TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoIssuer) {
+  // no issuer in jwt
+  iaapi::Jwt jwt;
+  google::protobuf::util::JsonParseOptions options;
+  FilterConfig filter_config;
+  JsonStringToMessage(
+      R"({
+              "jwt_output_payload_locations":
+              {
+                "issuer@foo.com": "sec-istio-auth-userinfo"
+              }
+           }
+        )",
+      &filter_config, options);
+  Http::TestHeaderMapImpl empty_request_headers{};
+  FilterContext filter_context{&empty_request_headers, &connection_,
+                               &filter_config};
+  MockAuthenticatorBase authenticator{&filter_context};
+  authenticator.validateJwt(jwt, [](const Payload* payload, bool success) {
+    // When there is no issuer in the JWT config, validateJwt() should return
+    // nullptr and failure.
+    EXPECT_TRUE(payload == nullptr);
+    EXPECT_FALSE(success);
+  });
+}
+
+TEST_F(AuthenticatorBaseTest, ValidateJwtWithEmptyJwtOutputPayloadLocations) {
+  iaapi::Jwt jwt;
+  *jwt.mutable_issuer() = "issuer@foo.com";
+  Http::TestHeaderMapImpl request_headers_with_jwt = CreateTestHeaderMap(
+      kSecIstioAuthUserInfoHeaderKey, kSecIstioAuthUserinfoHeaderValue);
+  google::protobuf::util::JsonParseOptions options;
+  FilterConfig filter_config;
+  JsonStringToMessage(
+      R"({
+              "jwt_output_payload_locations":
+              {
+              }
+           }
+        )",
+      &filter_config, options);
+  FilterContext filter_context{&request_headers_with_jwt, &connection_,
+                               &filter_config};
+  MockAuthenticatorBase authenticator{&filter_context};
+  // authenticator has empty jwt_output_payload_locations in Istio authn config
+  authenticator.validateJwt(jwt, [](const Payload* payload, bool success) {
+    // When there is no matching jwt_output_payload_locations for the issuer in
+    // the Istio authn config, validateJwt() should return nullptr and failure.
+    EXPECT_TRUE(payload == nullptr);
+    EXPECT_FALSE(success);
+  });
+}
+
 TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoJwtInHeader) {
   iaapi::Jwt jwt;
-  authenticator_.validateJwt(jwt, [](const Payload* payload, bool success) {
+  *jwt.mutable_issuer() = "issuer@foo.com";
+  google::protobuf::util::JsonParseOptions options;
+  FilterConfig filter_config;
+  JsonStringToMessage(
+      R"({
+              "jwt_output_payload_locations":
+              {
+                "issuer@foo.com": "sec-istio-auth-userinfo"
+              }
+           }
+        )",
+      &filter_config, options);
+  Http::TestHeaderMapImpl empty_request_headers{};
+  FilterContext filter_context{&empty_request_headers, &connection_,
+                               &filter_config};
+  MockAuthenticatorBase authenticator{&filter_context};
+  authenticator.validateJwt(jwt, [](const Payload* payload, bool success) {
     // When there is no JWT in the HTTP header, validateJwt() should return
     // nullptr and failure.
     EXPECT_TRUE(payload == nullptr);
@@ -145,24 +240,26 @@ TEST_F(AuthenticatorBaseTest, ValidateJwtWithNoJwtInHeader) {
   });
 }
 
-Http::TestHeaderMapImpl CreateTestHeaderMap(const std::string& header_key,
-                                            const std::string& header_value) {
-  // The base64 encoding is done through Base64::encode().
-  // If the test input has special chars, may need to use the counterpart of
-  // Base64UrlDecode().
-  std::string value_base64 =
-      Base64::encode(header_value.c_str(), header_value.size());
-  return Http::TestHeaderMapImpl{{header_key, value_base64}};
-}
-
 TEST_F(AuthenticatorBaseTest, ValidateJwtWithJwtInHeader) {
   iaapi::Jwt jwt;
+  *jwt.mutable_issuer() = "issuer@foo.com";
   Http::TestHeaderMapImpl request_headers_with_jwt = CreateTestHeaderMap(
       kSecIstioAuthUserInfoHeaderKey, kSecIstioAuthUserinfoHeaderValue);
-  FilterContext filter_context{&request_headers_with_jwt, &connection_};
+  google::protobuf::util::JsonParseOptions options;
+  FilterConfig filter_config;
+  JsonStringToMessage(
+      R"({
+              "jwt_output_payload_locations":
+              {
+                "issuer@foo.com": "sec-istio-auth-userinfo"
+              }
+           }
+        )",
+      &filter_config, options);
+  FilterContext filter_context{&request_headers_with_jwt, &connection_,
+                               &filter_config};
   MockAuthenticatorBase authenticator{&filter_context};
   Payload expected_payload;
-  google::protobuf::util::JsonParseOptions options;
   JsonStringToMessage(
       R"({
              "jwt": {

--- a/src/envoy/http/authn/authn_utils.cc
+++ b/src/envoy/http/authn/authn_utils.cc
@@ -56,8 +56,7 @@ bool AuthnUtils::GetJWTPayloadFromHeaders(
     istio::authn::JwtPayload* payload) {
   const HeaderEntry* entry = headers.get(jwt_payload_key);
   if (!entry) {
-    ENVOY_LOG(debug, "No JwtPayloadKey entry {} in the header",
-              jwt_payload_key.get());
+    ENVOY_LOG(debug, "No JWT payload {} in the header", jwt_payload_key.get());
     return false;
   }
   std::string value(entry->value().c_str(), entry->value().size());

--- a/src/envoy/http/authn/filter_context.h
+++ b/src/envoy/http/authn/filter_context.h
@@ -61,7 +61,7 @@ class FilterContext : public Logger::Loggable<Logger::Id::filter> {
   const Network::Connection* connection() { return connection_; }
   // Accessor to the filter config
   const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
-  filter_config() {
+  filter_config() const {
     return filter_config_;
   }
 

--- a/src/envoy/http/authn/filter_context.h
+++ b/src/envoy/http/authn/filter_context.h
@@ -17,6 +17,7 @@
 
 #include "authentication/v1alpha1/policy.pb.h"
 #include "common/common/logger.h"
+#include "envoy/config/filter/http/authn/v2alpha1/config.pb.h"
 #include "server/config/network/http_connection_manager.h"
 #include "src/istio/authn/context.pb.h"
 
@@ -29,8 +30,13 @@ namespace AuthN {
 // result data for authentication process.
 class FilterContext : public Logger::Loggable<Logger::Id::filter> {
  public:
-  FilterContext(HeaderMap* headers, const Network::Connection* connection)
-      : headers_(headers), connection_(connection) {}
+  FilterContext(
+      HeaderMap* headers, const Network::Connection* connection,
+      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig*
+          filter_config)
+      : headers_(headers),
+        connection_(connection),
+        filter_config_(filter_config) {}
   virtual ~FilterContext() {}
 
   // Sets peer result based on authenticated payload. Input payload can be null,
@@ -53,6 +59,11 @@ class FilterContext : public Logger::Loggable<Logger::Id::filter> {
   HeaderMap* headers() { return headers_; }
   // Accessor to connection
   const Network::Connection* connection() { return connection_; }
+  // Accessor to the filter config
+  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig*
+  filterConfig() {
+    return filter_config_;
+  }
 
  private:
   // Pointer to the headers of the request.
@@ -63,6 +74,10 @@ class FilterContext : public Logger::Loggable<Logger::Id::filter> {
 
   // Holds authentication attribute outputs.
   istio::authn::Result result_;
+
+  // Store the Istio authn filter config.
+  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig*
+      filter_config_;
 };
 
 }  // namespace AuthN

--- a/src/envoy/http/authn/filter_context.h
+++ b/src/envoy/http/authn/filter_context.h
@@ -32,7 +32,7 @@ class FilterContext : public Logger::Loggable<Logger::Id::filter> {
  public:
   FilterContext(
       HeaderMap* headers, const Network::Connection* connection,
-      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig*
+      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
           filter_config)
       : headers_(headers),
         connection_(connection),
@@ -60,8 +60,8 @@ class FilterContext : public Logger::Loggable<Logger::Id::filter> {
   // Accessor to connection
   const Network::Connection* connection() { return connection_; }
   // Accessor to the filter config
-  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig*
-  filterConfig() {
+  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
+  filter_config() {
     return filter_config_;
   }
 
@@ -76,7 +76,7 @@ class FilterContext : public Logger::Loggable<Logger::Id::filter> {
   istio::authn::Result result_;
 
   // Store the Istio authn filter config.
-  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig*
+  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
       filter_config_;
 };
 

--- a/src/envoy/http/authn/filter_context_test.cc
+++ b/src/envoy/http/authn/filter_context_test.cc
@@ -37,7 +37,7 @@ class FilterContextTest : public testing::Test {
 
   // This test suit does not use headers nor connection, so ok to use null for
   // them.
-  StrictMock<FilterContext> filter_context_{nullptr, nullptr};
+  StrictMock<FilterContext> filter_context_{nullptr, nullptr, nullptr};
   Payload x509_payload_{TestUtilities::CreateX509Payload("foo")};
   Payload jwt_payload_{TestUtilities::CreateJwtPayload("bar", "istio.io")};
 };

--- a/src/envoy/http/authn/filter_context_test.cc
+++ b/src/envoy/http/authn/filter_context_test.cc
@@ -14,7 +14,6 @@
  */
 
 #include "src/envoy/http/authn/filter_context.h"
-#include "gmock/gmock.h"
 #include "src/envoy/http/authn/test_utils.h"
 #include "test/test_common/utility.h"
 
@@ -35,10 +34,10 @@ class FilterContextTest : public testing::Test {
 
   // This test suit does not use headers nor connection, so ok to use null for
   // them.
-  StrictMock<FilterContext> filter_context_{
-      nullptr, nullptr,
-      istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig::
-          default_instance()};
+  FilterContext filter_context_{nullptr, nullptr,
+                                istio::envoy::config::filter::http::authn::
+                                    v2alpha1::FilterConfig::default_instance()};
+
   Payload x509_payload_{TestUtilities::CreateX509Payload("foo")};
   Payload jwt_payload_{TestUtilities::CreateJwtPayload("bar", "istio.io")};
 };

--- a/src/envoy/http/authn/filter_context_test.cc
+++ b/src/envoy/http/authn/filter_context_test.cc
@@ -15,9 +15,7 @@
 
 #include "src/envoy/http/authn/filter_context.h"
 #include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "src/envoy/http/authn/test_utils.h"
-#include "src/istio/authn/context.pb.h"
 #include "test/test_common/utility.h"
 
 using istio::authn::Payload;
@@ -37,7 +35,10 @@ class FilterContextTest : public testing::Test {
 
   // This test suit does not use headers nor connection, so ok to use null for
   // them.
-  StrictMock<FilterContext> filter_context_{nullptr, nullptr, nullptr};
+  StrictMock<FilterContext> filter_context_{
+      nullptr, nullptr,
+      istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig::
+          default_instance()};
   Payload x509_payload_{TestUtilities::CreateX509Payload("foo")};
   Payload jwt_payload_{TestUtilities::CreateJwtPayload("bar", "istio.io")};
 };

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -46,7 +46,7 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
   state_ = State::PROCESSING;
 
   filter_context_.reset(new Istio::AuthN::FilterContext(
-      &headers, decoder_callbacks_->connection(), &filter_config_));
+      &headers, decoder_callbacks_->connection(), filter_config_));
 
   authenticator_ = createPeerAuthenticator(
       filter_context_.get(),

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -46,7 +46,7 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
   state_ = State::PROCESSING;
 
   filter_context_.reset(new Istio::AuthN::FilterContext(
-      &headers, decoder_callbacks_->connection()));
+      &headers, decoder_callbacks_->connection(), &filter_config_));
 
   authenticator_ = createPeerAuthenticator(
       filter_context_.get(),

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -90,8 +90,8 @@ TEST_P(AuthenticationFilterIntegrationTest, SourceMTlsFail) {
   EXPECT_TRUE(response_->complete());
   EXPECT_STREQ("401", response_->headers().Status()->value().c_str());
 }
-//
-//// TODO (diemtvu/lei-tang): add test for MTls success.
+
+// TODO (diemtvu/lei-tang): add test for MTls success.
 
 TEST_P(AuthenticationFilterIntegrationTest, OriginJwtRequiredHeaderNoJwtFail) {
   createTestServer(

--- a/src/envoy/http/authn/origin_authenticator_test.cc
+++ b/src/envoy/http/authn/origin_authenticator_test.cc
@@ -122,7 +122,9 @@ class OriginAuthenticatorTest : public testing::TestWithParam<bool> {
   std::unique_ptr<StrictMock<MockOriginAuthenticator>> authenticator_;
   StrictMock<MockFunction<void(bool)>> on_done_callback_;
   Http::TestHeaderMapImpl request_headers_;
-  FilterContext filter_context_{&request_headers_, nullptr, nullptr};
+  FilterContext filter_context_{&request_headers_, nullptr,
+                                istio::envoy::config::filter::http::authn::
+                                    v2alpha1::FilterConfig::default_instance()};
   iaapi::Policy policy_;
 
   // Mock response payload.

--- a/src/envoy/http/authn/origin_authenticator_test.cc
+++ b/src/envoy/http/authn/origin_authenticator_test.cc
@@ -122,7 +122,7 @@ class OriginAuthenticatorTest : public testing::TestWithParam<bool> {
   std::unique_ptr<StrictMock<MockOriginAuthenticator>> authenticator_;
   StrictMock<MockFunction<void(bool)>> on_done_callback_;
   Http::TestHeaderMapImpl request_headers_;
-  FilterContext filter_context_{&request_headers_, nullptr};
+  FilterContext filter_context_{&request_headers_, nullptr, nullptr};
   iaapi::Policy policy_;
 
   // Mock response payload.

--- a/src/envoy/http/authn/peer_authenticator_test.cc
+++ b/src/envoy/http/authn/peer_authenticator_test.cc
@@ -67,7 +67,7 @@ class PeerAuthenticatorTest : public testing::Test {
   std::unique_ptr<StrictMock<MockPeerAuthenticator>> authenticator_;
   StrictMock<MockFunction<void(bool)>> on_done_callback_;
   Http::TestHeaderMapImpl request_headers_;
-  FilterContext filter_context_{&request_headers_, nullptr};
+  FilterContext filter_context_{&request_headers_, nullptr, nullptr};
   iaapi::Policy policy_;
 
   Payload x509_payload_{TestUtilities::CreateX509Payload("foo")};

--- a/src/envoy/http/authn/peer_authenticator_test.cc
+++ b/src/envoy/http/authn/peer_authenticator_test.cc
@@ -67,7 +67,10 @@ class PeerAuthenticatorTest : public testing::Test {
   std::unique_ptr<StrictMock<MockPeerAuthenticator>> authenticator_;
   StrictMock<MockFunction<void(bool)>> on_done_callback_;
   Http::TestHeaderMapImpl request_headers_;
-  FilterContext filter_context_{&request_headers_, nullptr, nullptr};
+  FilterContext filter_context_{&request_headers_, nullptr,
+                                istio::envoy::config::filter::http::authn::
+                                    v2alpha1::FilterConfig::default_instance()};
+
   iaapi::Policy policy_;
 
   Payload x509_payload_{TestUtilities::CreateX509Payload("foo")};

--- a/src/envoy/http/authn/testdata/envoy_origin_jwt_authn_only.conf
+++ b/src/envoy/http/authn/testdata/envoy_origin_jwt_authn_only.conf
@@ -43,6 +43,9 @@
                         }
                       }
                     ]
+                  },
+                  "jwt_output_payload_locations": {
+                    "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com": "sec-istio-auth-userinfo"
                   }
                 }
               },

--- a/src/envoy/http/jwt_auth/integration_test/envoy.conf.jwk
+++ b/src/envoy/http/jwt_auth/integration_test/envoy.conf.jwk
@@ -45,8 +45,9 @@
                              "uri": "http://example.com/foobar_cert",
                              "cluster": "example_issuer"
                           }
-                        }
-                      }
+                        },
+                        "forward_payload_header": "sec-istio-auth-userinfo"
+                     }
                    ]
                  }
               },

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -199,7 +199,7 @@ void JwtAuthenticator::VerifyKey(const PubkeyCacheItem& issuer_item) {
   }
 
   LowerCaseString key(issuer_item.jwt_config().forward_payload_header());
-  if (!jwt_->PayloadStrBase64Url().empty()) {
+  if (!key.get().empty() && !jwt_->PayloadStrBase64Url().empty()) {
     headers_->addCopy(key, jwt_->PayloadStrBase64Url());
   }
 

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -196,10 +196,15 @@ void JwtAuthenticator::VerifyKey(const PubkeyCacheItem& issuer_item) {
   }
 
   headers_->addReferenceKey(kJwtPayloadKey, jwt_->PayloadStrBase64Url());
-  const LowerCaseString key(issuer_item.jwt_config().forward_payload_header());
-  if (!key.get().empty() && !jwt_->PayloadStrBase64Url().empty() &&
-      !(key == kJwtPayloadKey)) {
-    headers_->addCopy(key, jwt_->PayloadStrBase64Url());
+
+  if (issuer_item.jwt_config().forward_payload_header().empty() == false) {
+    const LowerCaseString key(
+        issuer_item.jwt_config().forward_payload_header());
+    // No need to check jwt_->PayloadStrBaseUrl(): a valid JWT will not have an
+    // empty Payload
+    if (!(key == kJwtPayloadKey)) {
+      headers_->addCopy(key, jwt_->PayloadStrBase64Url());
+    }
   }
 
   if (!issuer_item.jwt_config().forward()) {

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -195,8 +195,10 @@ void JwtAuthenticator::VerifyKey(const PubkeyCacheItem& issuer_item) {
     return;
   }
 
-  // TODO: check forward_payload_header.
-  headers_->addReferenceKey(kJwtPayloadKey, jwt_->PayloadStrBase64Url());
+  forward_payload_header_.reset(
+      new LowerCaseString(issuer_item.jwt_config().forward_payload_header()));
+  headers_->addReferenceKey(*forward_payload_header_.get(),
+                            jwt_->PayloadStrBase64Url());
 
   if (!issuer_item.jwt_config().forward()) {
     // Remove JWT from headers.

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -22,9 +22,6 @@ namespace Http {
 namespace JwtAuth {
 namespace {
 
-// TODO (lei-tang) remove kJwtPayloadKey after adding the
-// support of forward_payload_header to Istio authn and other
-// code that reads the output from jwt_auth.
 // The HTTP header to pass verified token payload.
 const LowerCaseString kJwtPayloadKey("sec-istio-auth-userinfo");
 
@@ -198,8 +195,10 @@ void JwtAuthenticator::VerifyKey(const PubkeyCacheItem& issuer_item) {
     return;
   }
 
-  LowerCaseString key(issuer_item.jwt_config().forward_payload_header());
-  if (!key.get().empty() && !jwt_->PayloadStrBase64Url().empty()) {
+  headers_->addReferenceKey(kJwtPayloadKey, jwt_->PayloadStrBase64Url());
+  const LowerCaseString key(issuer_item.jwt_config().forward_payload_header());
+  if (!key.get().empty() && !jwt_->PayloadStrBase64Url().empty() &&
+      !(key == kJwtPayloadKey)) {
     headers_->addCopy(key, jwt_->PayloadStrBase64Url());
   }
 

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -197,12 +197,10 @@ void JwtAuthenticator::VerifyKey(const PubkeyCacheItem& issuer_item) {
 
   headers_->addReferenceKey(kJwtPayloadKey, jwt_->PayloadStrBase64Url());
 
-  if (issuer_item.jwt_config().forward_payload_header().empty() == false) {
+  if (!issuer_item.jwt_config().forward_payload_header().empty()) {
     const LowerCaseString key(
         issuer_item.jwt_config().forward_payload_header());
-    // No need to check jwt_->PayloadStrBaseUrl(): a valid JWT will not have an
-    // empty Payload
-    if (!(key == kJwtPayloadKey)) {
+    if (key.get() != kJwtPayloadKey.get()) {
       headers_->addCopy(key, jwt_->PayloadStrBase64Url());
     }
   }

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -22,6 +22,9 @@ namespace Http {
 namespace JwtAuth {
 namespace {
 
+// TODO (lei-tang) remove kJwtPayloadKey after adding the
+// support of forward_payload_header to Istio authn and other
+// code that reads the output from jwt_auth.
 // The HTTP header to pass verified token payload.
 const LowerCaseString kJwtPayloadKey("sec-istio-auth-userinfo");
 

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -195,10 +195,10 @@ void JwtAuthenticator::VerifyKey(const PubkeyCacheItem& issuer_item) {
     return;
   }
 
-  forward_payload_header_.reset(
-      new LowerCaseString(issuer_item.jwt_config().forward_payload_header()));
-  headers_->addReferenceKey(*forward_payload_header_.get(),
-                            jwt_->PayloadStrBase64Url());
+  LowerCaseString key(issuer_item.jwt_config().forward_payload_header());
+  if (!jwt_->PayloadStrBase64Url().empty()) {
+    headers_->addCopy(key, jwt_->PayloadStrBase64Url());
+  }
 
   if (!issuer_item.jwt_config().forward()) {
     // Remove JWT from headers.

--- a/src/envoy/http/jwt_auth/jwt_authenticator.h
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.h
@@ -83,13 +83,6 @@ class JwtAuthenticator : public Logger::Loggable<Logger::Id::filter>,
   std::string uri_;
   // The pending remote request so it can be canceled.
   AsyncClient::Request* request_{};
-
-  // The HTTP header to pass verified token payload.
-  // As HeaderMap::addReferenceKey() requires that "The key MUST point to point
-  // to data that will live beyond the lifetime of any request/response using
-  // the string (since a codec may optimize for zero copy)", the header key is
-  // not stored in a stack variable.
-  std::unique_ptr<LowerCaseString> forward_payload_header_;
 };
 
 }  // namespace JwtAuth

--- a/src/envoy/http/jwt_auth/jwt_authenticator.h
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.h
@@ -83,6 +83,13 @@ class JwtAuthenticator : public Logger::Loggable<Logger::Id::filter>,
   std::string uri_;
   // The pending remote request so it can be canceled.
   AsyncClient::Request* request_{};
+
+  // The HTTP header to pass verified token payload.
+  // As HeaderMap::addReferenceKey() requires that "The key MUST point to point
+  // to data that will live beyond the lifetime of any request/response using
+  // the string (since a codec may optimize for zero copy)", the header key is
+  // not stored in a stack variable.
+  std::unique_ptr<LowerCaseString> forward_payload_header_;
 };
 
 }  // namespace JwtAuth

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -106,7 +106,8 @@ const char kExampleConfig[] = R"(
             "cache_duration": {
               "seconds": 600
             }
-         }
+         },
+         "forward_payload_header": "sec-istio-auth-userinfo"
       }
    ]
 }

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -771,6 +771,8 @@ TEST_F(JwtAuthenticatorTest, TestNoForwardPayloadHeader) {
   // Test when forward_payload_header is not set, the output should still
   // contain the sec-istio-auth-userinfo header for backward compatibility.
   EXPECT_TRUE(headers.has("sec-istio-auth-userinfo"));
+  // In addition, the sec-istio-auth-userinfo header should be the only header
+  EXPECT_EQ(headers.size(), 1);
 }
 
 }  // namespace JwtAuth

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -768,8 +768,9 @@ TEST_F(JwtAuthenticatorTest, TestNoForwardPayloadHeader) {
   }));
   auth_->Verify(headers, &mock_cb);
 
-  // Test when forward_payload_header is not set, the output should be empty.
-  EXPECT_FALSE(headers.has("sec-istio-auth-userinfo"));
+  // Test when forward_payload_header is not set, the output should still
+  // contain the sec-istio-auth-userinfo header for backward compatibility.
+  EXPECT_TRUE(headers.has("sec-istio-auth-userinfo"));
 }
 
 }  // namespace JwtAuth

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -757,13 +757,9 @@ TEST_F(JwtAuthenticatorTest, TestOnDestroy) {
   auth_->onDestroy();
 }
 
-// In the test, there is no forward_payload_header
-class NoForwardPayloadHeaderTest : public JwtAuthenticatorTest {
- public:
-  void SetUp() { SetupConfig(kExampleConfigWithoutForwardPayloadHeader); }
-};
-
-TEST_F(NoForwardPayloadHeaderTest, TestNoForwardPayloadHeader) {
+TEST_F(JwtAuthenticatorTest, TestNoForwardPayloadHeader) {
+  // In this config, there is no forward_payload_header
+  SetupConfig(kExampleConfigWithoutForwardPayloadHeader);
   MockUpstream mock_pubkey(mock_cm_, kPublicKey);
   auto headers = TestHeaderMapImpl{{"Authorization", "Bearer " + kGoodToken}};
   MockJwtAuthenticatorCallbacks mock_cb;


### PR DESCRIPTION
**What this PR does / why we need it**: Add the support of forward_payload_header to jwt_auth, which specifies the output header of the JWT payload.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1213 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
