### PR TITLE
Update Envoy so that SNI is available

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,7 @@ git_repository(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "2b2c299144600fb9e525d21aabf39bf48e64fb1f"
+ENVOY_SHA = "cf0cbc58a02996b53c63e41bfdcd76c02fece84e"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -5,7 +5,7 @@
 		"repoName": "api",
 		"prodBranch": "master",
 		"file": "repositories.bzl",
-		"lastStableSHA": "903cfe96975ade4d2ba913cfbd98cafcea773d86"
+		"lastStableSHA": "793db0cb1a2e33012166f1d6ee5918596b8199d4"
 	},
 	{
 		"_comment": "",

--- a/istio.deps
+++ b/istio.deps
@@ -5,7 +5,7 @@
 		"repoName": "api",
 		"prodBranch": "master",
 		"file": "repositories.bzl",
-		"lastStableSHA": "793db0cb1a2e33012166f1d6ee5918596b8199d4"
+		"lastStableSHA": "78da6e6eb4ad4f158fb58e02f94efde4abf4cabf"
 	},
 	{
 		"_comment": "",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "2b2c299144600fb9e525d21aabf39bf48e64fb1f"
+		"lastStableSHA": "cf0cbc58a02996b53c63e41bfdcd76c02fece84e"
 	}
 ]

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "903cfe96975ade4d2ba913cfbd98cafcea773d86"
+ISTIO_API = "793db0cb1a2e33012166f1d6ee5918596b8199d4"
 
 def mixerapi_repositories(bind=True):
     BUILD = """

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "793db0cb1a2e33012166f1d6ee5918596b8199d4"
+ISTIO_API = "78da6e6eb4ad4f158fb58e02f94efde4abf4cabf"
 
 def mixerapi_repositories(bind=True):
     BUILD = """


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Envoy SHA so that SNI is available. SNI support was merged here: https://github.com/envoyproxy/envoy/pull/3217

I am not sure about the update process for istio/proxy, so please double check this PR.

**Which issue this PR fixes** 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
