### PR TITLE
Envoy rebase to 5843954375fe

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,7 +38,7 @@ git_repository(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "2b2c299144600fb9e525d21aabf39bf48e64fb1f"
+ENVOY_SHA = "5843954375fe548776d3d5c36ff8bb79cd61f2a0"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "2b2c299144600fb9e525d21aabf39bf48e64fb1f"
+		"lastStableSHA": "5843954375fe548776d3d5c36ff8bb79cd61f2a0"
 	}
 ]

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -114,8 +114,7 @@ void AuthenticationFilter::rejectRequest(const std::string& message) {
     return;
   }
   state_ = State::REJECTED;
-  Utility::sendLocalReply(*decoder_callbacks_, false, Http::Code::Unauthorized,
-                          message);
+  decoder_callbacks_->sendLocalReply(Http::Code::Unauthorized, message, nullptr);
 }
 
 std::unique_ptr<Istio::AuthN::AuthenticatorBase>

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -62,16 +62,16 @@ TEST_P(AuthenticationFilterIntegrationTest, EmptyPolicy) {
   createTestServer("src/envoy/http/authn/testdata/envoy_empty.conf", {"http"});
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(default_request_headers_, *response_);
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   // Wait for request to upstream[0] (backend)
   waitForNextUpstreamRequest(0);
   // Send backend response.
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}},
                                    true);
 
-  response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
-  EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_P(AuthenticationFilterIntegrationTest, SourceMTlsFail) {
@@ -82,13 +82,13 @@ TEST_P(AuthenticationFilterIntegrationTest, SourceMTlsFail) {
   // would be rejected.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(default_request_headers_, *response_);
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
   // Request is rejected, there will be no upstream request (thus no
   // waitForNextUpstreamRequest).
-  response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
-  EXPECT_STREQ("401", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("401", response->headers().Status()->value().c_str());
 }
 
 // TODO (diemtvu/lei-tang): add test for MTls success.
@@ -102,13 +102,13 @@ TEST_P(AuthenticationFilterIntegrationTest, OriginJwtRequiredHeaderNoJwtFail) {
   // would be rejected.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(default_request_headers_, *response_);
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
   // Request is rejected, there will be no upstream request (thus no
   // waitForNextUpstreamRequest).
-  response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
-  EXPECT_STREQ("401", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("401", response->headers().Status()->value().c_str());
 }
 
 TEST_P(AuthenticationFilterIntegrationTest, CheckValidJwtPassAuthentication) {
@@ -120,7 +120,7 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckValidJwtPassAuthentication) {
   // the authentication should succeed.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(request_headers_with_jwt_, *response_);
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers_with_jwt_);
 
   // Wait for request to upstream[0] (backend)
   waitForNextUpstreamRequest(0);
@@ -128,9 +128,9 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckValidJwtPassAuthentication) {
   upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}},
                                    true);
 
-  response_->waitForEndStream();
-  EXPECT_TRUE(response_->complete());
-  EXPECT_STREQ("200", response_->headers().Status()->value().c_str());
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
 }
 
 TEST_P(AuthenticationFilterIntegrationTest, CheckConsumedJwtHeadersAreRemoved) {
@@ -165,7 +165,7 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckConsumedJwtHeadersAreRemoved) {
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
   codec_client_->makeHeaderOnlyRequest(
-      request_headers_with_jwt_at_specified_location, *response_);
+      request_headers_with_jwt_at_specified_location);
 
   // Wait for request to upstream[0] (backend)
   waitForNextUpstreamRequest(0);
@@ -185,7 +185,7 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckAuthnResultIsExpected) {
   // should be generated.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(request_headers_with_jwt_, *response_);
+  codec_client_->makeHeaderOnlyRequest(request_headers_with_jwt_);
 
   // Wait for request to upstream[0] (backend)
   waitForNextUpstreamRequest(0);

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -164,11 +164,13 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckConsumedJwtHeadersAreRemoved) {
   // should be generated.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(
+  auto response = codec_client_->makeHeaderOnlyRequest(
       request_headers_with_jwt_at_specified_location);
 
   // Wait for request to upstream[0] (backend)
   waitForNextUpstreamRequest(0);
+
+  response->waitForEndStream();
 
   // After Istio authn, the JWT headers consumed by Istio authn should have
   // been removed.
@@ -185,10 +187,12 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckAuthnResultIsExpected) {
   // should be generated.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  codec_client_->makeHeaderOnlyRequest(request_headers_with_jwt_);
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers_with_jwt_);
 
   // Wait for request to upstream[0] (backend)
   waitForNextUpstreamRequest(0);
+
+  response->waitForEndStream();
 
   // Authn result should be as expected
   const Envoy::Http::HeaderString &header_value =

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -70,8 +70,7 @@ void JwtVerificationFilter::onDone(const JwtAuth::Status& status) {
     // verification failed
     Code code = Code(401);  // Unauthorized
     // return failure reason as message body
-    Utility::sendLocalReply(*decoder_callbacks_, false, code,
-                            JwtAuth::StatusToString(status));
+    decoder_callbacks_->sendLocalReply(code, JwtAuth::StatusToString(status), nullptr);
     return;
   }
 

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -186,8 +186,7 @@ void Filter::completeCheck(const Status& status) {
   if (!status.ok() && state_ != Responded) {
     state_ = Responded;
     int status_code = ::istio::utils::StatusHttpCode(status.error_code());
-    Utility::sendLocalReply(*decoder_callbacks_, false, Code(status_code),
-                            status.ToString());
+    decoder_callbacks_->sendLocalReply(Code(status_code), status.ToString(), nullptr);
     return;
   }
 


### PR DESCRIPTION
Envoy commit 5843954375fe548776d3d5c36ff8bb79cd61f2a0 adds a
sendLocalReply() callback that formats gRPC responses when the request
was gRPC, HTTP response otherwise.

test changes are due to Envoy commit
7379c351af794feb66f12f3963da6d4167e744ef ("test: remove response_ as
member variable. (#3314)").

Signed-off-by: Jarno Rajahalme jarno@covalent.io
