### PR TITLE
performance improvement: if the request matches one of the referenced, it won't match others.

### DIFF
--- a/src/istio/mixerclient/check_cache.cc
+++ b/src/istio/mixerclient/check_cache.cc
@@ -122,6 +122,8 @@ Status CheckCache::Check(const Attributes &attributes, Tick time_now,
         result->route_directive_ = elem->route_directive();
       }
       return elem->status();
+    } else {
+      return Status(Code::NOT_FOUND, "");
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is performance improvement: if the request matches one of the referenced, it won't match others. So we can directly exit the for loop and return NOT_FOUND.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

No issue.

**Special notes for your reviewer**:


