### PR TITLE
Sending full JWT claims as json string via new attribute request.auth.raw_claims

### DIFF
--- a/src/envoy/http/authn/authenticator_base_test.cc
+++ b/src/envoy/http/authn/authenticator_base_test.cc
@@ -307,7 +307,8 @@ TEST_F(ValidateJwtTest, JwtInHeader) {
                  "iss": "issuer@foo.com",
                  "sub": "sub@foo.com",
                  "some-other-string-claims": "some-claims-kept"
-               }
+               },
+               raw_claims: "\n     {\n       \"iss\": \"issuer@foo.com\",\n       \"sub\": \"sub@foo.com\",\n       \"aud\": \"aud1\",\n       \"non-string-will-be-ignored\": 1512754205,\n       \"some-other-string-claims\": \"some-claims-kept\"\n     }\n   "
              }
            }
         )",

--- a/src/envoy/http/authn/authn_utils.cc
+++ b/src/envoy/http/authn/authn_utils.cc
@@ -68,6 +68,7 @@ bool AuthnUtils::GetJWTPayloadFromHeaders(
               jwt_payload_key.get(), value);
     return false;
   }
+  *payload->mutable_raw_claims() = payload_str;
   ::google::protobuf::Map< ::std::string, ::std::string>* claims =
       payload->mutable_claims();
   Envoy::Json::ObjectSharedPtr json_obj;

--- a/src/envoy/http/authn/authn_utils_test.cc
+++ b/src/envoy/http/authn/authn_utils_test.cc
@@ -14,6 +14,7 @@
  */
 #include "src/envoy/http/authn/authn_utils.h"
 #include "common/common/base64.h"
+#include "common/common/utility.h"
 #include "src/envoy/http/authn/test_utils.h"
 #include "test/test_common/utility.h"
 
@@ -91,7 +92,8 @@ TEST(AuthnUtilsTest, GetJwtPayloadFromHeaderTest) {
         key: "some-other-string-claims"
         value: "some-claims-kept"
       }
-    )",
+      raw_claims: ")" +
+          StringUtil::escape(kSecIstioAuthUserinfoHeaderValue) + R"(")",
       &expected_payload));
   // The payload returned from GetJWTPayloadFromHeaders() should be the same as
   // the expected.
@@ -121,7 +123,9 @@ TEST(AuthnUtilsTest, GetJwtPayloadFromHeaderWithNoAudTest) {
         key: "some-other-string-claims"
         value: "some-claims-kept"
       }
-    )",
+      raw_claims: ")" +
+          StringUtil::escape(kSecIstioAuthUserInfoHeaderWithNoAudValue) +
+          R"(")",
       &expected_payload));
   // The payload returned from GetJWTPayloadFromHeaders() should be the same as
   // the expected. When there is no aud,  the aud is not saved in the payload
@@ -154,7 +158,9 @@ TEST(AuthnUtilsTest, GetJwtPayloadFromHeaderWithTwoAudTest) {
         key: "some-other-string-claims"
         value: "some-claims-kept"
       }
-    )",
+      raw_claims: ")" +
+          StringUtil::escape(kSecIstioAuthUserInfoHeaderWithTwoAudValue) +
+          R"(")",
       &expected_payload));
 
   // The payload returned from GetJWTPayloadFromHeaders() should be the same as

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -214,7 +214,8 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckAuthnResultIsExpected) {
                "aud": "bookstore-esp-echo.cloudendpointsapis.com",
                "iss": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com",
                "sub": "628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com"
-              }
+              },
+              raw_claims: "{\"iss\":\"628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com\",\"sub\":\"628645741881-noabiu23f5a8m8ovd8ucv698lj78vv0l@developer.gserviceaccount.com\",\"aud\":\"bookstore-esp-echo.cloudendpointsapis.com\",\"iat\":1512754205,\"exp\":5112754205}"
             }
           }
       )",

--- a/src/istio/authn/context.proto
+++ b/src/istio/authn/context.proto
@@ -35,6 +35,11 @@ message JwtPayload {
 
   // Only raw JWT string claims are kept.
   map<string, string> claims = 5;
+
+  // All original claims in JsonString format, which can be parsed into json
+  // object (map) to access other claims that not cover with the string claims
+  // map above.
+  string raw_claims = 6;
 }
 
 // Container to hold authenticated attributes from X509 (mTLS).

--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -78,6 +78,7 @@ const char AttributeName::kRequestAuthPrincipal[] = "request.auth.principal";
 const char AttributeName::kRequestAuthAudiences[] = "request.auth.audiences";
 const char AttributeName::kRequestAuthPresenter[] = "request.auth.presenter";
 const char AttributeName::kRequestAuthClaims[] = "request.auth.claims";
+const char AttributeName::kRequestAuthRawClaims[] = "request.auth.raw_claims";
 
 }  // namespace control
 }  // namespace istio

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -85,6 +85,7 @@ struct AttributeName {
   static const char kRequestAuthAudiences[];
   static const char kRequestAuthPresenter[];
   static const char kRequestAuthClaims[];
+  static const char kRequestAuthRawClaims[];
 };
 
 }  // namespace control

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -91,7 +91,7 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
       }
       if (!origin.raw_claims().empty()) {
         builder.AddString(AttributeName::kRequestAuthRawClaims,
-                                     origin.raw_claims());
+                          origin.raw_claims());
       }
     }
     return;

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -89,6 +89,10 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
         builder.AddProtobufStringMap(AttributeName::kRequestAuthClaims,
                                      origin.claims());
       }
+      if (!origin.raw_claims().empty()) {
+        builder.AddString(AttributeName::kRequestAuthRawClaims,
+                                     origin.raw_claims());
+      }
     }
     return;
   }

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -398,6 +398,7 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
             "thisisemail@email.com";
         (*result->mutable_origin()->mutable_claims())["iat"] = "1512754205";
         (*result->mutable_origin()->mutable_claims())["exp"] = "5112754205";
+        result->mutable_origin()->set_raw_claims("test_raw_claims");
         return true;
       }));
 
@@ -414,6 +415,12 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   Attributes expected_attributes;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kCheckAttributes, &expected_attributes));
+  // kCheckAttributes is also used in TestCheckAttributes, which is a deprecated way to construct
+  // mixer attribute (it was a fallback when authn filter is not available, which can be removed
+  // after 0.8). For now, modifying expected data manually for this test.
+  (*expected_attributes.mutable_attributes())[AttributeName::kRequestAuthRawClaims]
+      .set_string_value("test_raw_claims");
+
   EXPECT_TRUE(
       MessageDifferencer::Equals(request.attributes, expected_attributes));
 }

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -415,10 +415,12 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   Attributes expected_attributes;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kCheckAttributes, &expected_attributes));
-  // kCheckAttributes is also used in TestCheckAttributes, which is a deprecated way to construct
-  // mixer attribute (it was a fallback when authn filter is not available, which can be removed
-  // after 0.8). For now, modifying expected data manually for this test.
-  (*expected_attributes.mutable_attributes())[AttributeName::kRequestAuthRawClaims]
+  // kCheckAttributes is also used in TestCheckAttributes, which is a deprecated
+  // way to construct mixer attribute (it was a fallback when authn filter is
+  // not available, which can be removed after 0.8). For now, modifying expected
+  // data manually for this test.
+  (*expected_attributes
+        .mutable_attributes())[AttributeName::kRequestAuthRawClaims]
       .set_string_value("test_raw_claims");
 
   EXPECT_TRUE(


### PR DESCRIPTION

Issue: https://github.com/istio/proxy/issues/1743