### PR TITLE
Support per-route config with new Envoy method

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,7 @@ git_repository(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "cef07618939cdaf25fbc3be7646b6fdbbe780f45"
+ENVOY_SHA = "47c63e59bb7d30f199fb20bf431ea17eace72946"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -13,6 +13,6 @@
 		"repoName": "envoyproxy/envoy",
 		"prodBranch": "master",
 		"file": "WORKSPACE",
-		"lastStableSHA": "cef07618939cdaf25fbc3be7646b6fdbbe780f45"
+		"lastStableSHA": "47c63e59bb7d30f199fb20bf431ea17eace72946"
 	}
 ]

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -17,12 +17,22 @@
 
 #include "common/common/logger.h"
 #include "envoy/access_log/access_log.h"
+#include "envoy/config/filter/http/jwt_authn/v2alpha/config.pb.h"
 #include "envoy/http/filter.h"
 #include "src/envoy/http/mixer/control.h"
 
 namespace Envoy {
 namespace Http {
 namespace Mixer {
+
+// The struct to store per-route service config and its hash.
+struct PerRouteServiceConfig : public Router::RouteSpecificFilterConfig {
+  // The per_route service config.
+  ::istio::mixer::v1::config::client::ServiceConfig config;
+
+  // Its config hash
+  std::string hash;
+};
 
 class Filter : public Http::StreamDecoderFilter,
                public AccessLog::Instance,

--- a/src/envoy/http/mixer/filter_factory.cc
+++ b/src/envoy/http/mixer/filter_factory.cc
@@ -14,6 +14,7 @@
  */
 
 #include "common/config/utility.h"
+#include "common/protobuf/utility.h"
 #include "envoy/json/json_object.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
@@ -52,9 +53,15 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
     return ProtobufTypes::MessagePtr{new HttpClientConfig};
   }
-  ProtobufTypes::MessagePtr createEmptyRouteConfigProto() override {
-    return ProtobufTypes::MessagePtr{new ServiceConfig};
+
+  Router::RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfig(const ProtobufWkt::Struct& config) {
+    auto obj = std::make_shared<Http::Mixer::PerRouteServiceConfig>();
+    MessageUtil::jsonConvert(config, obj->config);
+    obj->hash = std::to_string(MessageUtil::hash(obj->config));
+    return obj;
   }
+
   std::string name() override { return "mixer"; }
 
  private:

--- a/src/envoy/http/mixer/filter_factory.cc
+++ b/src/envoy/http/mixer/filter_factory.cc
@@ -55,7 +55,7 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
   }
 
   Router::RouteSpecificFilterConfigConstSharedPtr
-  createRouteSpecificFilterConfig(const ProtobufWkt::Struct& config) {
+  createRouteSpecificFilterConfig(const ProtobufWkt::Struct& config) override {
     auto obj = std::make_shared<Http::Mixer::PerRouteServiceConfig>();
     MessageUtil::jsonConvert(config, obj->config);
     obj->hash = std::to_string(MessageUtil::hash(obj->config));


### PR DESCRIPTION
**What this PR does / why we need it**:

Envoy has a new perFilterConfig method.  Change Proxy code to use the new method


**Release note**:

```release-note
None
```
