### PR TITLE
Make release-binary script takes argument for gcs destination

### DIFF
--- a/script/release-binary
+++ b/script/release-binary
@@ -17,13 +17,30 @@
 ################################################################################
 #
 set -ex
+# The bucket name to store proxy binary
+DST="gs://istio-build/proxy"
+
+function usage() {
+  echo "$0
+    -d  The bucket name to store proxy binary (optional)"
+  exit 1
+}
+
+while getopts d: arg ; do
+  case "${arg}" in
+    d) DST="${OPTARG}";;
+    *) usage;;
+  esac
+done
+
+echo "Destination bucket: $DST"
+
+# The bucket name to store proxy binary
+# DST="gs://istio-build/proxy"
 
 # Make sure to this script on x86_64 Ubuntu Xenial
 UBUNTU_RELEASE=${UBUNTU_RELEASE:-$(lsb_release -c -s)}
 [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'must run on Ubuntu Xenial'; exit 1; }
-
-# The bucket name to store proxy binary
-DST="gs://istio-build/proxy"
 
 # The proxy binary name.
 SHA="$(git rev-parse --verify HEAD)"


### PR DESCRIPTION
Hi folks,

To istio/proxy git on borg release, release-binary needs to take gcs bucket parameter, it has no impact in OSS istio/proxy release, besides, for internal proxy release script, it can pass another destination instead of gs://istio-build/proxy.

This PR is tested locally which can build proxy outputs with my own GCB account.

Thanks for your review.
