### PR TITLE
Merge release-0.8 to master:  Just update Envoy sha to c2baf348055284ac761d94e9a06bc37ebf8a3532

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "8d67e57e3612dae1a3423795bce93a372cfe4fa4"
+		"lastStableSHA": "ecef45ec0f0ef17c4b383ee84dcbcdba4fcc0c8d"
 	},
 	{
 		"_comment": "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "8d67e57e3612dae1a3423795bce93a372cfe4fa4"
+ISTIO_API = "ecef45ec0f0ef17c4b383ee84dcbcdba4fcc0c8d"
 
 def mixerapi_repositories(bind=True):
     BUILD = """


### PR DESCRIPTION
**What this PR does / why we need it**:

Merge changes from release-0.8 to master.
Essentially just update Envoy sha

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
