### PR TITLE
Revert Not to flush out batched report in destructor (#1790)

### DIFF
--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -36,10 +36,7 @@ ReportBatch::ReportBatch(const ReportOptions& options,
       total_report_calls_(0),
       total_remote_report_calls_(0) {}
 
-ReportBatch::~ReportBatch() {
-  // No to flush batched report in the destructor. At this time
-  // Transport may be gone, should not be used.
-}
+ReportBatch::~ReportBatch() { Flush(); }
 
 void ReportBatch::Report(const Attributes& request) {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
This reverts commit e9cdb205862ca1fcf54b208ea73232bbfc23f919.

Will try to fix crash in another PR.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
