### PR TITLE
Distinguish different filter config when creating authn filter.

### DIFF
--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -31,7 +31,8 @@ class AuthenticationFilter : public StreamDecoderFilter,
                              public Logger::Loggable<Logger::Id::filter> {
  public:
   AuthenticationFilter(
-      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig& config);
+      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
+          config);
   ~AuthenticationFilter();
 
   // Http::StreamFilterBase
@@ -67,7 +68,8 @@ class AuthenticationFilter : public StreamDecoderFilter,
 
  private:
   // Store the config.
-   istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig filter_config_;
+  istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig
+      filter_config_;
 
   StreamDecoderFilterCallbacks* decoder_callbacks_{};
 

--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -68,7 +68,7 @@ class AuthenticationFilter : public StreamDecoderFilter,
 
  private:
   // Store the config.
-  istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig
+  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
       filter_config_;
 
   StreamDecoderFilterCallbacks* decoder_callbacks_{};

--- a/src/envoy/http/authn/http_filter.h
+++ b/src/envoy/http/authn/http_filter.h
@@ -31,8 +31,7 @@ class AuthenticationFilter : public StreamDecoderFilter,
                              public Logger::Loggable<Logger::Id::filter> {
  public:
   AuthenticationFilter(
-      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
-          config);
+      const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig& config);
   ~AuthenticationFilter();
 
   // Http::StreamFilterBase
@@ -68,8 +67,7 @@ class AuthenticationFilter : public StreamDecoderFilter,
 
  private:
   // Store the config.
-  const istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig&
-      filter_config_;
+   istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig filter_config_;
 
   StreamDecoderFilterCallbacks* decoder_callbacks_{};
 

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -57,8 +57,10 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
       const Protobuf::Message& proto_config, const std::string&,
       FactoryContext&) override {
     auto filter_config = dynamic_cast<const FilterConfig&>(proto_config);
-    ENVOY_LOG(error, "jianfeih debug, AuthnFilterConfig::createFilterFactoryFromProto : {}\n",
-      filter_config.DebugString());
+    ENVOY_LOG(error,
+              "jianfeih debug, AuthnFilterConfig::createFilterFactoryFromProto "
+              ": {}\n",
+              filter_config.DebugString());
     return createFilterFactory(filter_config);
   }
 
@@ -72,13 +74,15 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
  private:
   Http::FilterFactoryCb createFilterFactory(const FilterConfig& config_pb) {
     ENVOY_LOG(debug, "Called AuthnFilterConfig : {}", __func__);
-    // Make it shared_ptr so that the object is still reachable when callback is invoked.
+    // Make it shared_ptr so that the object is still reachable when callback is
+    // invoked.
     auto filter_config = std::make_shared<FilterConfig>(config_pb);
-    return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-      callbacks.addStreamDecoderFilter(
-          std::make_shared<Http::Istio::AuthN::AuthenticationFilter>(
-              *filter_config));
-    };
+    return
+        [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+          callbacks.addStreamDecoderFilter(
+              std::make_shared<Http::Istio::AuthN::AuthenticationFilter>(
+                  *filter_config));
+        };
   }
 };
 

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -72,6 +72,8 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
     ENVOY_LOG(debug, "Called AuthnFilterConfig : {}", __func__);
     // Make it shared_ptr so that the object is still reachable when callback is
     // invoked.
+    // TODO(incfly): add a test to simulate different config can be handled correctly
+    // similar to multiplexing on different port.
     auto filter_config = std::make_shared<FilterConfig>(config_pb);
     return
         [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -57,10 +57,6 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
       const Protobuf::Message& proto_config, const std::string&,
       FactoryContext&) override {
     auto filter_config = dynamic_cast<const FilterConfig&>(proto_config);
-    ENVOY_LOG(error,
-              "jianfeih debug, AuthnFilterConfig::createFilterFactoryFromProto "
-              ": {}\n",
-              filter_config.DebugString());
     return createFilterFactory(filter_config);
   }
 

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -72,8 +72,8 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
     ENVOY_LOG(debug, "Called AuthnFilterConfig : {}", __func__);
     // Make it shared_ptr so that the object is still reachable when callback is
     // invoked.
