### PR TITLE
Protect referenced_map_ read in check cache

### DIFF
--- a/src/istio/mixerclient/check_cache.cc
+++ b/src/istio/mixerclient/check_cache.cc
@@ -101,6 +101,7 @@ Status CheckCache::Check(const Attributes &attributes, Tick time_now) {
     return Status(Code::NOT_FOUND, "");
   }
 
+  std::lock_guard<std::mutex> lock(cache_mutex_);
   for (const auto &it : referenced_map_) {
     const Referenced &reference = it.second;
     std::string signature;
@@ -108,7 +109,6 @@ Status CheckCache::Check(const Attributes &attributes, Tick time_now) {
       continue;
     }
 
-    std::lock_guard<std::mutex> lock(cache_mutex_);
     CheckLRUCache::ScopedLookup lookup(cache_.get(), signature);
     if (lookup.Found()) {
       CacheElem *elem = lookup.value();


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a race condition: 
A read operation for referenced_map_ in CheckCache object is not protected.  

Istio doens't need this fix since it is creating the whole mixer_client object per thread. 
This fix is just a "nice to have" to make mixer_client thread safe.

**Release note**:
```release-note
None
```
