### PR TITLE
A fix for building on a MacOS with Python 3.6.5

### DIFF
--- a/src/istio/mixerclient/create_global_dictionary.py
+++ b/src/istio/mixerclient/create_global_dictionary.py
@@ -64,6 +64,6 @@ with open(sys.argv[1]) as src_file:
         if line.startswith("-"):
             all_words += "    \"" + line[1:].strip() + "\",\n"
 
-print TOP + all_words + BOTTOM
+print (TOP + all_words + BOTTOM)
 
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fix build failure on a Mac

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Trying to build without this fix on a Mac with Python 3.6.5 (latest from brew) fails.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
