### PR TITLE
release-binary: add missing dash to checksum filename

### DIFF
--- a/script/release-binary
+++ b/script/release-binary
@@ -101,7 +101,7 @@ echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
 gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DST}/"
 
 BINARY_NAME="istio-proxy-debug-${SHA}.deb"
-SHA256_NAME="istio-proxy-debug${SHA}.sha256"
+SHA256_NAME="istio-proxy-debug-${SHA}.sha256"
 bazel --batch build -c dbg //tools/deb:istio-proxy
 BAZEL_TARGET="bazel-bin/tools/deb/istio-proxy.deb"
 cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"


### PR DESCRIPTION
**What this PR does / why we need it**: 

It fixes a typo to the build artifact filename.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This typo has gone unnoticed for a long time (last time it was touched was 9 months ago), so it's probably just a cosmetic fix for us humans.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
