### PR TITLE
Update istio/api dependency to be the latest in release-1.0.0-snapshot.0.

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "f403f2ff3a7ee656a1bfbf23e66966a633160300",
+		"lastStableSHA": "2d2fd0bdcf2ce26f5d96615e05974913b3d260c5",
 	},
 	{
 		"_comment": "",

--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "2d2fd0bdcf2ce26f5d96615e05974913b3d260c5",
+		"lastStableSHA": "c6ad574a1cd532463cd805f948bef90d03564f60",
 	},
 	{
 		"_comment": "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "f403f2ff3a7ee656a1bfbf23e66966a633160300"
+ISTIO_API = "2d2fd0bdcf2ce26f5d96615e05974913b3d260c5"
 
 def mixerapi_repositories(bind=True):
     BUILD = """

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -113,7 +113,7 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "2d2fd0bdcf2ce26f5d96615e05974913b3d260c5"
+ISTIO_API = "c6ad574a1cd532463cd805f948bef90d03564f60"
 
 def mixerapi_repositories(bind=True):
     BUILD = """

--- a/src/envoy/http/authn/authenticator_base.cc
+++ b/src/envoy/http/authn/authenticator_base.cc
@@ -51,13 +51,10 @@ bool AuthenticatorBase::validateX509(const iaapi::MutualTls& mtls,
   // Return value depend on mode:
   // - PERMISSIVE: plaintext connection is acceptable, thus return true
   // regardless.
-  // - TLS_PERMISSIVE: tls connection is required, but certificate is optional.
   // - STRICT: must be TLS with valid certificate.
   switch (mtls.mode()) {
     case iaapi::MutualTls::PERMISSIVE:
       return true;
-    case iaapi::MutualTls::TLS_PERMISSIVE:
-      return connection->ssl() != nullptr;
     case iaapi::MutualTls::STRICT:
       return has_user;
     default:

--- a/src/envoy/http/authn/authenticator_base_test.cc
+++ b/src/envoy/http/authn/authenticator_base_test.cc
@@ -100,10 +100,8 @@ TEST_P(ValidateX509Test, SslConnectionWithNoPeerCert) {
       .Times(1)
       .WillOnce(Return(false));
 
-  // Should return false except mode is PERMISSIVE (accept plaintext) or
-  // TLS_PERMISSIVE
-  if (GetParam() == iaapi::MutualTls::PERMISSIVE ||
-      GetParam() == iaapi::MutualTls::TLS_PERMISSIVE) {
+  // Should return false except mode is PERMISSIVE (accept plaintext).
+  if (GetParam() == iaapi::MutualTls::PERMISSIVE) {
     EXPECT_TRUE(authenticator_.validateX509(mtls_params_, payload_));
   } else {
     EXPECT_FALSE(authenticator_.validateX509(mtls_params_, payload_));
@@ -157,7 +155,6 @@ TEST_P(ValidateX509Test, SslConnectionWithPeerMalformedSpiffeCert) {
 
 INSTANTIATE_TEST_CASE_P(ValidateX509Tests, ValidateX509Test,
                         testing::Values(iaapi::MutualTls::STRICT,
-                                        iaapi::MutualTls::TLS_PERMISSIVE,
                                         iaapi::MutualTls::PERMISSIVE));
 
 class ValidateJwtTest : public testing::Test,


### PR DESCRIPTION
Fortunately, the SHA `2d2fd0bdcf2ce26f5d96615e05974913b3d260c5` is already present in istio/api:release-1.0-snapshot.0 branch, proof:  https://github.com/istio/api/commits/release-1.0.0-snapshot.0, search "2d2fd0"

istio/istio#5091