### PR TITLE
Fix a bug that Istio authn filter blocks downstream filters

### DIFF
--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -77,7 +77,7 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
     Utils::Authentication::SaveResultToHeader(
         filter_context_->authenticationResult(), filter_context_->headers());
   }
-
+  state_ = State::COMPLETE;
   return FilterHeadersStatus::Continue;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fix a bug that the Istio authn filter blocks downstream filters. With this bug, the processing of a HTTP request will not proceed to the filters after the Istio authn filter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1464

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
