### PR TITLE
Apply EDS per-host metadata override

### DIFF
--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -44,6 +44,9 @@ class ReportData {
   virtual void GetReportInfo(ReportInfo* info) const = 0;
 
   virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
+
+  // Get upstream host UID. This value overrides the value in the report bag.
+  virtual bool GetDestinationUID(std::string* uid) const = 0;
 };
 
 }  // namespace http

--- a/include/istio/control/tcp/report_data.h
+++ b/include/istio/control/tcp/report_data.h
@@ -39,6 +39,9 @@ class ReportData {
     std::chrono::nanoseconds duration;
   };
   virtual void GetReportInfo(ReportInfo* info) const = 0;
+
+  // Get upstream host UID. This value overrides the value in the report bag.
+  virtual bool GetDestinationUID(std::string* uid) const = 0;
 };
 
 }  // namespace tcp

--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "636ea68d62bf143ee9f8067a31a7824804613440"
+		"lastStableSHA": "7d7710a0533b543527897badc342c50eb169c83e"
 	},
 	{
 		"_comment": "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "636ea68d62bf143ee9f8067a31a7824804613440"
+ISTIO_API = "7d7710a0533b543527897badc342c50eb169c83e"
 
 def mixerapi_repositories(bind=True):
     BUILD = """

--- a/src/envoy/http/mixer/README.md
+++ b/src/envoy/http/mixer/README.md
@@ -233,4 +233,8 @@ This filter will intercept a tcp connection:
 * All mixer settings described above can be used here.
 * disable_tcp_check_calls is a tcp filter specific config to disable check for tcp connection.
 
+## How to override destination.uid for upstream hosts
 
+You can set metadata field `destination.uid` for filter `mixer` to a string
+value in the per-host metadata in the EDS response. That will override the
+value of the attribute sent to the telemetry service.

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -77,6 +77,13 @@ class ReportData : public ::istio::control::http::ReportData {
     }
     return false;
   }
+
+  bool GetDestinationUID(std::string *uid) const override {
+    if (info_.upstreamHost()) {
+      return Utils::GetDestinationUID(info_.upstreamHost()->metadata(), uid);
+    }
+    return false;
+  }
 };
 
 }  // namespace Mixer

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -163,6 +163,13 @@ bool Filter::GetDestinationIpPort(std::string* str_ip, int* port) const {
   }
   return false;
 }
+bool Filter::GetDestinationUID(std::string* uid) const {
+  if (filter_callbacks_->upstreamHost()) {  // TODO: guard metadata
+    return Utils::GetDestinationUID(
+        filter_callbacks_->upstreamHost()->metadata(), uid);
+  }
+  return false;
+}
 void Filter::GetReportInfo(
     ::istio::control::tcp::ReportData::ReportInfo* data) const {
   data->received_bytes = received_bytes_;

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -56,6 +56,7 @@ class Filter : public Network::Filter,
 
   // ReportData virtual functions.
   bool GetDestinationIpPort(std::string* str_ip, int* port) const override;
+  bool GetDestinationUID(std::string* uid) const override;
   void GetReportInfo(
       ::istio::control::tcp::ReportData::ReportInfo* data) const override;
   std::string GetConnectionId() const override;

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -70,6 +70,20 @@ bool GetIpPort(const Network::Address::Ip* ip, std::string* str_ip, int* port) {
   return false;
 }
 
+bool GetDestinationUID(const envoy::api::v2::core::Metadata& metadata,
+                       std::string* uid) {
+  const auto filter_it = metadata.filter_metadata().find("mixer");
+  if (filter_it == metadata.filter_metadata().end()) {
+    return false;
+  }
+  const auto fields_it = filter_it->second.fields().find("destination.uid");
+  if (fields_it == filter_it->second.fields().end()) {
+    return false;
+  }
+  *uid = fields_it->second.string_value();
+  return true;
+}
+
 bool GetSourceUser(const Network::Connection* connection, std::string* user) {
   if (connection) {
     Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -32,6 +32,10 @@ std::map<std::string, std::string> ExtractHeaders(
 // Get ip and port from Envoy ip.
 bool GetIpPort(const Network::Address::Ip* ip, std::string* str_ip, int* port);
 
+// Get destination.uid attribute value from metadata.
+bool GetDestinationUID(const envoy::api::v2::core::Metadata& metadata,
+                       std::string* uid);
+
 // Get user id from ssl.
 bool GetSourceUser(const Network::Connection* connection, std::string* user);
 

--- a/src/istio/control/attribute_names.cc
+++ b/src/istio/control/attribute_names.cc
@@ -45,9 +45,10 @@ const char AttributeName::kResponseTime[] = "response.time";
 // Downstream tcp connection: source ip/port.
 const char AttributeName::kSourceIp[] = "source.ip";
 const char AttributeName::kSourcePort[] = "source.port";
-// Upstream tcp connection: destionation ip/port.
+// Upstream tcp connection: destination ip/port.
 const char AttributeName::kDestinationIp[] = "destination.ip";
 const char AttributeName::kDestinationPort[] = "destination.port";
+const char AttributeName::kDestinationUID[] = "destination.uid";
 const char AttributeName::kConnectionReceviedBytes[] =
     "connection.received.bytes";
 const char AttributeName::kConnectionReceviedTotalBytes[] =

--- a/src/istio/control/attribute_names.h
+++ b/src/istio/control/attribute_names.h
@@ -58,6 +58,7 @@ struct AttributeName {
 
   static const char kDestinationIp[];
   static const char kDestinationPort[];
+  static const char kDestinationUID[];
   static const char kConnectionReceviedBytes[];
   static const char kConnectionReceviedTotalBytes[];
   static const char kConnectionSendBytes[];

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -175,6 +175,11 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
     builder.AddInt64(AttributeName::kDestinationPort, dest_port);
   }
 
+  std::string uid;
+  if (report_data->GetDestinationUID(&uid)) {
+    builder.AddString(AttributeName::kDestinationUID, uid);
+  }
+
   std::map<std::string, std::string> headers =
       report_data->GetResponseHeaders();
   builder.AddStringMap(AttributeName::kResponseHeaders, headers);

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -435,6 +435,11 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         *port = 8080;
         return true;
       }));
+  EXPECT_CALL(mock_data, GetDestinationUID(_))
+      .WillOnce(Invoke([](std::string *uid) -> bool {
+        *uid = "pod1.ns2";
+        return true;
+      }));
   EXPECT_CALL(mock_data, GetResponseHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;
@@ -465,6 +470,8 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   Attributes expected_attributes;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kReportAttributes, &expected_attributes));
+  (*expected_attributes.mutable_attributes())[AttributeName::kDestinationUID]
+      .set_string_value("pod1.ns2");
   EXPECT_TRUE(
       MessageDifferencer::Equals(request.attributes, expected_attributes));
 }

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -29,6 +29,7 @@ class MockReportData : public ReportData {
   MOCK_CONST_METHOD0(GetResponseHeaders, std::map<std::string, std::string>());
   MOCK_CONST_METHOD1(GetReportInfo, void(ReportInfo* info));
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
+  MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string* ip));
 };
 
 }  // namespace http

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -96,6 +96,11 @@ void AttributesBuilder::ExtractReportAttributes(
     builder.AddInt64(AttributeName::kDestinationPort, dest_port);
   }
 
+  std::string uid;
+  if (report_data->GetDestinationUID(&uid)) {
+    builder.AddString(AttributeName::kDestinationUID, uid);
+  }
+
   builder.AddTimestamp(AttributeName::kContextTime,
                        std::chrono::system_clock::now());
 }

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -163,6 +163,12 @@ attributes {
     int64_value: 8080
   }
 }
+attributes {
+  key: "destination.uid"
+  value {
+    string_value: "pod1.ns2"
+  }
+}
 )";
 
 const char kDeltaOneReportAttributes[] = R"(
@@ -213,6 +219,12 @@ attributes {
   key: "destination.port"
   value {
     int64_value: 8080
+  }
+}
+attributes {
+  key: "destination.uid"
+  value {
+    string_value: "pod1.ns2"
   }
 }
 )";
@@ -267,6 +279,12 @@ attributes {
     int64_value: 8080
   }
 }
+attributes {
+  key: "destination.uid"
+  value {
+    string_value: "pod1.ns2"
+  }
+}
 )";
 
 void ClearContextTime(RequestContext* request) {
@@ -318,6 +336,12 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
       .WillRepeatedly(Invoke([](std::string* ip, int* port) -> bool {
         *ip = "1.2.3.4";
         *port = 8080;
+        return true;
+      }));
+  EXPECT_CALL(mock_data, GetDestinationUID(_))
+      .Times(3)
+      .WillRepeatedly(Invoke([](std::string* uid) -> bool {
+        *uid = "pod1.ns2";
         return true;
       }));
   EXPECT_CALL(mock_data, GetReportInfo(_))

--- a/src/istio/control/tcp/mock_report_data.h
+++ b/src/istio/control/tcp/mock_report_data.h
@@ -27,6 +27,7 @@ namespace tcp {
 class MockReportData : public ReportData {
  public:
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
+  MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string*));
   MOCK_CONST_METHOD1(GetReportInfo, void(ReportInfo* info));
 };
 

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -102,6 +102,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
 TEST_F(RequestHandlerImplTest, TestHandlerReport) {
   ::testing::NiceMock<MockReportData> mock_data;
   EXPECT_CALL(mock_data, GetDestinationIpPort(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetDestinationUID(_)).Times(1);
   EXPECT_CALL(mock_data, GetReportInfo(_)).Times(1);
 
   // Report should be called.


### PR DESCRIPTION
This PR allows overriding `destination.uid` per host in EDS response.