### PR TITLE
Route directive

### DIFF
--- a/include/istio/control/http/request_handler.h
+++ b/include/istio/control/http/request_handler.h
@@ -38,7 +38,7 @@ class RequestHandler {
   virtual ::istio::mixerclient::CancelFunc Check(
       CheckData* check_data, HeaderUpdate* header_update,
       ::istio::mixerclient::TransportCheckFunc transport,
-      ::istio::mixerclient::DoneFunc on_done) = 0;
+      ::istio::mixerclient::CheckDoneFunc on_done) = 0;
 
   // Make a Report call. It will:
   // * check service config to see if Report is required

--- a/include/istio/control/tcp/request_handler.h
+++ b/include/istio/control/tcp/request_handler.h
@@ -33,7 +33,7 @@ class RequestHandler {
   // * extract downstream tcp connection attributes
   // * check config, make a Check call if necessary.
   virtual ::istio::mixerclient::CancelFunc Check(
-      CheckData* check_data, ::istio::mixerclient::DoneFunc on_done) = 0;
+      CheckData* check_data, ::istio::mixerclient::CheckDoneFunc on_done) = 0;
 
   // Make report call.
   // This can be called multiple times for long connection.

--- a/include/istio/mixerclient/BUILD
+++ b/include/istio/mixerclient/BUILD
@@ -25,6 +25,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//external:mixer_api_cc_proto",
         "//include/istio/quota_config:requirement_header",
     ],
 )

--- a/include/istio/mixerclient/check_response.h
+++ b/include/istio/mixerclient/check_response.h
@@ -35,7 +35,8 @@ struct CheckResponseInfo {
       ::google::protobuf::util::Status::UNKNOWN};
 
   // Routing directive (applicable if the status is OK)
-  ::istio::mixer::v1::RouteDirective route_directive{::istio::mixer::v1::RouteDirective::default_instance()};
+  ::istio::mixer::v1::RouteDirective route_directive{
+      ::istio::mixer::v1::RouteDirective::default_instance()};
 };
 
 }  // namespace mixerclient

--- a/include/istio/mixerclient/check_response.h
+++ b/include/istio/mixerclient/check_response.h
@@ -17,6 +17,7 @@
 #define ISTIO_MIXERCLIENT_CHECK_RESPONSE_H
 
 #include "google/protobuf/stubs/status.h"
