### PR TITLE
Change target_service_accounts to peer_service_accounts in ALTS config proto.

### DIFF
--- a/src/envoy/alts/README.md
+++ b/src/envoy/alts/README.md
@@ -7,6 +7,7 @@ A prototype of
 support for Istio/Envoy. It depends on ALTS stack in gRPC library and implemented as Envoy's
 [transport socket](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/base.proto#core-transportsocket).
 
-An example config is in `example.yaml`. Note: Please replace the `peer_service_accounts` with the
-actual service account in your environment, otherwise the ALTS connection will be closed due to
-validation failure.
+An example config is in `example.yaml`. Note: If you want to enable the peer validation, please
+uncomment and replace the content of `peer_service_accounts` with the actual service account in your
+environment. Please make sure the service account is correct otherwise the ALTS connection will be
+closed due to validation failure.

--- a/src/envoy/alts/README.md
+++ b/src/envoy/alts/README.md
@@ -7,6 +7,6 @@ A prototype of
 support for Istio/Envoy. It depends on ALTS stack in gRPC library and implemented as Envoy's
 [transport socket](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/base.proto#core-transportsocket).
 
-An example config is in `example.yaml`. Note: Please replace the `target_service_accounts` with the
+An example config is in `example.yaml`. Note: Please replace the `peer_service_accounts` with the
 actual service account in your environment, otherwise the ALTS connection will be closed due to
 validation failure.

--- a/src/envoy/alts/alts_socket.proto
+++ b/src/envoy/alts/alts_socket.proto
@@ -26,5 +26,5 @@ message AltsSocket {
 
   // The AltsSocket will only connect to peers with service account listed here.
   // Peers not in the list will be rejected in the handshake validation step.
-  repeated string target_service_accounts = 2;
+  repeated string peer_service_accounts = 2;
 }

--- a/src/envoy/alts/alts_socket.proto
+++ b/src/envoy/alts/alts_socket.proto
@@ -24,7 +24,8 @@ message AltsSocket {
   // on GCE
   string handshaker_service = 1 [(validate.rules).string.min_bytes = 1];
 
-  // The AltsSocket will only connect to peers with service account listed here.
-  // Peers not in the list will be rejected in the handshake validation step.
+  // The acceptable service accounts from peer, peers not in the list will be
+  // rejected in the handshake validation step.
+  // If empty, no validation will be performed.
   repeated string peer_service_accounts = 2;
 }

--- a/src/envoy/alts/alts_socket_factory.cc
+++ b/src/envoy/alts/alts_socket_factory.cc
@@ -31,30 +31,27 @@ namespace Configuration {
 
 using ::google::protobuf::RepeatedPtrField;
 
-// Returns true if the peer's service account is found in targets, otherwise
+// Returns true if the peer's service account is found in peers, otherwise
 // returns false and fills out err with an error message.
 static bool doValidate(const tsi_peer &peer,
-                       const RepeatedPtrField<std::string> &targets,
+                       std::unordered_set<std::string> peers,
                        std::string &err) {
   for (size_t i = 0; i < peer.property_count; ++i) {
     std::string name = std::string(peer.properties[i].name);
     std::string value = std::string(peer.properties[i].value.data,
                                     peer.properties[i].value.length);
-    if (name.compare(TSI_ALTS_SERVICE_ACCOUNT_PEER_PROPERTY) == 0) {
-      for (int j = 0; j < targets.size(); ++j) {
-        if (value.compare(targets[j]) == 0) {
-          return true;
-        }
-      }
+    if (name.compare(TSI_ALTS_SERVICE_ACCOUNT_PEER_PROPERTY) == 0 &&
+        peers.count(value) > 0) {
+      return true;
     }
   }
 
-  err = "Couldn't find peer's service account in targets: ";
-  for (int i = 0; i < targets.size(); ++i) {
-    if (i != 0) {
+  err = "Couldn't find peer's service account in peer_service_accounts: ";
+  for (auto it = peers.cbegin(); it != peers.cend(); ++it) {
+    if (it != peers.cbegin()) {
       err += ", ";
     }
-    err += targets[i];
+    err += *it;
   }
   return false;
 }
@@ -77,8 +74,9 @@ UpstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
           message);
 
   std::string handshaker_service = config.handshaker_service();
-  const auto &target_service_accounts = config.target_service_accounts();
-
+  const auto &peer_service_accounts = config.peer_service_accounts();
+  std::unordered_set<std::string> peers(peer_service_accounts.cbegin(),
+                                        peer_service_accounts.cend());
   return std::make_unique<Security::TsiSocketFactory>(
       [handshaker_service](Event::Dispatcher &dispatcher) {
         grpc_alts_credentials_options *options =
@@ -99,8 +97,8 @@ UpstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
         return std::make_unique<Security::TsiHandshaker>(handshaker,
                                                          dispatcher);
       },
-      [target_service_accounts](const tsi_peer &peer, std::string &err) {
-        return doValidate(peer, target_service_accounts, err);
+      [peers](const tsi_peer &peer, std::string &err) {
+        return doValidate(peer, peers, err);
       });
 }
 
@@ -113,7 +111,9 @@ DownstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
           message);
 
   std::string handshaker_service = config.handshaker_service();
-  const auto &target_service_accounts = config.target_service_accounts();
+  const auto &peer_service_accounts = config.peer_service_accounts();
+  std::unordered_set<std::string> peers(peer_service_accounts.cbegin(),
+                                        peer_service_accounts.cend());
 
   return std::make_unique<Security::TsiSocketFactory>(
       [handshaker_service](Event::Dispatcher &dispatcher) {
@@ -132,8 +132,8 @@ DownstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
         return std::make_unique<Security::TsiHandshaker>(handshaker,
                                                          dispatcher);
       },
-      [target_service_accounts](const tsi_peer &peer, std::string &err) {
-        return doValidate(peer, target_service_accounts, err);
+      [peers](const tsi_peer &peer, std::string &err) {
+        return doValidate(peer, peers, err);
       });
 }
 

--- a/src/envoy/alts/alts_socket_factory.cc
+++ b/src/envoy/alts/alts_socket_factory.cc
@@ -78,10 +78,13 @@ UpstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
   std::unordered_set<std::string> peers(peer_service_accounts.cbegin(),
                                         peer_service_accounts.cend());
 
-  std::function<bool(const tsi_peer &, std::string &)> empty_validator;
-  auto actual_validator = [peers](const tsi_peer &peer, std::string &err) {
-    return doValidate(peer, peers, err);
-  };
+  Security::HandshakeValidator validator;
+  // Skip validation if peers is empty.
+  if (!peers.empty()) {
+    validator = [peers](const tsi_peer &peer, std::string &err) {
+      return doValidate(peer, peers, err);
+    };
+  }
 
   return std::make_unique<Security::TsiSocketFactory>(
       [handshaker_service](Event::Dispatcher &dispatcher) {
@@ -103,8 +106,7 @@ UpstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
         return std::make_unique<Security::TsiHandshaker>(handshaker,
                                                          dispatcher);
       },
-      // Skip validation if peers is empty.
-      peers.empty() ? empty_validator : actual_validator);
+      validator);
 }
 
 Network::TransportSocketFactoryPtr
@@ -120,10 +122,13 @@ DownstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
   std::unordered_set<std::string> peers(peer_service_accounts.cbegin(),
                                         peer_service_accounts.cend());
 
-  std::function<bool(const tsi_peer &, std::string &)> empty_validator;
-  auto actual_validator = [peers](const tsi_peer &peer, std::string &err) {
-    return doValidate(peer, peers, err);
-  };
+  Security::HandshakeValidator validator;
+  // Skip validation if peers is empty.
+  if (!peers.empty()) {
+    validator = [peers](const tsi_peer &peer, std::string &err) {
+      return doValidate(peer, peers, err);
+    };
+  }
 
   return std::make_unique<Security::TsiSocketFactory>(
       [handshaker_service](Event::Dispatcher &dispatcher) {
@@ -142,8 +147,7 @@ DownstreamAltsTransportSocketConfigFactory::createTransportSocketFactory(
         return std::make_unique<Security::TsiHandshaker>(handshaker,
                                                          dispatcher);
       },
-      // Skip validation if peers is empty.
-      peers.empty() ? empty_validator : actual_validator);
+      validator);
 }
 
 static Registry::RegisterFactory<UpstreamAltsTransportSocketConfigFactory,

--- a/src/envoy/alts/example.yaml
+++ b/src/envoy/alts/example.yaml
@@ -19,9 +19,9 @@ static_resources:
         name: alts
         config:
           handshaker_service: "169.254.169.254:8080"
-          # Please add the actual service account used in your environment, otherwise the ALTS
-          # connection will be closed due to validation failure.
-          peer_service_accounts: ["test-service-account"]
+          # If you want to enable the peer validation, please uncomment peer_service_accounts and
+          # replace it with the actual service account used in your environment.
+          # peer_service_accounts: ["test-service-account"]
       filters:
       - name: envoy.tcp_proxy
         config:
@@ -33,9 +33,9 @@ static_resources:
       name: alts
       config:
         handshaker_service: "169.254.169.254:8080"
-        # Please add the actual service account used in your environment, otherwise the ALTS
-        # connection will be closed due to validation failure.
-        peer_service_accounts: ["test-service-account"]
+        # If you want to enable the peer validation, please uncomment peer_service_accounts and
+        # replace it with the actual service account used in your environment.
+        # peer_service_accounts: ["test-service-account"]
     connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin

--- a/src/envoy/alts/example.yaml
+++ b/src/envoy/alts/example.yaml
@@ -21,7 +21,7 @@ static_resources:
           handshaker_service: "169.254.169.254:8080"
           # Please add the actual service account used in your environment, otherwise the ALTS
           # connection will be closed due to validation failure.
-          target_service_accounts: ["test-service-account"]
+          peer_service_accounts: ["test-service-account"]
       filters:
       - name: envoy.tcp_proxy
         config:
@@ -35,7 +35,7 @@ static_resources:
         handshaker_service: "169.254.169.254:8080"
         # Please add the actual service account used in your environment, otherwise the ALTS
         # connection will be closed due to validation failure.
-        target_service_accounts: ["test-service-account"]
+        peer_service_accounts: ["test-service-account"]
     connect_timeout: 0.25s
     type: strict_dns
     lb_policy: round_robin

--- a/src/envoy/alts/tsi_transport_socket.cc
+++ b/src/envoy/alts/tsi_transport_socket.cc
@@ -92,7 +92,7 @@ Network::PostIoAction TsiSocket::doHandshakeNextDone(
                                  peer.properties[i].value.length));
     }
     if (handshake_validator_) {
-      std::string err = "";
+      std::string err;
       bool peer_validated = handshake_validator_(peer, err);
       if (peer_validated) {
         ENVOY_CONN_LOG(info, "TSI: Handshake validation succeeded.",

--- a/src/envoy/alts/tsi_transport_socket.h
+++ b/src/envoy/alts/tsi_transport_socket.h
@@ -24,6 +24,14 @@ namespace Envoy {
 namespace Security {
 
 typedef std::function<TsiHandshakerPtr(Event::Dispatcher&)> HandshakerFactory;
+
+/**
+ * A function to validate the peer of the connection.
+ * @param peer the detail peer information of the connection.
+ * @param err an error message to indicate why the peer is invalid. This is an
+ * output param that should be populated by the function implementation.
+ * @return true if the peer is valid or false if the peer is invalid.
+ */
 typedef std::function<bool(const tsi_peer& peer, std::string& err)>
     HandshakeValidator;
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Change the target_service_accounts to peer_service_accounts in config proto, address some other comments.
- Skip validation if peer_service_accounts is empty.
- Manually tested with custom config (both validation success and fail) and environment on GKE.

**Which issue this PR fixes**:
Per request in #1374 .

**Special notes for your reviewer**:
None.

**Release note**:
None
