### PR TITLE
Change the format to json for logging config

### DIFF
--- a/src/envoy/http/jwt_auth/auth_store.h
+++ b/src/envoy/http/jwt_auth/auth_store.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "common/common/logger.h"
+#include "common/protobuf/utility.h"
 #include "envoy/config/filter/http/jwt_auth/v2alpha1/config.pb.h"
 #include "envoy/server/filter_config.h"
 #include "envoy/thread_local/thread_local.h"
@@ -70,7 +71,8 @@ class JwtAuthStoreFactory : public Logger::Loggable<Logger::Id::config> {
         [this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
           return std::make_shared<JwtAuthStore>(config_);
         });
-    ENVOY_LOG(info, "Loaded JwtAuthConfig: {}", config_.DebugString());
+    ENVOY_LOG(info, "Loaded JwtAuthConfig: {}",
+              MessageUtil::getJsonStringFromMessage(config_, true));
   }
 
   // Get per-thread auth store object.

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -16,6 +16,7 @@
 #include "src/envoy/http/mixer/filter.h"
 
 #include "common/common/base64.h"
+#include "common/protobuf/utility.h"
 #include "include/istio/utils/status.h"
 #include "src/envoy/http/mixer/check_data.h"
 #include "src/envoy/http/mixer/report_data.h"
@@ -114,7 +115,7 @@ void Filter::ReadPerRouteConfig(
   control_.controller()->AddServiceConfig(config->service_config_id, config_pb);
   ENVOY_LOG(info, "Service {}, config_id {}, config: {}",
             config->destination_service, config->service_config_id,
-            config_pb.DebugString());
+            MessageUtil::getJsonStringFromMessage(config_pb, true));
 }
 
 FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {

--- a/src/envoy/utils/config.cc
+++ b/src/envoy/utils/config.cc
@@ -47,7 +47,7 @@ bool ReadConfig(const Json::Object &json, const std::string &config_version,
   auto &logger = Logger::Registry::getLog(Logger::Id::config);
   if (status.ok()) {
     ENVOY_LOG_TO_LOGGER(logger, info, "{} mixer client config: {}",
-                        config_version, message->DebugString());
+                        config_version, config_str);
     return true;
   }
   ENVOY_LOG_TO_LOGGER(


### PR DESCRIPTION
**What this PR does / why we need it**:

For easy debug, Istio envoy filters log config at INFO level. It used to se protobuf.DebugString().  
As per request, change it to JSON

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
