### PR TITLE
Update jwt filter sample envoy.conf to align with latest config proto

### DIFF
--- a/src/envoy/http/jwt_auth/sample/envoy.conf
+++ b/src/envoy/http/jwt_auth/sample/envoy.conf
@@ -34,12 +34,16 @@
                 "type": "decoder",
                 "name": "jwt-auth",
                 "config": {
-                   "jwts": [
+                   "rules": [
                      {
-                        "issuer": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
-                        "jwks_uri": "http://localhost:8081/",
-                        "jwks_uri_envoy_cluster": "example_issuer"
-                     }
+                          "issuer": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
+                          "remote_jwks": {
+                              "http_uri":{
+                                  "uri": "http://localhost:8081/",
+                                  "cluster": "example_issuer"
+                              }
+                          }
+                      }
                    ]
                 }
               },


### PR DESCRIPTION
**What this PR does / why we need it**:
Update jwt filter sample envoy.conf to align with latest config proto

**Which issue this PR fixes** 
try sample in https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/README.md, it fails 

bazel-bin/src/envoy/envoy -c src/envoy/http/jwt_auth/sample/envoy.conf
hit error initializing configuration 'src/envoy/http/jwt_auth/sample/envoy.conf': Unable to parse JSON as proto (INVALID_ARGUMENT:: Cannot find field.): {"jwts":[{"jwks_uri_envoy_cluster":"example_issuer","jwks_uri":"http://localhost:8081/","issuer":"628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"}]}


**Special notes for your reviewer**:

**Release note**:

