### PR TITLE
No setPeerResult() when peer is empty

### DIFF
--- a/src/envoy/http/authn/peer_authenticator.cc
+++ b/src/envoy/http/authn/peer_authenticator.cc
@@ -36,25 +36,25 @@ bool PeerAuthenticator::run(Payload* payload) {
   if (policy_.peers_size() == 0) {
     ENVOY_LOG(debug, "No method defined. Skip source authentication.");
     success = true;
-  } else {
-    for (const auto& method : policy_.peers()) {
-      switch (method.params_case()) {
-        case iaapi::PeerAuthenticationMethod::ParamsCase::kMtls:
-          success = validateX509(method.mtls(), payload);
-          break;
-        case iaapi::PeerAuthenticationMethod::ParamsCase::kJwt:
-          success = validateJwt(method.jwt(), payload);
-          break;
-        default:
-          ENVOY_LOG(error, "Unknown peer authentication param {}",
-                    method.DebugString());
-          success = false;
-          break;
-      }
-
-      if (success) {
+    return success;
+  }
+  for (const auto& method : policy_.peers()) {
+    switch (method.params_case()) {
+      case iaapi::PeerAuthenticationMethod::ParamsCase::kMtls:
+        success = validateX509(method.mtls(), payload);
         break;
-      }
+      case iaapi::PeerAuthenticationMethod::ParamsCase::kJwt:
+        success = validateJwt(method.jwt(), payload);
+        break;
+      default:
+        ENVOY_LOG(error, "Unknown peer authentication param {}",
+                  method.DebugString());
+        success = false;
+        break;
+    }
+
+    if (success) {
+      break;
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**: when peer is empty in Istio authn policy, do not setPeerResult()

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1460

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
