### PR TITLE
Remove JWT payload even in when requests are rejected.

### DIFF
--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -63,6 +63,9 @@ class AuthenticationFilter : public StreamDecoderFilter,
 
   createOriginAuthenticator(Istio::AuthN::FilterContext* filter_context);
 
+  // Removes output JWT valiation from headers.
+  void removeJwtPayloadFromHeaders();
+
  private:
   // Store the config.
   const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&


### PR DESCRIPTION
This is to make sure mixer logging do not have unintentional data.
Issue: https://github.com/istio/proxy/pull/1364