### PR TITLE
R08: fix Envoy crash, not to flush batched report when worker thread going away

### DIFF
--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -36,10 +36,12 @@ ReportBatch::ReportBatch(const ReportOptions& options,
       total_report_calls_(0),
       total_remote_report_calls_(0) {}
 
-ReportBatch::~ReportBatch() { Flush(); }
+ReportBatch::~ReportBatch() {
+  // No to flush batched report in the destructor. At this time
+  // Transport may be gone, may not be used.
+}
 
 void ReportBatch::Report(const Attributes& request) {
-  std::lock_guard<std::mutex> lock(mutex_);
   ++total_report_calls_;
   if (!batch_compressor_) {
     batch_compressor_ = compressor_.CreateBatchCompressor();

--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -38,7 +38,7 @@ ReportBatch::ReportBatch(const ReportOptions& options,
 
 ReportBatch::~ReportBatch() {
   // No to flush batched report in the destructor. At this time
-  // Transport may be gone, may not be used.
+  // Transport may be gone, should not be used.
 }
 
 void ReportBatch::Report(const Attributes& request) {

--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -42,6 +42,7 @@ ReportBatch::~ReportBatch() {
 }
 
 void ReportBatch::Report(const Attributes& request) {
+  std::lock_guard<std::mutex> lock(mutex_);
   ++total_report_calls_;
   if (!batch_compressor_) {
     batch_compressor_ = compressor_.CreateBatchCompressor();


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix crash reported in https://github.com/istio/proxy/issues/1789
Cherry pick the fix into release-0.8 branch

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