+#include "mixer/v1/check.pb.h"
 
 namespace istio {
 namespace mixerclient {
@@ -32,6 +33,9 @@ struct CheckResponseInfo {
   // The check and quota response status.
   ::google::protobuf::util::Status response_status{
       ::google::protobuf::util::Status::UNKNOWN};
+
+  // Routing directive (applicable if the status is OK)
+  ::istio::mixer::v1::RouteDirective route_directive{::istio::mixer::v1::RouteDirective::default_instance()};
 };
 
 }  // namespace mixerclient

--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "ecef45ec0f0ef17c4b383ee84dcbcdba4fcc0c8d"
+		"lastStableSHA": "f403f2ff3a7ee656a1bfbf23e66966a633160300",
 	},
 	{
 		"_comment": "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "ecef45ec0f0ef17c4b383ee84dcbcdba4fcc0c8d"
+ISTIO_API = "8bfa0666dd205ae675a77138a302b5668479f999"
 
 def mixerapi_repositories(bind=True):
     BUILD = """

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "8bfa0666dd205ae675a77138a302b5668479f999"
+ISTIO_API = "f403f2ff3a7ee656a1bfbf23e66966a633160300"
 
 def mixerapi_repositories(bind=True):
     BUILD = """

--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -40,4 +40,5 @@ pkg_tar(
     files = [":envoy"],
     mode = "0755",
     package_dir = "/usr/local/bin/",
+    tags = ["manual"],
 )

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -24,6 +24,7 @@
 
 using ::google::protobuf::util::Status;
 using ::istio::mixer::v1::config::client::ServiceConfig;
+using ::istio::mixerclient::CheckResponseInfo;
 
 namespace Envoy {
 namespace Http {
@@ -135,7 +136,9 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
   cancel_check_ = handler_->Check(
       &check_data, &header_update,
       control_.GetCheckTransport(decoder_callbacks_->activeSpan()),
-      [this](const Status& status) { completeCheck(status); });
+      [this](const CheckResponseInfo& info) {
+        completeCheck(info.response_status);
+      });
   initiating_call_ = false;
 
   if (state_ == Complete) {

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -191,7 +191,7 @@ FilterHeadersStatus Filter::encodeHeaders(HeaderMap& headers, bool) {
   ASSERT(state_ == Complete || state_ == Responded);
   if (state_ == Complete) {
     // handle response header operations
-    UpdateHeaders(&headers, route_directive_.update_response_headers());
+    UpdateHeaders(&headers, route_directive_.response_header_operations());
   }
   return FilterHeadersStatus::Continue;
 }
@@ -254,7 +254,7 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
   }
 
   // handle request header operations
-  UpdateHeaders(headers_, route_directive_.update_request_headers());
+  UpdateHeaders(headers_, route_directive_.request_header_operations());
   headers_ = nullptr;
 
   if (!initiating_call_) {

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -198,17 +198,13 @@ FilterHeadersStatus Filter::encodeHeaders(HeaderMap& headers, bool) {
 
 FilterDataStatus Filter::encodeData(Buffer::Instance&, bool) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
-  if (state_ == Calling) {
-    return FilterDataStatus::StopIterationAndWatermark;
-  }
+  ASSERT(state_ == Complete || state_ == Responded);
   return FilterDataStatus::Continue;
 }
 
 FilterTrailersStatus Filter::encodeTrailers(HeaderMap&) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
-  if (state_ == Calling) {
-    return FilterTrailersStatus::StopIteration;
-  }
+  ASSERT(state_ == Complete || state_ == Responded);
   return FilterTrailersStatus::Continue;
 }
 

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -33,13 +33,13 @@ struct PerRouteServiceConfig : public Router::RouteSpecificFilterConfig {
   std::string hash;
 };
 
-class Filter : public Http::StreamDecoderFilter,
+class Filter : public StreamFilter,
                public AccessLog::Instance,
                public Logger::Loggable<Logger::Id::filter> {
  public:
   Filter(Control& control);
 
-  // Implementing virtual functions for StreamDecoderFilter
+  // Http::StreamDecoderFilter
   FilterHeadersStatus decodeHeaders(HeaderMap& headers, bool) override;
   FilterDataStatus decodeData(Buffer::Instance& data, bool end_stream) override;
   FilterTrailersStatus decodeTrailers(HeaderMap& trailers) override;
@@ -49,8 +49,20 @@ class Filter : public Http::StreamDecoderFilter,
   // Http::StreamFilterBase
   void onDestroy() override;
 
+  // Http::StreamEncoderFilter
+  FilterHeadersStatus encode100ContinueHeaders(HeaderMap&) override {
+    return FilterHeadersStatus::Continue;
+  }
+  FilterHeadersStatus encodeHeaders(HeaderMap& headers, bool) override;
+  FilterDataStatus encodeData(Buffer::Instance&, bool) override;
+  FilterTrailersStatus encodeTrailers(HeaderMap&) override;
+  void setEncoderFilterCallbacks(
+      StreamEncoderFilterCallbacks& callbacks) override {
+    encoder_callbacks_ = &callbacks;
+  }
+
   // This is the callback function when Check is done.
-  void completeCheck(const ::google::protobuf::util::Status& status);
+  void completeCheck(const ::istio::mixerclient::CheckResponseInfo& info);
 
   // Called when the request is completed.
   virtual void log(const HeaderMap* request_headers,
@@ -85,6 +97,13 @@ class Filter : public Http::StreamDecoderFilter,
 
   // The stream decoder filter callback.
   StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};
+
+  // The stream encoder filter callback.
+  StreamEncoderFilterCallbacks* encoder_callbacks_{nullptr};
+
+  // Returned directive
+  ::istio::mixer::v1::RouteDirective route_directive_{
+      ::istio::mixer::v1::RouteDirective::default_instance()};
 };
 
 }  // namespace Mixer

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -74,7 +74,7 @@ class Filter : public StreamFilter,
       ::istio::control::http::Controller::PerRouteConfig* config);
 
   // Update header maps
