### PR TITLE
update envoy sha

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,7 @@ git_repository(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "47c63e59bb7d30f199fb20bf431ea17eace72946"
+ENVOY_SHA = "cf1e2dffdc4a6284adb76a7118ac59ea8302823a"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -13,6 +13,6 @@
 		"repoName": "envoyproxy/envoy",
 		"prodBranch": "master",
 		"file": "WORKSPACE",
-		"lastStableSHA": "47c63e59bb7d30f199fb20bf431ea17eace72946"
+		"lastStableSHA": "cf1e2dffdc4a6284adb76a7118ac59ea8302823a"
 	}
 ]


### PR DESCRIPTION
Enables fault injection using per-filter configuration.
This SHA is necessary to enable fault injection in envoyv2 in 0.8

cc @hklai

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>