### PR TITLE
pre-serialize attributes_for_mixer_proxy

### DIFF
--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -33,16 +33,8 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  [this](::istio::mixerclient::Statistics* stat) -> bool {
                    return GetStats(stat);
                  }) {
-  if (!config_.config_pb()
-           .transport()
-           .attributes_for_mixer_proxy()
-           .attributes()
-           .empty()) {
-    config_.config_pb()
-        .transport()
-        .attributes_for_mixer_proxy()
-        .SerializeToString(&serialized_forward_attributes_);
-  }
+  Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
+                                      &serialized_forward_attributes_);
 
   ::istio::control::http::Controller::Options options(config_.config_pb());
 

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -46,10 +46,9 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
 
   ::istio::control::http::Controller::Options options(config_.config_pb());
 
-  Utils::CreateEnvironment(
-      dispatcher, random, *check_client_factory_, *report_client_factory_,
-      serialized_forward_attributes_,
-      &options.env);
+  Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
+                           *report_client_factory_,
+                           serialized_forward_attributes_, &options.env);
 
   controller_ = ::istio::control::http::Controller::Create(options);
 }

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -45,9 +45,21 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
 
 Utils::CheckTransport::Func Control::GetCheckTransport(
     Tracing::Span& parent_span) {
-  return Utils::CheckTransport::GetFunc(
-      *check_client_factory_, parent_span,
-      config_.config_pb().transport().attributes_for_mixer_proxy());
+  std::string serialized_forward_attributes;
+
+  if (!config_.config_pb()
+           .transport()
+           .attributes_for_mixer_proxy()
+           .attributes()
+           .empty()) {
+    config_.config_pb()
+        .transport()
+        .attributes_for_mixer_proxy()
+        .SerializeToString(&serialized_forward_attributes);
+  }
+
+  return Utils::CheckTransport::GetFunc(*check_client_factory_, parent_span,
+                                        serialized_forward_attributes);
 }
 
 // Call controller to get statistics.

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -49,6 +49,8 @@ class Control final : public ThreadLocal::ThreadLocalObject {
 
   // The mixer config.
   const Config& config_;
+  // Pre-serialized attributes_for_mixer_proxy.
+  std::string serialized_forward_attributes_;
   // async client factories
   Grpc::AsyncClientFactoryPtr check_client_factory_;
   Grpc::AsyncClientFactoryPtr report_client_factory_;

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -49,10 +49,9 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
   }
   ::istio::control::tcp::Controller::Options options(config_.config_pb());
 
-  Utils::CreateEnvironment(
-      dispatcher, random, *check_client_factory_, *report_client_factory_,
-      serialized_forward_attributes,
-      &options.env);
+  Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
+                           *report_client_factory_,
+                           serialized_forward_attributes, &options.env);
 
   controller_ = ::istio::control::tcp::Controller::Create(options);
 }

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -36,7 +36,6 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  config_.config_pb().transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool { return GetStats(stat); }),
       uuid_(uuid) {
-  std::string serialized_forward_attributes;
   if (!config_.config_pb()
            .transport()
            .attributes_for_mixer_proxy()
@@ -45,13 +44,13 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
     config_.config_pb()
         .transport()
         .attributes_for_mixer_proxy()
-        .SerializeToString(&serialized_forward_attributes);
+        .SerializeToString(&serialized_forward_attributes_);
   }
   ::istio::control::tcp::Controller::Options options(config_.config_pb());
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,
-                           serialized_forward_attributes, &options.env);
+                           serialized_forward_attributes_, &options.env);
 
   controller_ = ::istio::control::tcp::Controller::Create(options);
 }

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -36,16 +36,9 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  config_.config_pb().transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool { return GetStats(stat); }),
       uuid_(uuid) {
-  if (!config_.config_pb()
-           .transport()
-           .attributes_for_mixer_proxy()
-           .attributes()
-           .empty()) {
-    config_.config_pb()
-        .transport()
-        .attributes_for_mixer_proxy()
-        .SerializeToString(&serialized_forward_attributes_);
-  }
+  Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
+                                      &serialized_forward_attributes_);
+
   ::istio::control::tcp::Controller::Options options(config_.config_pb());
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -36,12 +36,23 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  config_.config_pb().transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool { return GetStats(stat); }),
       uuid_(uuid) {
+  std::string serialized_forward_attributes;
+  if (!config_.config_pb()
+           .transport()
+           .attributes_for_mixer_proxy()
+           .attributes()
+           .empty()) {
+    config_.config_pb()
+        .transport()
+        .attributes_for_mixer_proxy()
+        .SerializeToString(&serialized_forward_attributes);
+  }
   ::istio::control::tcp::Controller::Options options(config_.config_pb());
 
   Utils::CreateEnvironment(
       dispatcher, random, *check_client_factory_, *report_client_factory_,
-      &options.env,
-      config_.config_pb().transport().attributes_for_mixer_proxy());
+      serialized_forward_attributes,
+      &options.env);
 
   controller_ = ::istio::control::tcp::Controller::Create(options);
 }

--- a/src/envoy/tcp/mixer/control.h
+++ b/src/envoy/tcp/mixer/control.h
@@ -53,6 +53,9 @@ class Control final : public ThreadLocal::ThreadLocalObject {
   // dispatcher.
   Event::Dispatcher& dispatcher_;
 
+  // Pre-serialized attributes_for_mixer_proxy.
+  std::string serialized_forward_attributes_;
+
   // async client factories
   Grpc::AsyncClientFactoryPtr check_client_factory_;
   Grpc::AsyncClientFactoryPtr report_client_factory_;

--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -91,7 +91,7 @@ typename GrpcTransport<RequestType, ResponseType>::Func
 GrpcTransport<RequestType, ResponseType>::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
     std::string serialized_forward_attributes) {
-  return [&factory, &parent_span, &serialized_forward_attributes](
+  return [&factory, &parent_span, serialized_forward_attributes](
              const RequestType &request, ResponseType *response,
              istio::mixerclient::DoneFunc on_done)
              -> istio::mixerclient::CancelFunc {

--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -33,7 +33,7 @@ template <class RequestType, class ResponseType>
 GrpcTransport<RequestType, ResponseType>::GrpcTransport(
     Grpc::AsyncClientPtr async_client, const RequestType &request,
     ResponseType *response, Tracing::Span &parent_span,
-    std::string serialized_forward_attributes,
+    const std::string &serialized_forward_attributes,
     istio::mixerclient::DoneFunc on_done)
     : async_client_(std::move(async_client)),
       response_(response),
@@ -90,8 +90,8 @@ template <class RequestType, class ResponseType>
 typename GrpcTransport<RequestType, ResponseType>::Func
 GrpcTransport<RequestType, ResponseType>::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
-    std::string serialized_forward_attributes) {
-  return [&factory, &parent_span, serialized_forward_attributes](
+    const std::string &serialized_forward_attributes) {
+  return [&factory, &parent_span, &serialized_forward_attributes](
              const RequestType &request, ResponseType *response,
              istio::mixerclient::DoneFunc on_done)
              -> istio::mixerclient::CancelFunc {
@@ -123,10 +123,10 @@ const google::protobuf::MethodDescriptor &ReportTransport::descriptor() {
 // explicitly instantiate CheckTransport and ReportTransport
 template CheckTransport::Func CheckTransport::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
-    std::string serialized_forward_attributes);
+    const std::string &serialized_forward_attributes);
 template ReportTransport::Func ReportTransport::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
-    std::string serialized_forward_attributes);
+    const std::string &serialized_forward_attributes);
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -33,10 +33,11 @@ template <class RequestType, class ResponseType>
 GrpcTransport<RequestType, ResponseType>::GrpcTransport(
     Grpc::AsyncClientPtr async_client, const RequestType &request,
     ResponseType *response, Tracing::Span &parent_span,
-    const Attributes &forward_attributes, istio::mixerclient::DoneFunc on_done)
+    std::string serialized_forward_attributes,
+    istio::mixerclient::DoneFunc on_done)
     : async_client_(std::move(async_client)),
       response_(response),
-      forward_attributes_(forward_attributes),
+      serialized_forward_attributes_(serialized_forward_attributes),
       on_done_(on_done),
       request_(async_client_->send(
           descriptor(), request, *this, parent_span,
@@ -53,11 +54,9 @@ void GrpcTransport<RequestType, ResponseType>::onCreateInitialMetadata(
   // See https://github.com/envoyproxy/envoy/issues/3297 for details.
   metadata.Host()->value("mixer", 5);
 
-  if (!forward_attributes_.attributes().empty()) {
+  if (!serialized_forward_attributes_.empty()) {
     HeaderUpdate header_update_(&metadata);
-    std::string serialized_attributes;
-    forward_attributes_.SerializeToString(&serialized_attributes);
-    header_update_.AddIstioAttributes(serialized_attributes);
+    header_update_.AddIstioAttributes(serialized_forward_attributes_);
   }
 }
 
@@ -91,14 +90,14 @@ template <class RequestType, class ResponseType>
 typename GrpcTransport<RequestType, ResponseType>::Func
 GrpcTransport<RequestType, ResponseType>::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
-    const Attributes &forward_attributes) {
-  return [&factory, &parent_span, &forward_attributes](
+    std::string serialized_forward_attributes) {
+  return [&factory, &parent_span, &serialized_forward_attributes](
              const RequestType &request, ResponseType *response,
              istio::mixerclient::DoneFunc on_done)
              -> istio::mixerclient::CancelFunc {
     auto transport = new GrpcTransport<RequestType, ResponseType>(
-        factory.create(), request, response, parent_span, forward_attributes,
-        on_done);
+        factory.create(), request, response, parent_span,
+        serialized_forward_attributes, on_done);
     return [transport]() { transport->Cancel(); };
   };
 }
@@ -124,10 +123,10 @@ const google::protobuf::MethodDescriptor &ReportTransport::descriptor() {
 // explicitly instantiate CheckTransport and ReportTransport
 template CheckTransport::Func CheckTransport::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
-    const Attributes &forward_attributes);
+    std::string serialized_forward_attributes);
 template ReportTransport::Func ReportTransport::GetFunc(
     Grpc::AsyncClientFactory &factory, Tracing::Span &parent_span,
-    const Attributes &forward_attributes);
+    std::string serialized_forward_attributes);
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/grpc_transport.h
+++ b/src/envoy/utils/grpc_transport.h
@@ -40,11 +40,11 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
 
   static Func GetFunc(Grpc::AsyncClientFactory& factory,
                       Tracing::Span& parent_span,
-                      std::string serialized_forward_attributes);
+                      const std::string& serialized_forward_attributes);
 
   GrpcTransport(Grpc::AsyncClientPtr async_client, const RequestType& request,
                 ResponseType* response, Tracing::Span& parent_span,
-                std::string serialized_forward_attributes,
+                const std::string& serialized_forward_attributes,
                 istio::mixerclient::DoneFunc on_done);
 
   void onCreateInitialMetadata(Http::HeaderMap& metadata) override;
@@ -62,7 +62,7 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
 
   Grpc::AsyncClientPtr async_client_;
   ResponseType* response_;
-  std::string serialized_forward_attributes_;
+  const std::string& serialized_forward_attributes_;
   ::istio::mixerclient::DoneFunc on_done_;
   Grpc::AsyncRequest* request_{};
 };

--- a/src/envoy/utils/grpc_transport.h
+++ b/src/envoy/utils/grpc_transport.h
@@ -40,11 +40,11 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
 
   static Func GetFunc(Grpc::AsyncClientFactory& factory,
                       Tracing::Span& parent_span,
-                      const ::istio::mixer::v1::Attributes& forward_attributes);
+                      std::string serialized_forward_attributes);
 
   GrpcTransport(Grpc::AsyncClientPtr async_client, const RequestType& request,
                 ResponseType* response, Tracing::Span& parent_span,
-                const ::istio::mixer::v1::Attributes& forward_attributes,
+                std::string serialized_forward_attributes,
                 istio::mixerclient::DoneFunc on_done);
 
   void onCreateInitialMetadata(Http::HeaderMap& metadata) override;
@@ -62,7 +62,7 @@ class GrpcTransport : public Grpc::TypedAsyncRequestCallbacks<ResponseType>,
 
   Grpc::AsyncClientPtr async_client_;
   ResponseType* response_;
-  const ::istio::mixer::v1::Attributes& forward_attributes_;
+  std::string serialized_forward_attributes_;
   ::istio::mixerclient::DoneFunc on_done_;
   Grpc::AsyncRequest* request_{};
 };

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -60,7 +60,7 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-std::string serialized_forward_attributes,
+                       std::string serialized_forward_attributes,
                        ::istio::mixerclient::Environment *env) {
   env->check_transport = CheckTransport::GetFunc(check_client_factory,
                                                  Tracing::NullSpan::instance(),

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -60,13 +60,8 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-                       ::istio::mixerclient::Environment *env,
-                       const Attributes &forward_attributes) {
-  std::string serialized_forward_attributes;
-
-  if (!forward_attributes.attributes().empty()) {
-    forward_attributes.SerializeToString(&serialized_forward_attributes);
-  }
+std::string serialized_forward_attributes,
+                       ::istio::mixerclient::Environment *env) {
   env->check_transport = CheckTransport::GetFunc(check_client_factory,
                                                  Tracing::NullSpan::instance(),
                                                  serialized_forward_attributes);

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -60,7 +60,7 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-                       std::string serialized_forward_attributes,
+                       const std::string &serialized_forward_attributes,
                        ::istio::mixerclient::Environment *env) {
   env->check_transport = CheckTransport::GetFunc(check_client_factory,
                                                  Tracing::NullSpan::instance(),
@@ -78,6 +78,15 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
   env->uuid_generate_func = [&random]() -> std::string {
     return random.uuid();
   };
+}
+
+void SerializeForwardedAttributes(
+    const ::istio::mixer::v1::config::client::TransportConfig &transport,
+    std::string *serialized_forward_attributes) {
+  if (!transport.attributes_for_mixer_proxy().attributes().empty()) {
+    transport.attributes_for_mixer_proxy().SerializeToString(
+        serialized_forward_attributes);
+  }
 }
 
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -62,10 +62,17 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Grpc::AsyncClientFactory &report_client_factory,
                        ::istio::mixerclient::Environment *env,
                        const Attributes &forward_attributes) {
-  env->check_transport = CheckTransport::GetFunc(
-      check_client_factory, Tracing::NullSpan::instance(), forward_attributes);
+  std::string serialized_forward_attributes;
+
+  if (!forward_attributes.attributes().empty()) {
+    forward_attributes.SerializeToString(&serialized_forward_attributes);
+  }
+  env->check_transport = CheckTransport::GetFunc(check_client_factory,
+                                                 Tracing::NullSpan::instance(),
+                                                 serialized_forward_attributes);
   env->report_transport = ReportTransport::GetFunc(
-      report_client_factory, Tracing::NullSpan::instance(), forward_attributes);
+      report_client_factory, Tracing::NullSpan::instance(),
+      serialized_forward_attributes);
 
   env->timer_create_func = [&dispatcher](std::function<void()> timer_cb)
       -> std::unique_ptr<::istio::mixerclient::Timer> {

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -31,8 +31,8 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-                       ::istio::mixerclient::Environment *env,
-                       const Attributes &forward_attributes);
+                       std::string serialized_forward_attributes,
+                       ::istio::mixerclient::Environment *env);
 
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -31,8 +31,12 @@ void CreateEnvironment(Event::Dispatcher &dispatcher,
                        Runtime::RandomGenerator &random,
                        Grpc::AsyncClientFactory &check_client_factory,
                        Grpc::AsyncClientFactory &report_client_factory,
-                       std::string serialized_forward_attributes,
+                       const std::string &serialized_forward_attributes,
                        ::istio::mixerclient::Environment *env);
+
+void SerializeForwardedAttributes(
+    const ::istio::mixer::v1::config::client::TransportConfig &transport,
+    std::string *serialized_forward_attributes);
 
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,


### PR DESCRIPTION
Also fixes the stale pointer dereference.