### PR TITLE
Fix filter factory to set Mixer HTTP filter as StreamFilter.

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -211,6 +211,7 @@ FilterTrailersStatus Filter::encodeTrailers(Http::HeaderMap& trailers) {
 
 void Filter::setEncoderFilterCallbacks(
     StreamEncoderFilterCallbacks& callbacks) {
+  ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
   encoder_callbacks_ = &callbacks;
 }
 

--- a/src/envoy/http/mixer/filter_factory.cc
+++ b/src/envoy/http/mixer/filter_factory.cc
@@ -104,8 +104,7 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
       }
       std::shared_ptr<Http::Mixer::Filter> instance =
           std::make_shared<Http::Mixer::Filter>(control_factory->control());
-      callbacks.addStreamDecoderFilter(
-          Http::StreamDecoderFilterSharedPtr(instance));
+      callbacks.addStreamFilter(Http::StreamFilterSharedPtr(instance));
       callbacks.addAccessLogHandler(AccessLog::InstanceSharedPtr(instance));
     };
   }

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -81,8 +81,8 @@ void AttributesBuilder::ExtractReportAttributes(
                        request_->check_status.error_code());
       builder.AddString(AttributeName::kCheckErrorMessage,
                         request_->check_status.ToString());
-      builder.AddString(AttributeName::kConnectionEvent, kConnectionClose);
     }
+    builder.AddString(AttributeName::kConnectionEvent, kConnectionClose);
   } else {
     last_report_info->received_bytes = info.received_bytes;
     last_report_info->send_bytes = info.send_bytes;


### PR DESCRIPTION
**What this PR does / why we need it**:Fix Mixer HTTP filter factory callback so that Mixer HTTP filter works as a stream filter instead of a stream decoder filter. Fix Mixer TCP filter to generate connection.event correctly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
