### PR TITLE
Release-0.8: Build additional artifacts with debug symbols

### DIFF
--- a/script/release-binary
+++ b/script/release-binary
@@ -27,13 +27,27 @@ DST="gs://istio-build/proxy"
 
 # The proxy binary name.
 SHA="$(git rev-parse --verify HEAD)"
-BINARY_NAME="envoy-alpha-${SHA}.tar.gz"
-SHA256_NAME="envoy-alpha-${SHA}.sha256"
+
+BINARY_NAME="envoy-symbol-${SHA}.tar.gz"
+SHA256_NAME="envoy-symbol-${SHA}.sha256"
 
 # If binary already exists skip.
 gsutil stat "${DST}/${BINARY_NAME}" \
   && { echo 'Binary already exists'; exit 0; } \
   || echo 'Building a new binary.'
+
+# Build the release binary with symbol
+bazel --batch build --config=release-symbol //src/envoy:envoy_tar
+BAZEL_TARGET="bazel-bin/src/envoy/envoy_tar.tar.gz"
+cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
+sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
+
+# Copy it to the bucket.
+echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
+gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
+
+BINARY_NAME="envoy-alpha-${SHA}.tar.gz"
+SHA256_NAME="envoy-alpha-${SHA}.sha256"
 
 # Build the release binary
 bazel --batch build --config=release //src/envoy:envoy_tar

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -47,9 +47,12 @@ build:clang-msan --copt -fsanitize-memory-track-origins=2
 # Test options
 test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
 
-# Release builds
+# Release builds without debug symbols.
 build:release -c opt
 build:release --strip=always
+
+# Release builds with debug symbols
+build:release-symbol -c opt
 
 # Add compile option for all C++ files
 build --cxxopt -Wnon-virtual-dtor


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a build step to build release envoy binary with debug symbol.  and copy it to the istio-build storage
The production docker image still use the release envoy without debug symbol.    

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