-  void UpdateHeaders(HeaderMap* headers,
+  void UpdateHeaders(HeaderMap& headers,
                      const ::google::protobuf::RepeatedPtrField<
                          ::istio::mixer::v1::HeaderOperation>& operations);
 

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -56,10 +56,7 @@ class Filter : public StreamFilter,
   FilterHeadersStatus encodeHeaders(HeaderMap& headers, bool) override;
   FilterDataStatus encodeData(Buffer::Instance&, bool) override;
   FilterTrailersStatus encodeTrailers(HeaderMap&) override;
-  void setEncoderFilterCallbacks(
-      StreamEncoderFilterCallbacks& callbacks) override {
-    encoder_callbacks_ = &callbacks;
-  }
+  void setEncoderFilterCallbacks(StreamEncoderFilterCallbacks&) override {}
 
   // This is the callback function when Check is done.
   void completeCheck(const ::istio::mixerclient::CheckResponseInfo& info);
@@ -75,6 +72,11 @@ class Filter : public StreamFilter,
   void ReadPerRouteConfig(
       const Router::RouteEntry* entry,
       ::istio::control::http::Controller::PerRouteConfig* config);
+
+  // Update header maps
+  void UpdateHeaders(HeaderMap* headers,
+                     const ::google::protobuf::RepeatedPtrField<
+                         ::istio::mixer::v1::HeaderOperation>& operations);
 
   // The control object.
   Control& control_;
@@ -97,9 +99,6 @@ class Filter : public StreamFilter,
 
   // The stream decoder filter callback.
   StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};
-
-  // The stream encoder filter callback.
-  StreamEncoderFilterCallbacks* encoder_callbacks_{nullptr};
 
   // Returned directive
   ::istio::mixer::v1::RouteDirective route_directive_{

--- a/src/envoy/http/mixer/filter_factory.cc
+++ b/src/envoy/http/mixer/filter_factory.cc
@@ -83,8 +83,7 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
                Http::FilterChainFactoryCallbacks& callbacks) -> void {
       std::shared_ptr<Http::Mixer::Filter> instance =
           std::make_shared<Http::Mixer::Filter>(control_factory->control());
-      callbacks.addStreamDecoderFilter(
-          Http::StreamDecoderFilterSharedPtr(instance));
+      callbacks.addStreamFilter(Http::StreamFilterSharedPtr(instance));
       callbacks.addAccessLogHandler(AccessLog::InstanceSharedPtr(instance));
     };
   }

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -18,6 +18,7 @@
 #include "src/envoy/utils/utils.h"
 
 using ::google::protobuf::util::Status;
+using ::istio::mixerclient::CheckResponseInfo;
 
 namespace Envoy {
 namespace Tcp {
@@ -59,8 +60,9 @@ void Filter::callCheck() {
   state_ = State::Calling;
   filter_callbacks_->connection().readDisable(true);
   calling_check_ = true;
-  cancel_check_ = handler_->Check(
-      this, [this](const Status& status) { completeCheck(status); });
+  cancel_check_ = handler_->Check(this, [this](const CheckResponseInfo& info) {
+    completeCheck(info.response_status);
+  });
   calling_check_ = false;
 }
 

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -22,9 +22,9 @@ using ::google::protobuf::util::Status;
 using ::istio::mixer::v1::config::client::NetworkFailPolicy;
 using ::istio::mixer::v1::config::client::TransportConfig;
 using ::istio::mixerclient::CancelFunc;
+using ::istio::mixerclient::CheckDoneFunc;
 using ::istio::mixerclient::CheckOptions;
 using ::istio::mixerclient::CheckResponseInfo;
-using ::istio::mixerclient::DoneFunc;
 using ::istio::mixerclient::Environment;
 using ::istio::mixerclient::MixerClientOptions;
 using ::istio::mixerclient::QuotaOptions;
@@ -77,7 +77,7 @@ ClientContextBase::ClientContextBase(const TransportConfig& config,
 }
 
 CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
-                                        DoneFunc on_done,
+                                        CheckDoneFunc on_done,
                                         RequestContext* request) {
   // Intercept the callback to save check status in request_context
   auto local_on_done = [request,
@@ -90,7 +90,7 @@ CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
                     check_response_info.is_check_cache_hit);
     builder.AddBool(AttributeName::kQuotaCacheHit,
                     check_response_info.is_quota_cache_hit);
-    on_done(check_response_info.response_status);
+    on_done(check_response_info);
   };
 
   // TODO: add debug message

--- a/src/istio/control/client_context_base.h
+++ b/src/istio/control/client_context_base.h
@@ -41,7 +41,7 @@ class ClientContextBase {
   // Use mixer client object to make a Check call.
   ::istio::mixerclient::CancelFunc SendCheck(
       ::istio::mixerclient::TransportCheckFunc transport,
-      ::istio::mixerclient::DoneFunc on_done, RequestContext* request);
+      ::istio::mixerclient::CheckDoneFunc on_done, RequestContext* request);
 
   // Use mixer client object to make a Report call.
   void SendReport(const RequestContext& request);

--- a/src/istio/control/http/request_handler_impl.cc
+++ b/src/istio/control/http/request_handler_impl.cc
@@ -18,7 +18,8 @@
 
 using ::google::protobuf::util::Status;
 using ::istio::mixerclient::CancelFunc;
-using ::istio::mixerclient::DoneFunc;
+using ::istio::mixerclient::CheckDoneFunc;
+using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::mixerclient::TransportCheckFunc;
 using ::istio::quota_config::Requirement;
 
@@ -46,13 +47,15 @@ void RequestHandlerImpl::ExtractRequestAttributes(CheckData* check_data) {
 CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
                                      HeaderUpdate* header_update,
                                      TransportCheckFunc transport,
-                                     DoneFunc on_done) {
+                                     CheckDoneFunc on_done) {
   ExtractRequestAttributes(check_data);
   header_update->RemoveIstioAttributes();
   service_context_->InjectForwardedAttributes(header_update);
 
   if (!service_context_->enable_mixer_check()) {
-    on_done(Status::OK);
+    CheckResponseInfo check_response_info;
+    check_response_info.response_status = Status::OK;
+    on_done(check_response_info);
     return nullptr;
   }
 

--- a/src/istio/control/http/request_handler_impl.h
+++ b/src/istio/control/http/request_handler_impl.h
@@ -34,7 +34,7 @@ class RequestHandlerImpl : public RequestHandler {
   ::istio::mixerclient::CancelFunc Check(
       CheckData* check_data, HeaderUpdate* header_update,
       ::istio::mixerclient::TransportCheckFunc transport,
-      ::istio::mixerclient::DoneFunc on_done) override;
+      ::istio::mixerclient::CheckDoneFunc on_done) override;
 
   // Make a Report call.
   void Report(ReportData* report_data) override;

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -29,6 +29,7 @@ using ::istio::mixer::v1::config::client::HttpClientConfig;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::mixerclient::CancelFunc;
 using ::istio::mixerclient::CheckDoneFunc;
+using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::mixerclient::DoneFunc;
 using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
@@ -162,7 +163,9 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheckReport) {
 
   auto handler = controller_->CreateRequestHandler(per_route);
   handler->Check(&mock_data, &mock_header, nullptr,
-                 [](const Status& status) { EXPECT_TRUE(status.ok()); });
+                 [](const CheckResponseInfo& info) {
+                   EXPECT_TRUE(info.response_status.ok());
+                 });
 }
 
 TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
@@ -182,7 +185,9 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
 
   auto handler = controller_->CreateRequestHandler(per_route);
   handler->Check(&mock_data, &mock_header, nullptr,
-                 [](const Status& status) { EXPECT_TRUE(status.ok()); });
+                 [](const CheckResponseInfo& info) {
+                   EXPECT_TRUE(info.response_status.ok());
+                 });
 }
 
 TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
@@ -473,7 +478,9 @@ TEST_F(RequestHandlerImplTest, TestEmptyConfig) {
   Controller::PerRouteConfig config;
   auto handler = controller_->CreateRequestHandler(config);
   handler->Check(&mock_check, &mock_header, nullptr,
-                 [](const Status& status) { EXPECT_TRUE(status.ok()); });
+                 [](const CheckResponseInfo& info) {
+                   EXPECT_TRUE(info.response_status.ok());
+                 });
   handler->Report(&mock_report);
 }
 

--- a/src/istio/control/tcp/request_handler_impl.cc
+++ b/src/istio/control/tcp/request_handler_impl.cc
@@ -18,7 +18,8 @@
 
 using ::google::protobuf::util::Status;
 using ::istio::mixerclient::CancelFunc;
