### PR TITLE
Support Mixer TCP filter to send string type of attribute "connection.event"

### DIFF
--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -56,6 +56,7 @@ const char AttributeName::kConnectionDuration[] = "connection.duration";
 const char AttributeName::kConnectionMtls[] = "connection.mtls";
 // Downstream TCP connection id.
 const char AttributeName::kConnectionId[] = "connection.id";
+const char AttributeName::kConnectionEvent[] = "connection.event";
 
 // Context attributes
 const char AttributeName::kContextProtocol[] = "context.protocol";

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -57,6 +57,8 @@ struct AttributeName {
   static const char kConnectionDuration[];
   static const char kConnectionMtls[];
   static const char kConnectionId[];
+  // Record TCP connection status: open, continue, close
+  static const char kConnectionEvent[];
 
   // Context attributes
   static const char kContextProtocol[];

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -21,6 +21,12 @@
 namespace istio {
 namespace control {
 namespace tcp {
+namespace {
+// Connection events for TCP connection.
+const std::string kConnectionOpen("open");
+const std::string kConnectionContinue("continue");
+const std::string kConnectionClose("close");
+}  // namespace
 
 void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   utils::AttributesBuilder builder(&request_->attributes);
@@ -43,6 +49,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   builder.AddTimestamp(AttributeName::kContextTime,
                        std::chrono::system_clock::now());
   builder.AddString(AttributeName::kContextProtocol, "tcp");
+  builder.AddString(AttributeName::kConnectionEvent, kConnectionOpen);
 
   // Get unique downstream connection ID, which is <uuid>-<connection id>.
   std::string connection_id = check_data->GetConnectionId();
@@ -71,10 +78,12 @@ void AttributesBuilder::ExtractReportAttributes(
                        request_->check_status.error_code());
       builder.AddString(AttributeName::kCheckErrorMessage,
                         request_->check_status.ToString());
+      builder.AddString(AttributeName::kConnectionEvent, kConnectionClose);
     }
   } else {
     last_report_info->received_bytes = info.received_bytes;
     last_report_info->send_bytes = info.send_bytes;
+    builder.AddString(AttributeName::kConnectionEvent, kConnectionContinue);
   }
 
   std::string dest_ip;

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -37,6 +37,12 @@ namespace {
 
 const char kCheckAttributes[] = R"(
 attributes {
+  key: "connection.event"
+  value {
+    string_value: "open"
+  }
+}
+attributes {
   key: "context.protocol"
   value {
     string_value: "tcp"
@@ -82,6 +88,12 @@ attributes {
 )";
 
 const char kReportAttributes[] = R"(
+attributes {
+  key: "connection.event"
+  value {
+    string_value: "close"
+  }
+}
 attributes {
   key: "check.error_code"
   value {
@@ -149,6 +161,12 @@ attributes {
 
 const char kDeltaOneReportAttributes[] = R"(
 attributes {
+  key: "connection.event"
+  value {
+    string_value: "continue"
+  }
+}
+attributes {
   key: "connection.received.bytes"
   value {
     int64_value: 100
@@ -194,6 +212,12 @@ attributes {
 )";
 
 const char kDeltaTwoReportAttributes[] = R"(
+attributes {
+  key: "connection.event"
+  value {
+    string_value: "continue"
+  }
+}
 attributes {
   key: "connection.received.bytes"
   value {


### PR DESCRIPTION
**What this PR does / why we need it**: Mixer need to keep tracking of TCP connection creation rate.
Support Mixer TCP filter to send attribute "connection.event". 
In Check() call, "connection.event" is set to "open"
In periodical Report() call, "connection.event" is set to "continue"
In final Report() call, "connection.event" is set to "close"

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1369 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
