### PR TITLE
Populate source.principal attribute with the same value as source.user

### DIFF
--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -20,6 +20,7 @@ namespace control {
 
 // Define attribute names
 const char AttributeName::kSourceUser[] = "source.user";
+const char AttributeName::kSourcePrincipal[] = "source.principal";
 
 const char AttributeName::kRequestHeaders[] = "request.headers";
 const char AttributeName::kRequestHost[] = "request.host";

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -23,7 +23,10 @@ namespace control {
 
 // Define attribute names
 struct AttributeName {
+  // source.user is replaced by source.principal
+  // https://github.com/istio/istio/issues/4689
   static const char kSourceUser[];
+  static const char kSourcePrincipal[];
 
   static const char kRequestHeaders[];
   static const char kRequestHost[];

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -66,7 +66,10 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
                         authn_result.principal());
     }
     if (!authn_result.peer_user().empty()) {
+      // TODO(diemtvu): remove kSourceUser once migration to source.principal is over.
+      // https://github.com/istio/istio/issues/4689
       builder.AddString(AttributeName::kSourceUser, authn_result.peer_user());
+      builder.AddString(AttributeName::kSourcePrincipal, authn_result.peer_user());
     }
     if (authn_result.has_origin()) {
       const auto &origin = authn_result.origin();
@@ -109,7 +112,10 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
   }
   std::string source_user;
   if (check_data->GetSourceUser(&source_user)) {
+    // TODO(diemtvu): remove kSourceUser once migration to source.principal is over.
+    // https://github.com/istio/istio/issues/4689
     builder.AddString(AttributeName::kSourceUser, source_user);
+    builder.AddString(AttributeName::kSourcePrincipal, source_user);
   }
 }  // namespace http
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -102,6 +102,12 @@ attributes {
   }
 }
 attributes {
+  key: "source.principal"
+  value {
+    string_value: "test_user"
+  }
+}
+attributes {
   key: "source.user"
   value {
     string_value: "test_user"

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -42,7 +42,10 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   // result output here instead.
   std::string source_user;
   if (check_data->GetSourceUser(&source_user)) {
+    // TODO(diemtvu): remove kSourceUser once migration to source.principal is over.
+    // https://github.com/istio/istio/issues/4689
     builder.AddString(AttributeName::kSourceUser, source_user);
+    builder.AddString(AttributeName::kSourcePrincipal, source_user);
   }
   builder.AddBool(AttributeName::kConnectionMtls, check_data->IsMutualTLS());
 

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -74,6 +74,12 @@ attributes {
   }
 }
 attributes {
+  key: "source.principal"
+  value {
+    string_value: "test_user"
+  }
+}
+attributes {
   key: "source.user"
   value {
     string_value: "test_user"


### PR DESCRIPTION
This PR adds `source.principal` attribute with the same value as `source.user`. `source.user` will be removed in later PR to complete the migration.

Issue: https://github.com/istio/istio/issues/4689