-    // TODO(incfly): add a test to simulate different config can be handled correctly
-    // similar to multiplexing on different port.
+    // TODO(incfly): add a test to simulate different config can be handled
+    // correctly similar to multiplexing on different port.
     auto filter_config = std::make_shared<FilterConfig>(config_pb);
     return
         [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -38,13 +38,11 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
                                             const std::string&,
                                             FactoryContext&) override {
     ENVOY_LOG(debug, "Called AuthnFilterConfig : {}", __func__);
-
+    FilterConfig filter_config;
     google::protobuf::util::Status status =
-        Utils::ParseJsonMessage(config.asJsonString(), &filter_config_);
+        Utils::ParseJsonMessage(config.asJsonString(), &filter_config);
     ENVOY_LOG(debug, "Called AuthnFilterConfig : Utils::ParseJsonMessage()");
-    if (status.ok()) {
-      return createFilter();
-    } else {
+    if (!status.ok()) {
       ENVOY_LOG(critical, "Utils::ParseJsonMessage() return value is: " +
                               status.ToString());
       throw EnvoyException(
@@ -52,13 +50,16 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
           "is: " +
           status.ToString());
     }
+    return createFilterFactory(filter_config);
   }
 
   Http::FilterFactoryCb createFilterFactoryFromProto(
       const Protobuf::Message& proto_config, const std::string&,
       FactoryContext&) override {
-    filter_config_ = dynamic_cast<const FilterConfig&>(proto_config);
-    return createFilter();
+    auto filter_config = dynamic_cast<const FilterConfig&>(proto_config);
+    ENVOY_LOG(error, "jianfeih debug, AuthnFilterConfig::createFilterFactoryFromProto : {}\n",
+      filter_config.DebugString());
+    return createFilterFactory(filter_config);
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -69,17 +70,16 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
   std::string name() override { return kAuthnFactoryName; }
 
  private:
-  Http::FilterFactoryCb createFilter() {
+  Http::FilterFactoryCb createFilterFactory(const FilterConfig& config_pb) {
     ENVOY_LOG(debug, "Called AuthnFilterConfig : {}", __func__);
-
-    return [&](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    // Make it shared_ptr so that the object is still reachable when callback is invoked.
+    auto filter_config = std::make_shared<FilterConfig>(config_pb);
+    return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
       callbacks.addStreamDecoderFilter(
           std::make_shared<Http::Istio::AuthN::AuthenticationFilter>(
-              filter_config_));
+              *filter_config));
     };
   }
-
-  FilterConfig filter_config_;
 };
 
 /**

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -166,8 +166,10 @@ TEST_F(AuthenticationFilterTest, IgnoreBothFail) {
   ASSERT_TRUE(
       Protobuf::TextFormat::ParseFromString(ingoreBothPolicy, &policy_));
   *filter_config_.mutable_policy() = policy_;
+  StrictMock<MockAuthenticationFilter> filter(filter_config_);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
-            filter_.decodeHeaders(request_headers_, true));
+            filter.decodeHeaders(request_headers_, true));
 }
 
 }  // namespace

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -30,10 +30,10 @@ using Envoy::Http::Istio::AuthN::FilterContext;
 using istio::authn::Payload;
 using istio::authn::Result;
 using istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig;
+using testing::_;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::StrictMock;
-using testing::_;
 
 namespace iaapi = istio::authentication::v1alpha1;
 

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -30,10 +30,10 @@ using Envoy::Http::Istio::AuthN::FilterContext;
 using istio::authn::Payload;
 using istio::authn::Result;
 using istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig;
-using testing::_;
 using testing::Invoke;
 using testing::NiceMock;
 using testing::StrictMock;
+using testing::_;
 
 namespace iaapi = istio::authentication::v1alpha1;
 
@@ -51,11 +51,11 @@ const char ingoreBothPolicy[] = R"(
 // Create a fake authenticator for test. This authenticator do nothing except
 // making the authentication fail.
 std::unique_ptr<AuthenticatorBase> createAlwaysFailAuthenticator(
-    FilterContext* filter_context) {
+    FilterContext *filter_context) {
   class _local : public AuthenticatorBase {
    public:
-    _local(FilterContext* filter_context) : AuthenticatorBase(filter_context) {}
-    bool run(Payload*) override { return false; }
+    _local(FilterContext *filter_context) : AuthenticatorBase(filter_context) {}
+    bool run(Payload *) override { return false; }
   };
   return std::make_unique<_local>(filter_context);
 }
@@ -63,11 +63,11 @@ std::unique_ptr<AuthenticatorBase> createAlwaysFailAuthenticator(
 // Create a fake authenticator for test. This authenticator do nothing except
 // making the authentication successful.
 std::unique_ptr<AuthenticatorBase> createAlwaysPassAuthenticator(
-    FilterContext* filter_context) {
+    FilterContext *filter_context) {
   class _local : public AuthenticatorBase {
    public:
-    _local(FilterContext* filter_context) : AuthenticatorBase(filter_context) {}
-    bool run(Payload*) override {
+    _local(FilterContext *filter_context) : AuthenticatorBase(filter_context) {}
+    bool run(Payload *) override {
       // Set some data to verify authentication result later.
       auto payload = TestUtilities::CreateX509Payload("foo");
       filter_context()->setPeerResult(&payload);
@@ -81,15 +81,15 @@ class MockAuthenticationFilter : public AuthenticationFilter {
  public:
   // We'll use fake authenticator for test, so policy is not really needed. Use
   // default config for simplicity.
-  MockAuthenticationFilter(const FilterConfig& filter_config)
+  MockAuthenticationFilter(const FilterConfig &filter_config)
       : AuthenticationFilter(filter_config) {}
 
   ~MockAuthenticationFilter(){};
 
   MOCK_METHOD1(createPeerAuthenticator,
-               std::unique_ptr<AuthenticatorBase>(FilterContext*));
+               std::unique_ptr<AuthenticatorBase>(FilterContext *));
   MOCK_METHOD1(createOriginAuthenticator,
-               std::unique_ptr<AuthenticatorBase>(FilterContext*));
+               std::unique_ptr<AuthenticatorBase>(FilterContext *));
 };
 
 class AuthenticationFilterTest : public testing::Test {
@@ -118,7 +118,7 @@ TEST_F(AuthenticationFilterTest, PeerFail) {
       .WillOnce(Invoke(createAlwaysFailAuthenticator));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
       .Times(1)
-      .WillOnce(testing::Invoke([](Http::HeaderMap& headers, bool) {
+      .WillOnce(testing::Invoke([](Http::HeaderMap &headers, bool) {
         EXPECT_STREQ("401", headers.Status()->value().c_str());
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
@@ -137,7 +137,7 @@ TEST_F(AuthenticationFilterTest, PeerPassOrginFail) {
       .WillOnce(Invoke(createAlwaysFailAuthenticator));
   EXPECT_CALL(decoder_callbacks_, encodeHeaders_(_, _))
       .Times(1)
-      .WillOnce(testing::Invoke([](Http::HeaderMap& headers, bool) {
+      .WillOnce(testing::Invoke([](Http::HeaderMap &headers, bool) {
         EXPECT_STREQ("401", headers.Status()->value().c_str());
       }));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,

--- a/src/envoy/http/authn/peer_authenticator.cc
+++ b/src/envoy/http/authn/peer_authenticator.cc
@@ -32,7 +32,6 @@ PeerAuthenticator::PeerAuthenticator(FilterContext* filter_context,
 
 bool PeerAuthenticator::run(Payload* payload) {
   bool success = false;
-
   if (policy_.peers_size() == 0) {
     ENVOY_LOG(debug, "No method defined. Skip source authentication.");
     success = true;


### PR DESCRIPTION
**Which issue this PR fixes**: https://github.com/istio/istio/issues/6361

**Release note**:
Each authn filter has its own configuration.

With a proxy build included change, I can get multiplexing work when different port have different policies.
