### PR TITLE
Release-0.8: Move controler to be the last object

### DIFF
--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -49,13 +49,13 @@ class Control final : public ThreadLocal::ThreadLocalObject {
 
   // The mixer config.
   const Config& config_;
-  // The mixer control
-  std::unique_ptr<::istio::control::http::Controller> controller_;
   // async client factories
   Grpc::AsyncClientFactoryPtr check_client_factory_;
   Grpc::AsyncClientFactoryPtr report_client_factory_;
   // The stats object.
   Utils::MixerStatsObject stats_obj_;
+  // The mixer control
+  std::unique_ptr<::istio::control::http::Controller> controller_;
 };
 
 }  // namespace Mixer

--- a/src/envoy/tcp/mixer/control.h
+++ b/src/envoy/tcp/mixer/control.h
@@ -49,8 +49,6 @@ class Control final : public ThreadLocal::ThreadLocalObject {
 
   // The mixer config.
   const Config& config_;
-  // The mixer control
-  std::unique_ptr<::istio::control::tcp::Controller> controller_;
 
   // dispatcher.
   Event::Dispatcher& dispatcher_;
@@ -63,6 +61,8 @@ class Control final : public ThreadLocal::ThreadLocalObject {
   Utils::MixerStatsObject stats_obj_;
   // UUID of the Envoy TCP mixer filter.
   const std::string& uuid_;
+  // The mixer control
+  std::unique_ptr<::istio::control::tcp::Controller> controller_;
 };
 
 }  // namespace Mixer


### PR DESCRIPTION
**What this PR does / why we need it**:

To fix Envoy crash:  https://github.com/istio/istio/issues/5694


**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
