### PR TITLE
Add control plane attribute forwarding

### DIFF
--- a/src/envoy/http/mixer/BUILD
+++ b/src/envoy/http/mixer/BUILD
@@ -33,7 +33,6 @@ envoy_cc_library(
         "filter.cc",
         "filter.h",
         "filter_factory.cc",
-        "header_update.h",
         "report_data.h",
     ],
     repository = "@envoy",

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -18,6 +18,7 @@
 #include "src/envoy/http/jwt_auth/jwt.h"
 #include "src/envoy/http/jwt_auth/jwt_authenticator.h"
 #include "src/envoy/utils/authn.h"
+#include "src/envoy/utils/header_update.h"
 #include "src/envoy/utils/utils.h"
 
 using HttpCheckData = ::istio::control::http::CheckData;
@@ -26,15 +27,12 @@ namespace Envoy {
 namespace Http {
 namespace Mixer {
 namespace {
-// The HTTP header to forward Istio attributes.
-const LowerCaseString kIstioAttributeHeader("x-istio-attributes");
-
 // Referer header
 const LowerCaseString kRefererHeaderKey("referer");
 
 // Set of headers excluded from request.headers attribute.
 const std::set<std::string> RequestHeaderExclusives = {
-    kIstioAttributeHeader.get(),
+    Utils::HeaderUpdate::IstioAttributeHeader().get(),
 };
 
 }  // namespace
@@ -48,13 +46,10 @@ CheckData::CheckData(const HeaderMap& headers,
   }
 }
 
-const LowerCaseString& CheckData::IstioAttributeHeader() {
-  return kIstioAttributeHeader;
-}
-
 bool CheckData::ExtractIstioAttributes(std::string* data) const {
   // Extract attributes from x-istio-attributes header
-  const HeaderEntry* entry = headers_.get(kIstioAttributeHeader);
+  const HeaderEntry* entry =
+      headers_.get(Utils::HeaderUpdate::IstioAttributeHeader());
   if (entry) {
     *data = Base64::decode(
         std::string(entry->value().c_str(), entry->value().size()));

--- a/src/envoy/http/mixer/check_data.h
+++ b/src/envoy/http/mixer/check_data.h
@@ -59,8 +59,6 @@ class CheckData : public ::istio::control::http::CheckData,
 
   bool GetAuthenticationResult(istio::authn::Result* result) const override;
 
-  static const LowerCaseString& IstioAttributeHeader();
-
  private:
   const HeaderMap& headers_;
   const Network::Connection* connection_;

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -35,15 +35,19 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  }) {
   ::istio::control::http::Controller::Options options(config_.config_pb());
 
-  Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
-                           *report_client_factory_, &options.env);
+  Utils::CreateEnvironment(
+      dispatcher, random, *check_client_factory_, *report_client_factory_,
+      &options.env,
+      config_.config_pb().transport().attributes_for_mixer_proxy());
 
   controller_ = ::istio::control::http::Controller::Create(options);
 }
 
 Utils::CheckTransport::Func Control::GetCheckTransport(
     Tracing::Span& parent_span) {
-  return Utils::CheckTransport::GetFunc(*check_client_factory_, parent_span);
+  return Utils::CheckTransport::GetFunc(
+      *check_client_factory_, parent_span,
+      config_.config_pb().transport().attributes_for_mixer_proxy());
 }
 
 // Call controller to get statistics.

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -18,9 +18,9 @@
 #include "common/common/base64.h"
 #include "include/istio/utils/status.h"
 #include "src/envoy/http/mixer/check_data.h"
-#include "src/envoy/http/mixer/header_update.h"
 #include "src/envoy/http/mixer/report_data.h"
 #include "src/envoy/utils/authn.h"
+#include "src/envoy/utils/header_update.h"
 
 using ::google::protobuf::util::Status;
 using ::istio::mixer::v1::config::client::ServiceConfig;
@@ -130,7 +130,7 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
   state_ = Calling;
   initiating_call_ = true;
   CheckData check_data(headers, decoder_callbacks_->connection());
-  HeaderUpdate header_update(&headers);
+  Utils::HeaderUpdate header_update(&headers);
   headers_ = &headers;
   cancel_check_ = handler_->Check(
       &check_data, &header_update,

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -38,8 +38,10 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
       uuid_(uuid) {
   ::istio::control::tcp::Controller::Options options(config_.config_pb());
 
-  Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
-                           *report_client_factory_, &options.env);
+  Utils::CreateEnvironment(
+      dispatcher, random, *check_client_factory_, *report_client_factory_,
+      &options.env,
+      config_.config_pb().transport().attributes_for_mixer_proxy());
 
   controller_ = ::istio::control::tcp::Controller::Create(options);
 }

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -49,6 +49,7 @@ envoy_cc_library(
     hdrs = [
         "config.h",
         "grpc_transport.h",
+        "header_update.h",
         "mixer_control.h",
         "stats.h",
         "utils.h",
@@ -58,6 +59,7 @@ envoy_cc_library(
     deps = [
         "//external:mixer_client_config_cc_proto",
         "//src/istio/mixerclient:mixerclient_lib",
+        "//src/istio/control/http:control_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -34,14 +34,13 @@ GrpcTransport<RequestType, ResponseType>::GrpcTransport(
     const Attributes &forward_attributes, istio::mixerclient::DoneFunc on_done)
     : async_client_(std::move(async_client)),
       response_(response),
+      forward_attributes_(forward_attributes),
       on_done_(on_done),
       request_(async_client_->send(
           descriptor(), request, *this, parent_span,
           absl::optional<std::chrono::milliseconds>(kGrpcRequestTimeoutMs))) {
   ENVOY_LOG(debug, "Sending {} request: {}", descriptor().name(),
             request.DebugString());
-
-  forward_attributes.SerializeToString(&forward_attributes_);
 }
 
 template <class RequestType, class ResponseType>

--- a/src/envoy/utils/grpc_transport.h
+++ b/src/envoy/utils/grpc_transport.h
@@ -57,7 +57,9 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
     metadata.Host()->value("mixer", 5);
 
     HeaderUpdate header_update_(&metadata);
-    header_update_.AddIstioAttributes(forward_attributes_);
+    std::string serialized_attributes;
+    forward_attributes_.SerializeToString(&serialized_attributes);
+    header_update_.AddIstioAttributes(serialized_attributes);
   }
 
   void onSuccess(std::unique_ptr<ResponseType>&& response,
@@ -73,9 +75,9 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
 
   Grpc::AsyncClientPtr async_client_;
   ResponseType* response_;
+  const Attributes& forward_attributes_;
   ::istio::mixerclient::DoneFunc on_done_;
   Grpc::AsyncRequest* request_{};
-  std::string forward_attributes_;
 };
 
 typedef GrpcTransport<istio::mixer::v1::CheckRequest,

--- a/src/envoy/utils/header_update.h
+++ b/src/envoy/utils/header_update.h
@@ -17,32 +17,41 @@
 
 #include "common/common/logger.h"
 #include "envoy/http/header_map.h"
+#include "common/common/base64.h"
+
 #include "include/istio/control/http/controller.h"
-#include "src/envoy/http/mixer/check_data.h"
 
 namespace Envoy {
-namespace Http {
-namespace Mixer {
+namespace Utils {
+
+namespace {
+// The HTTP header to forward Istio attributes.
+const Http::LowerCaseString kIstioAttributeHeader("x-istio-attributes");
+}; // namespace
 
 class HeaderUpdate : public ::istio::control::http::HeaderUpdate,
                      public Logger::Loggable<Logger::Id::filter> {
-  HeaderMap* headers_;
+  Http::HeaderMap* headers_;
 
  public:
-  HeaderUpdate(HeaderMap* headers) : headers_(headers) {}
+  HeaderUpdate(Http::HeaderMap* headers) : headers_(headers) {}
 
   void RemoveIstioAttributes() override {
-    headers_->remove(CheckData::IstioAttributeHeader());
+    headers_->remove(kIstioAttributeHeader);
   }
 
   // base64 encode data, and add it to the HTTP header.
   void AddIstioAttributes(const std::string& data) override {
     std::string base64 = Base64::encode(data.c_str(), data.size());
     ENVOY_LOG(debug, "Mixer forward attributes set: {}", base64);
-    headers_->addReferenceKey(CheckData::IstioAttributeHeader(), base64);
+    headers_->setReferenceKey(kIstioAttributeHeader, base64);
   }
+
+  static const Http::LowerCaseString& IstioAttributeHeader() {
+    return kIstioAttributeHeader;
+  }
+
 };
 
-}  // namespace Mixer
-}  // namespace Http
+}  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/header_update.h
+++ b/src/envoy/utils/header_update.h
@@ -15,9 +15,9 @@
 
 #pragma once
 
+#include "common/common/base64.h"
 #include "common/common/logger.h"
 #include "envoy/http/header_map.h"
-#include "common/common/base64.h"
 
 #include "include/istio/control/http/controller.h"
 
@@ -27,7 +27,7 @@ namespace Utils {
 namespace {
 // The HTTP header to forward Istio attributes.
 const Http::LowerCaseString kIstioAttributeHeader("x-istio-attributes");
-}; // namespace
+};  // namespace
 
 class HeaderUpdate : public ::istio::control::http::HeaderUpdate,
                      public Logger::Loggable<Logger::Id::filter> {
@@ -50,7 +50,6 @@ class HeaderUpdate : public ::istio::control::http::HeaderUpdate,
   static const Http::LowerCaseString& IstioAttributeHeader() {
     return kIstioAttributeHeader;
   }
-
 };
 
 }  // namespace Utils

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -60,11 +60,12 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-                       ::istio::mixerclient::Environment *env) {
-  env->check_transport = CheckTransport::GetFunc(check_client_factory,
-                                                 Tracing::NullSpan::instance());
+                       ::istio::mixerclient::Environment *env,
+                       const Attributes &forward_attributes) {
+  env->check_transport = CheckTransport::GetFunc(
+      check_client_factory, Tracing::NullSpan::instance(), forward_attributes);
   env->report_transport = ReportTransport::GetFunc(
-      report_client_factory, Tracing::NullSpan::instance());
+      report_client_factory, Tracing::NullSpan::instance(), forward_attributes);
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixerclient::Timer> {

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -21,6 +21,8 @@
 #include "include/istio/mixerclient/client.h"
 #include "src/envoy/utils/config.h"
 
+using ::istio::mixer::v1::Attributes;
+
 namespace Envoy {
 namespace Utils {
 
@@ -29,7 +31,8 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-                       ::istio::mixerclient::Environment *env);
+                       ::istio::mixerclient::Environment *env,
+                       const Attributes &forward_attributes);
 
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,


### PR DESCRIPTION
Implements API change https://github.com/istio/api/pull/502.

Some refactoring was due to move header encoding into shared utilities, since HTTP upstreams are used for TCP filters.

Manually verified in bookinfo:
```
{"level":"info","time":"2018-05-24T22:37:58.354941Z","instance":"accesslog.logentry.istio-system","destination":"istio-telemetry.istio-system.svc.cluster.local","destinationUid":"kubernetes://istio-telemetry-6984b98654-6fqj6.istio-system","source":"details.default.svc.cluster.local","sourceIp":"10.32.2.104","sourceUid":"default/details-v1-79c5c966db-zwgn4"}
```