### PR TITLE
Remove source auto-derivation

### DIFF
--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -142,12 +142,6 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
 
   utils::AttributesBuilder builder(&request_->attributes);
 
-  std::string source_ip;
-  int source_port;
-  if (check_data->GetSourceIpPort(&source_ip, &source_port)) {
-    builder.AddBytes(AttributeName::kSourceIp, source_ip);
-    builder.AddInt64(AttributeName::kSourcePort, source_port);
-  }
   builder.AddBool(AttributeName::kConnectionMtls, check_data->IsMutualTLS());
 
   builder.AddTimestamp(AttributeName::kRequestTime,
@@ -167,12 +161,14 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
 
   std::string dest_ip;
   int dest_port;
+  // Do not overwrite destination IP and port if it has already been set.
   if (report_data->GetDestinationIpPort(&dest_ip, &dest_port)) {
-    // Do not overwrite DestionationIP if it has already been set.
     if (!builder.HasAttribute(AttributeName::kDestinationIp)) {
       builder.AddBytes(AttributeName::kDestinationIp, dest_ip);
     }
-    builder.AddInt64(AttributeName::kDestinationPort, dest_port);
+    if (!builder.HasAttribute(AttributeName::kDestinationPort)) {
+      builder.AddInt64(AttributeName::kDestinationPort, dest_port);
+    }
   }
 
   std::map<std::string, std::string> headers =

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -84,18 +84,6 @@ attributes {
   }
 }
 attributes {
-  key: "source.ip"
-  value {
-    bytes_value: "1.2.3.4"
-  }
-}
-attributes {
-  key: "source.port"
-  value {
-    int64_value: 8080
-  }
-}
-attributes {
   key: "connection.mtls"
   value {
     bool_value: true
@@ -290,12 +278,6 @@ TEST(AttributesBuilderTest, TestForwardAttributes) {
 
 TEST(AttributesBuilderTest, TestCheckAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _))
-      .WillOnce(Invoke([](std::string *ip, int *port) -> bool {
-        *ip = "1.2.3.4";
-        *port = 8080;
-        return true;
-      }));
   EXPECT_CALL(mock_data, GetSourceUser(_))
       .WillOnce(Invoke([](std::string *user) -> bool {
         *user = "test_user";
@@ -356,12 +338,6 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
 
 TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   ::testing::NiceMock<MockCheckData> mock_data;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _))
-      .WillOnce(Invoke([](std::string *ip, int *port) -> bool {
-        *ip = "1.2.3.4";
-        *port = 8080;
-        return true;
-      }));
   EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
     return true;
   }));

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -153,7 +153,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   // Check should NOT be called.
@@ -172,7 +172,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
 TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   // Check should be called.
@@ -200,7 +200,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
 TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   // Check should be called.
@@ -224,7 +224,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
 TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   ServiceConfig route_config;
@@ -330,7 +330,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteApiSpec) {
 TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
   EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
 
   // Check should be called.

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -33,9 +33,10 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
 
   std::string source_ip;
   int source_port;
+  // TODO(kuat): there is no way to propagate source IP in TCP, so we auto-set
+  // it
   if (check_data->GetSourceIpPort(&source_ip, &source_port)) {
     builder.AddBytes(AttributeName::kSourceIp, source_ip);
-    builder.AddInt64(AttributeName::kSourcePort, source_port);
   }
 
   // TODO(diemtvu): add TCP authn filter similar to http case, and use authn
@@ -91,9 +92,14 @@ void AttributesBuilder::ExtractReportAttributes(
 
   std::string dest_ip;
   int dest_port;
+  // Do not overwrite destination IP and port if it has already been set.
   if (report_data->GetDestinationIpPort(&dest_ip, &dest_port)) {
-    builder.AddBytes(AttributeName::kDestinationIp, dest_ip);
-    builder.AddInt64(AttributeName::kDestinationPort, dest_port);
+    if (!builder.HasAttribute(AttributeName::kDestinationIp)) {
+      builder.AddBytes(AttributeName::kDestinationIp, dest_ip);
+    }
+    if (!builder.HasAttribute(AttributeName::kDestinationPort)) {
+      builder.AddInt64(AttributeName::kDestinationPort, dest_port);
+    }
   }
 
   builder.AddTimestamp(AttributeName::kContextTime,

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -68,12 +68,6 @@ attributes {
   }
 }
 attributes {
-  key: "source.port"
-  value {
-    int64_value: 8080
-  }
-}
-attributes {
   key: "source.principal"
   value {
     string_value: "test_user"


### PR DESCRIPTION
Remove source port auto-derivation. It's meaningless and has no value.

Remove source IP auto-derivation for HTTP. Always filling in source.ip provides false data at ingress.

Remote destination port auto-filling if the attribute is set statically. That fixes the problem with UDS upstreams.