-using ::istio::mixerclient::DoneFunc;
+using ::istio::mixerclient::CheckDoneFunc;
+using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::quota_config::Requirement;
 
 namespace istio {
@@ -30,7 +31,8 @@ RequestHandlerImpl::RequestHandlerImpl(
     : client_context_(client_context),
       last_report_info_{0ULL, 0ULL, std::chrono::nanoseconds::zero()} {}
 
-CancelFunc RequestHandlerImpl::Check(CheckData* check_data, DoneFunc on_done) {
+CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
+                                     CheckDoneFunc on_done) {
   if (client_context_->enable_mixer_check() ||
       client_context_->enable_mixer_report()) {
     client_context_->AddStaticAttributes(&request_context_);
@@ -40,7 +42,9 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data, DoneFunc on_done) {
   }
 
   if (!client_context_->enable_mixer_check()) {
-    on_done(Status::OK);
+    CheckResponseInfo check_response_info;
+    check_response_info.response_status = Status::OK;
+    on_done(check_response_info);
     return nullptr;
   }
 

--- a/src/istio/control/tcp/request_handler_impl.h
+++ b/src/istio/control/tcp/request_handler_impl.h
@@ -31,7 +31,8 @@ class RequestHandlerImpl : public RequestHandler {
 
   // Make a Check call.
   ::istio::mixerclient::CancelFunc Check(
-      CheckData* check_data, ::istio::mixerclient::DoneFunc on_done) override;
+      CheckData* check_data,
+      ::istio::mixerclient::CheckDoneFunc on_done) override;
 
   // Make a Report call.
   // TODO(JimmyCYJ): Let TCP filter use

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -25,6 +25,7 @@ using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::config::client::TcpClientConfig;
 using ::istio::mixerclient::CancelFunc;
 using ::istio::mixerclient::CheckDoneFunc;
+using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::mixerclient::DoneFunc;
 using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
@@ -72,8 +73,9 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
 
   client_config_.set_disable_check_calls(true);
   auto handler = controller_->CreateRequestHandler();
-  handler->Check(&mock_data,
-                 [](const Status& status) { EXPECT_TRUE(status.ok()); });
+  handler->Check(&mock_data, [](const CheckResponseInfo& info) {
+    EXPECT_TRUE(info.response_status.ok());
+  });
 }
 
 TEST_F(RequestHandlerImplTest, TestHandlerCheck) {

--- a/src/istio/mixerclient/check_cache.cc
+++ b/src/istio/mixerclient/check_cache.cc
@@ -96,7 +96,8 @@ void CheckCache::Check(const Attributes &attributes, CheckResult *result) {
   };
 }
 
-Status CheckCache::Check(const Attributes &attributes, Tick time_now, CheckResult *result) {
+Status CheckCache::Check(const Attributes &attributes, Tick time_now,
+                         CheckResult *result) {
   if (!cache_) {
     // By returning NOT_FOUND, caller will send request to server.
     return Status(Code::NOT_FOUND, "");

--- a/src/istio/mixerclient/check_cache.cc
+++ b/src/istio/mixerclient/check_cache.cc
@@ -38,6 +38,7 @@ void CheckCache::CacheElem::CacheElem::SetResponse(
       expire_time_ = time_point<system_clock>::max();
     }
     use_count_ = response.precondition().valid_use_count();
+    route_directive_ = response.precondition().route_directive();
   } else {
     status_ = Status(Code::INVALID_ARGUMENT,
                      "CheckResponse doesn't have PreconditionResult");
@@ -75,7 +76,7 @@ CheckCache::~CheckCache() {
 }
 
 void CheckCache::Check(const Attributes &attributes, CheckResult *result) {
-  Status status = Check(attributes, system_clock::now());
+  Status status = Check(attributes, system_clock::now(), result);
   if (status.error_code() != Code::NOT_FOUND) {
     result->status_ = status;
   }
@@ -95,7 +96,7 @@ void CheckCache::Check(const Attributes &attributes, CheckResult *result) {
   };
 }
 
-Status CheckCache::Check(const Attributes &attributes, Tick time_now) {
+Status CheckCache::Check(const Attributes &attributes, Tick time_now, CheckResult *result) {
   if (!cache_) {
     // By returning NOT_FOUND, caller will send request to server.
     return Status(Code::NOT_FOUND, "");
@@ -115,6 +116,9 @@ Status CheckCache::Check(const Attributes &attributes, Tick time_now) {
       if (elem->IsExpired(time_now)) {
         cache_->Remove(signature);
         return Status(Code::NOT_FOUND, "");
+      }
+      if (result) {
+        result->route_directive_ = elem->route_directive();
       }
       return elem->status();
     }

--- a/src/istio/mixerclient/check_cache.h
+++ b/src/istio/mixerclient/check_cache.h
@@ -56,7 +56,9 @@ class CheckCache {
 
     ::google::protobuf::util::Status status() const { return status_; }
 
-    ::istio::mixer::v1::RouteDirective route_directive() const { return route_directive_; }
+    ::istio::mixer::v1::RouteDirective route_directive() const {
+      return route_directive_;
+    }
 
     void SetResponse(const ::google::protobuf::util::Status& status,
                      const ::istio::mixer::v1::Attributes& attributes,
@@ -95,7 +97,8 @@ class CheckCache {
   // If the check could not be handled by the cache, returns NOT_FOUND,
   // caller has to send the request to mixer.
   ::google::protobuf::util::Status Check(
-      const ::istio::mixer::v1::Attributes& request, Tick time_now, CheckResult* result);
+      const ::istio::mixer::v1::Attributes& request, Tick time_now,
+      CheckResult* result);
 
   // Caches a response from a remote mixer call.
   // Return the converted status from response.
@@ -130,7 +133,9 @@ class CheckCache {
     ::google::protobuf::util::Status status() const { return status_; }
 
     // getter for the route directive
-    ::istio::mixer::v1::RouteDirective route_directive() const { return route_directive_; }
+    ::istio::mixer::v1::RouteDirective route_directive() const {
+      return route_directive_;
+    }
 
    private:
     // To the parent cache object.

--- a/src/istio/mixerclient/check_cache.h
+++ b/src/istio/mixerclient/check_cache.h
@@ -56,11 +56,16 @@ class CheckCache {
 
     ::google::protobuf::util::Status status() const { return status_; }
 
+    ::istio::mixer::v1::RouteDirective route_directive() const { return route_directive_; }
+
     void SetResponse(const ::google::protobuf::util::Status& status,
                      const ::istio::mixer::v1::Attributes& attributes,
                      const ::istio::mixer::v1::CheckResponse& response) {
       if (on_response_) {
         status_ = on_response_(status, attributes, response);
+      }
+      if (response.has_precondition()) {
+        route_directive_ = response.precondition().route_directive();
       }
     }
 
@@ -68,6 +73,9 @@ class CheckCache {
     friend class CheckCache;
     // Check status.
     ::google::protobuf::util::Status status_;
+
+    // Route directive (if status is OK).
+    ::istio::mixer::v1::RouteDirective route_directive_;
 
     // The function to set check response.
     using OnResponseFunc = std::function<::google::protobuf::util::Status(
@@ -87,7 +95,7 @@ class CheckCache {
   // If the check could not be handled by the cache, returns NOT_FOUND,
   // caller has to send the request to mixer.
   ::google::protobuf::util::Status Check(
-      const ::istio::mixer::v1::Attributes& request, Tick time_now);
+      const ::istio::mixer::v1::Attributes& request, Tick time_now, CheckResult* result);
 
   // Caches a response from a remote mixer call.
   // Return the converted status from response.
@@ -121,11 +129,16 @@ class CheckCache {
     // getter for converted status from response.
     ::google::protobuf::util::Status status() const { return status_; }
 
+    // getter for the route directive
+    ::istio::mixer::v1::RouteDirective route_directive() const { return route_directive_; }
+
    private:
     // To the parent cache object.
     const CheckCache& parent_;
     // The check status for the last check request.
     ::google::protobuf::util::Status status_;
+    // Route directive
+    ::istio::mixer::v1::RouteDirective route_directive_;
     // Cache item should not be used after it is expired.
     std::chrono::time_point<std::chrono::system_clock> expire_time_;
     // if -1, not to check use_count.

--- a/src/istio/mixerclient/check_cache_test.cc
+++ b/src/istio/mixerclient/check_cache_test.cc
@@ -133,6 +133,9 @@ TEST_F(CheckCacheTest, TestCheckResult) {
 
   CheckResponse ok_response;
   ok_response.mutable_precondition()->set_valid_use_count(1000);
+  ok_response.mutable_precondition()
+      ->mutable_route_directive()
+      ->set_direct_response_code(302);
   result.SetResponse(Status::OK, attributes_, ok_response);
   EXPECT_OK(result.status());
 
@@ -141,6 +144,7 @@ TEST_F(CheckCacheTest, TestCheckResult) {
     cache_->Check(attributes_, &result);
     EXPECT_TRUE(result.IsCacheHit());
     EXPECT_OK(result.status());
+    EXPECT_EQ(result.route_directive().direct_response_code(), 302);
   }
 }
 

--- a/src/istio/mixerclient/check_cache_test.cc
+++ b/src/istio/mixerclient/check_cache_test.cc
@@ -49,16 +49,16 @@ class CheckCacheTest : public ::testing::Test {
     CheckResponse ok_response;
     ok_response.mutable_precondition()->set_valid_use_count(1000);
     // Just to calculate signature
-    EXPECT_ERROR_CODE(Code::NOT_FOUND, cache_->Check(attributes_, FakeTime(0)));
+    EXPECT_ERROR_CODE(Code::NOT_FOUND, cache_->Check(attributes_, FakeTime(0), nullptr));
     // set to the cache
     EXPECT_OK(cache_->CacheResponse(attributes_, ok_response, FakeTime(0)));
 
     // Still not_found, so cache is disabled.
-    EXPECT_ERROR_CODE(Code::NOT_FOUND, cache_->Check(attributes_, FakeTime(0)));
+    EXPECT_ERROR_CODE(Code::NOT_FOUND, cache_->Check(attributes_, FakeTime(0), nullptr));
   }
 
   Status Check(const Attributes& request, time_point<system_clock> time_now) {
-    return cache_->Check(request, time_now);
+    return cache_->Check(request, time_now, nullptr);
   }
   Status CacheResponse(const Attributes& attributes,
                        const ::istio::mixer::v1::CheckResponse& response,

--- a/src/istio/mixerclient/check_cache_test.cc
+++ b/src/istio/mixerclient/check_cache_test.cc
@@ -49,12 +49,14 @@ class CheckCacheTest : public ::testing::Test {
     CheckResponse ok_response;
     ok_response.mutable_precondition()->set_valid_use_count(1000);
     // Just to calculate signature
-    EXPECT_ERROR_CODE(Code::NOT_FOUND, cache_->Check(attributes_, FakeTime(0), nullptr));
+    EXPECT_ERROR_CODE(Code::NOT_FOUND,
+                      cache_->Check(attributes_, FakeTime(0), nullptr));
     // set to the cache
     EXPECT_OK(cache_->CacheResponse(attributes_, ok_response, FakeTime(0)));
 
     // Still not_found, so cache is disabled.
-    EXPECT_ERROR_CODE(Code::NOT_FOUND, cache_->Check(attributes_, FakeTime(0), nullptr));
+    EXPECT_ERROR_CODE(Code::NOT_FOUND,
+                      cache_->Check(attributes_, FakeTime(0), nullptr));
   }
 
   Status Check(const Attributes& request, time_point<system_clock> time_now) {

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -133,6 +133,8 @@ CancelFunc MixerClientImpl::Check(
           } else {
             check_response_info.response_status = raw_quota_result->status();
           }
+          check_response_info.route_directive =
+              raw_check_result->route_directive();
           on_done(check_response_info);
         }
         delete raw_check_result;

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -64,13 +64,12 @@ CancelFunc MixerClientImpl::Check(
   CheckResponseInfo check_response_info;
   check_response_info.is_check_cache_hit = check_result->IsCacheHit();
   check_response_info.response_status = check_result->status();
+  check_response_info.route_directive = check_result->route_directive();
 
   if (check_result->IsCacheHit() && !check_result->status().ok()) {
     on_done(check_response_info);
     return nullptr;
   }
-
-  check_response_info.route_directive = check_result->route_directive();
 
   if (!quotas.empty()) {
     ++total_quota_calls_;

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -70,6 +70,8 @@ CancelFunc MixerClientImpl::Check(
     return nullptr;
   }
 
+  check_response_info.route_directive = check_result->route_directive();
+
   if (!quotas.empty()) {
     ++total_quota_calls_;
   }

--- a/test/backend/echo/echo.go
+++ b/test/backend/echo/echo.go
@@ -118,6 +118,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			fmt.Printf("%v: %v\n", name, h)
 		}
 	}
+	fmt.Printf("Host: %v\n", r.Host)
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/tools/deb/BUILD
+++ b/tools/deb/BUILD
@@ -45,6 +45,7 @@ pkg_tar(
         ":envoy-bin",
         ":istio-conf",
     ],
+    tags = ["manual"],
 )
 
 pkg_deb(


### PR DESCRIPTION
Implementation of the route directive.
API change: https://github.com/istio/api/pull/510

Manually tested with the following set-up.

envoy config:
```yaml
node:
  id: test
admin:
  access_log_path: /dev/stdout
  address:
    socket_address:
      address: 127.0.0.1
      port_value: 8001
static_resources:
  clusters:
    - name: mixer_server
      connect_timeout: 1s
      type: STATIC
      http2_protocol_options: {}
      hosts:
        - socket_address:
            address: 127.0.0.1
            port_value: 9091
    - name: echo
      connect_timeout: 1s
      type: STATIC
      hosts:
        - socket_address:
            address: 127.0.0.1
            port_value: 8080
  listeners:
    - name: echo
      address:
        socket_address:
          address: 127.0.0.1
          port_value: 8000
      filter_chains:
        - filters:
          - name: envoy.http_connection_manager
            config:
              codec_type: AUTO
              stat_prefix: http
              generate_request_id: true
              http_filters:
                - name: mixer
                  config:
                    default_destination_service: echo
                    service_configs:
                      echo:
                        disable_report_calls: true
                    transport:
                      network_fail_policy:
                        policy: FAIL_CLOSE
                - name: envoy.router
              route_config:
                name: echo
                virtual_hosts:
                  - domains:
                    - '*'
                    name: echo
                    routes:
                      - match:
                          prefix: /
                        route:
                          cluster: echo
                          timeout: 0s
```

Mixer check response:
```golang
&mixerpb.CheckResponse{
                Precondition: mixerpb.CheckResponse_PreconditionResult{
                        ReferencedAttributes: mixerpb.ReferencedAttributes{
                                Words: []string{"request.method"},
                                AttributeMatches: []mixerpb.ReferencedAttributes_AttributeMatch{{
                                        Name:      -1,
                                        Condition: mixerpb.EXACT,
                                }},
                        },
                        ValidDuration: time.Minute,
                        Status:        rpc.Status{Code: int32(rpc.OK)},
                        ValidUseCount: 10000000,
                        RouteDirective: &mixerpb.RouteDirective{
                                UpdateRequestHeaders: []mixerpb.HeaderOperation{{
                                        Name:  ":path",
                                        Value: "/path",
                                }, {
                                        Name:  ":authority",
                                        Value: "echo",
                                }, {
                                        Name:  ":method",
                                        Value: "POST",
                                }, {
                                        Name:  "x-istio-request",
                                        Value: "value",
                                }, {
                                        Name:      "x-istio-request",
                                        Value:     "value2",
                                        Operation: mixerpb.APPEND,
                                }, {
                                        Name:      "user-agent",
                                        Value:     "value2",
                                        Operation: mixerpb.REMOVE,
                                }},
                                UpdateResponseHeaders: []mixerpb.HeaderOperation{{
                                        Name:  "x-istio-response",
                                        Value: "value",
                                }, {
                                        Name:      "x-istio-response",
                                        Value:     "value2",
                                        Operation: mixerpb.APPEND,
                                }},
                        },
                },
```

Making a request:
```bash
 curl -v 127.0.0.1:8000
* Rebuilt URL to: 127.0.0.1:8000/
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 8000 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8000
> User-Agent: curl/7.47.0
> Accept: */*
>
< HTTP/1.1 200 OK
< content-length: 0
< date: Tue, 05 Jun 2018 23:03:40 GMT
< x-envoy-upstream-service-time: 0
< x-istio-response: value
< x-istio-response: value2
< server: envoy
<
* Connection #0 to host 127.0.0.1 left intact
```

Backend echo:
```bash
POST /path HTTP/1.1 127.0.0.1:55792
Accept: */*
X-Forwarded-Proto: http
X-Request-Id: 77f19556-8ea2-4a71-b4e9-4ef2b6bbb2bc
X-Istio-Request: value
X-Istio-Request: value2
Content-Length: 0
Host: echo
```