### PR TITLE
authn: save attributes to RequestInfo.metadata for later use in RBAC filter.

### DIFF
--- a/include/istio/utils/BUILD
+++ b/include/istio/utils/BUILD
@@ -34,3 +34,11 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "attribute_names_lib",
+    hdrs = [
+        "attribute_names.h",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/include/istio/utils/BUILD
+++ b/include/istio/utils/BUILD
@@ -36,7 +36,7 @@ cc_library(
 )
 
 cc_library(
-    name = "attribute_names_lib",
+    name = "attribute_names_header",
     hdrs = [
         "attribute_names.h",
     ],

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -1,4 +1,4 @@
-/* Copyright 2017 Istio Authors. All Rights Reserved.
+/* Copyright 2018 Istio Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
-#ifndef ISTIO_CONTROL_ATTRIBUTE_NAMES_H
-#define ISTIO_CONTROL_ATTRIBUTE_NAMES_H
+#ifndef ISTIO_UTILS_ATTRIBUTE_NAMES_H
+#define ISTIO_UTILS_ATTRIBUTE_NAMES_H
 
 #include <string>
 
 namespace istio {
-namespace control {
+namespace utils {
 
 // Define attribute names
 struct AttributeName {
@@ -92,7 +92,7 @@ struct AttributeName {
   static const char kResponseGrpcMessage[];
 };
 
-}  // namespace control
+}  // namespace utils
 }  // namespace istio
 
-#endif  // ISTIO_CONTROL_ATTRIBUTE_NAMES_H
+#endif  // ISTIO_UTILS_ATTRIBUTE_NAMES_H

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -21,7 +21,6 @@
 #include "src/envoy/http/authn/peer_authenticator.h"
 #include "src/envoy/utils/authn.h"
 #include "src/envoy/utils/utils.h"
-#include "src/istio/control/http/attributes_builder.h"
 
 using istio::authn::Payload;
 using istio::envoy::config::filter::http::authn::v2alpha1::FilterConfig;
@@ -82,7 +81,7 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
 
     // Save auth results in the metadata, could be later used by RBAC filter.
     ProtobufWkt::Struct data;
-    ::istio::control::http::AttributesBuilder::SaveAuthAttributesToStruct(
+    Utils::Authentication::SaveAuthAttributesToStruct(
         filter_context_->authenticationResult(), data);
     decoder_callbacks_->requestInfo().setDynamicMetadata("istio_authn", data);
     ENVOY_LOG(debug, "Saved Dynamic Metadata:\n{}", data.DebugString());

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -32,7 +32,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//include/istio/utils:attribute_names_lib",
+        "//include/istio/utils:attribute_names_header",
         "//src/istio/authn:context_proto",
         "//src/istio/utils:attribute_names_lib",
         "@envoy//source/exe:envoy_common_lib",

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -32,7 +32,9 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        "//include/istio/utils:attribute_names_lib",
         "//src/istio/authn:context_proto",
+        "//src/istio/utils:attribute_names_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )
@@ -58,8 +60,8 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//external:mixer_client_config_cc_proto",
-        "//src/istio/mixerclient:mixerclient_lib",
         "//src/istio/control/http:control_lib",
+        "//src/istio/mixerclient:mixerclient_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/src/envoy/utils/authn.h
+++ b/src/envoy/utils/authn.h
@@ -15,6 +15,7 @@
 
 #include "common/common/logger.h"
 #include "envoy/http/header_map.h"
+#include "google/protobuf/struct.pb.h"
 #include "src/istio/authn/context.pb.h"
 
 namespace Envoy {
@@ -28,6 +29,10 @@ class Authentication : public Logger::Loggable<Logger::Id::filter> {
   // returns false and data is *not* overwritten.
   static bool SaveResultToHeader(const istio::authn::Result& result,
                                  Http::HeaderMap* headers);
+
+  // Save authentication attributes into the data Struct.
+  static void SaveAuthAttributesToStruct(const istio::authn::Result& result,
+                                         ::google::protobuf::Struct& data);
 
   // Looks up authentication result data in the header. If data is available,
   // decodes and output result proto. Returns false if data is not available, or

--- a/src/istio/control/BUILD
+++ b/src/istio/control/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 Istio Authors. All Rights Reserved.
+# Copyright 2018 Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,19 +17,19 @@ licenses(["notice"])
 cc_library(
     name = "common_lib",
     srcs = [
-        "attribute_names.cc",
         "client_context_base.cc",
     ],
     hdrs = [
-        "attribute_names.h",
         "client_context_base.h",
         "request_context.h",
     ],
     visibility = [":__subpackages__"],
     deps = [
         "//external:mixer_client_config_cc_proto",
+        "//include/istio/utils:attribute_names_lib",
         "//src/istio/mixerclient:mixerclient_lib",
         "//src/istio/quota_config:config_parser_lib",
+        "//src/istio/utils:attribute_names_lib",
     ],
 )
 

--- a/src/istio/control/BUILD
+++ b/src/istio/control/BUILD
@@ -26,7 +26,7 @@ cc_library(
     visibility = [":__subpackages__"],
     deps = [
         "//external:mixer_client_config_cc_proto",
-        "//include/istio/utils:attribute_names_lib",
+        "//include/istio/utils:attribute_names_header",
         "//src/istio/mixerclient:mixerclient_lib",
         "//src/istio/quota_config:config_parser_lib",
         "//src/istio/utils:attribute_names_lib",

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -86,9 +86,9 @@ CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
     request->check_status = check_response_info.response_status;
 
     utils::AttributesBuilder builder(&request->attributes);
-    builder.AddBool(istio::utils::AttributeName::kCheckCacheHit,
+    builder.AddBool(utils::AttributeName::kCheckCacheHit,
                     check_response_info.is_check_cache_hit);
-    builder.AddBool(istio::utils::AttributeName::kQuotaCacheHit,
+    builder.AddBool(utils::AttributeName::kQuotaCacheHit,
                     check_response_info.is_quota_cache_hit);
     on_done(check_response_info);
   };

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -15,8 +15,8 @@
 
 #include "client_context_base.h"
 #include "include/istio/mixerclient/check_response.h"
+#include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
-#include "src/istio/control/attribute_names.h"
 
 using ::google::protobuf::util::Status;
 using ::istio::mixer::v1::config::client::NetworkFailPolicy;
@@ -86,9 +86,9 @@ CancelFunc ClientContextBase::SendCheck(TransportCheckFunc transport,
     request->check_status = check_response_info.response_status;
 
     utils::AttributesBuilder builder(&request->attributes);
-    builder.AddBool(AttributeName::kCheckCacheHit,
+    builder.AddBool(istio::utils::AttributeName::kCheckCacheHit,
                     check_response_info.is_check_cache_hit);
-    builder.AddBool(AttributeName::kQuotaCacheHit,
+    builder.AddBool(istio::utils::AttributeName::kQuotaCacheHit,
                     check_response_info.is_quota_cache_hit);
     on_done(check_response_info);
   };

--- a/src/istio/control/http/BUILD
+++ b/src/istio/control/http/BUILD
@@ -31,7 +31,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//include/istio/control/http:headers_lib",
-        "//include/istio/utils:attribute_names_lib",
+        "//include/istio/utils:attribute_names_header",
         "//src/istio/api_spec:api_spec_lib",
         "//src/istio/authn:context_proto",
         "//src/istio/control:common_lib",

--- a/src/istio/control/http/BUILD
+++ b/src/istio/control/http/BUILD
@@ -31,9 +31,11 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//include/istio/control/http:headers_lib",
+        "//include/istio/utils:attribute_names_lib",
         "//src/istio/api_spec:api_spec_lib",
         "//src/istio/authn:context_proto",
         "//src/istio/control:common_lib",
+        "//src/istio/utils:attribute_names_lib",
         "//src/istio/utils:utils_lib",
     ],
 )

--- a/src/istio/control/http/attributes_builder.h
+++ b/src/istio/control/http/attributes_builder.h
@@ -16,6 +16,7 @@
 #ifndef ISTIO_CONTROL_HTTP_ATTRIBUTES_BUILDER_H
 #define ISTIO_CONTROL_HTTP_ATTRIBUTES_BUILDER_H
 
+#include "google/protobuf/struct.pb.h"
 #include "include/istio/control/http/check_data.h"
 #include "include/istio/control/http/report_data.h"
 #include "src/istio/control/request_context.h"
@@ -40,6 +41,10 @@ class AttributesBuilder {
   void ExtractCheckAttributes(CheckData* check_data);
   // Extract attributes for Report call.
   void ExtractReportAttributes(ReportData* report_data);
+
+  // Save authentication attributes into the data Struct.
+  static void SaveAuthAttributesToStruct(const istio::authn::Result& result,
+                                         ::google::protobuf::Struct& data);
 
  private:
   // Extract HTTP header attributes

--- a/src/istio/control/http/attributes_builder.h
+++ b/src/istio/control/http/attributes_builder.h
@@ -16,7 +16,6 @@
 #ifndef ISTIO_CONTROL_HTTP_ATTRIBUTES_BUILDER_H
 #define ISTIO_CONTROL_HTTP_ATTRIBUTES_BUILDER_H
 
-#include "google/protobuf/struct.pb.h"
 #include "include/istio/control/http/check_data.h"
 #include "include/istio/control/http/report_data.h"
 #include "src/istio/control/request_context.h"
@@ -41,10 +40,6 @@ class AttributesBuilder {
   void ExtractCheckAttributes(CheckData* check_data);
   // Extract attributes for Report call.
   void ExtractReportAttributes(ReportData* report_data);
-
-  // Save authentication attributes into the data Struct.
-  static void SaveAuthAttributesToStruct(const istio::authn::Result& result,
-                                         ::google::protobuf::Struct& data);
 
  private:
   // Extract HTTP header attributes

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -240,7 +240,7 @@ void ClearContextTime(const std::string &name, RequestContext *request) {
 
 void SetDestinationIp(RequestContext *request, const std::string &ip) {
   utils::AttributesBuilder builder(&request->attributes);
-  builder.AddBytes(istio::utils::AttributeName::kDestinationIp, ip);
+  builder.AddBytes(utils::AttributeName::kDestinationIp, ip);
 }
 
 TEST(AttributesBuilderTest, TestExtractForwardedAttributes) {
@@ -323,7 +323,7 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
   AttributesBuilder builder(&request);
   builder.ExtractCheckAttributes(&mock_data);
 
-  ClearContextTime(istio::utils::AttributeName::kRequestTime, &request);
+  ClearContextTime(utils::AttributeName::kRequestTime, &request);
 
   std::string out_str;
   TextFormat::PrintToString(request.attributes, &out_str);
@@ -382,7 +382,7 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   AttributesBuilder builder(&request);
   builder.ExtractCheckAttributes(&mock_data);
 
-  ClearContextTime(istio::utils::AttributeName::kRequestTime, &request);
+  ClearContextTime(utils::AttributeName::kRequestTime, &request);
 
   std::string out_str;
   TextFormat::PrintToString(request.attributes, &out_str);
@@ -395,9 +395,9 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   // way to construct mixer attribute (it was a fallback when authn filter is
   // not available, which can be removed after 0.8). For now, modifying expected
   // data manually for this test.
-  (*expected_attributes.mutable_attributes())
-      [istio::utils::AttributeName::kRequestAuthRawClaims]
-          .set_string_value("test_raw_claims");
+  (*expected_attributes
+        .mutable_attributes())[utils::AttributeName::kRequestAuthRawClaims]
+      .set_string_value("test_raw_claims");
 
   EXPECT_TRUE(
       MessageDifferencer::Equals(request.attributes, expected_attributes));
@@ -443,7 +443,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   AttributesBuilder builder(&request);
   builder.ExtractReportAttributes(&mock_data);
 
-  ClearContextTime(istio::utils::AttributeName::kResponseTime, &request);
+  ClearContextTime(utils::AttributeName::kResponseTime, &request);
 
   std::string out_str;
   TextFormat::PrintToString(request.attributes, &out_str);
@@ -453,14 +453,14 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kReportAttributes, &expected_attributes));
   (*expected_attributes
-        .mutable_attributes())[istio::utils::AttributeName::kDestinationUID]
+        .mutable_attributes())[utils::AttributeName::kDestinationUID]
       .set_string_value("pod1.ns2");
   (*expected_attributes
-        .mutable_attributes())[istio::utils::AttributeName::kResponseGrpcStatus]
+        .mutable_attributes())[utils::AttributeName::kResponseGrpcStatus]
       .set_string_value("grpc-status");
-  (*expected_attributes.mutable_attributes())
-      [istio::utils::AttributeName::kResponseGrpcMessage]
-          .set_string_value("grpc-message");
+  (*expected_attributes
+        .mutable_attributes())[utils::AttributeName::kResponseGrpcMessage]
+      .set_string_value("grpc-message");
   EXPECT_TRUE(
       MessageDifferencer::Equals(request.attributes, expected_attributes));
 }
@@ -495,7 +495,7 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
   AttributesBuilder builder(&request);
   builder.ExtractReportAttributes(&mock_data);
 
-  ClearContextTime(istio::utils::AttributeName::kResponseTime, &request);
+  ClearContextTime(utils::AttributeName::kResponseTime, &request);
 
   std::string out_str;
   TextFormat::PrintToString(request.attributes, &out_str);

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -15,7 +15,7 @@
 
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
-#include "src/istio/control/attribute_names.h"
+#include "include/istio/utils/attribute_names.h"
 #include "src/istio/control/http/client_context.h"
 #include "src/istio/control/http/controller_impl.h"
 #include "src/istio/control/http/mock_check_data.h"
@@ -403,8 +403,9 @@ TEST_F(RequestHandlerImplTest, TestDefaultApiKey) {
                           TransportCheckFunc transport,
                           CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
-        EXPECT_EQ(map[AttributeName::kRequestApiKey].string_value(),
-                  "test-api-key");
+        EXPECT_EQ(
+            map[istio::utils::AttributeName::kRequestApiKey].string_value(),
+            "test-api-key");
         return nullptr;
       }));
 

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -403,9 +403,8 @@ TEST_F(RequestHandlerImplTest, TestDefaultApiKey) {
                           TransportCheckFunc transport,
                           CheckDoneFunc on_done) -> CancelFunc {
         auto map = attributes.attributes();
-        EXPECT_EQ(
-            map[istio::utils::AttributeName::kRequestApiKey].string_value(),
-            "test-api-key");
+        EXPECT_EQ(map[utils::AttributeName::kRequestApiKey].string_value(),
+                  "test-api-key");
         return nullptr;
       }));
 

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -92,7 +92,7 @@ void ServiceContext::AddApiAttributes(CheckData *check_data,
   std::string api_key;
   if (api_spec_parser_->ExtractApiKey(check_data, &api_key)) {
     (*request->attributes
-          .mutable_attributes())[istio::utils::AttributeName::kRequestApiKey]
+          .mutable_attributes())[utils::AttributeName::kRequestApiKey]
         .set_string_value(api_key);
   }
 }

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -14,7 +14,7 @@
  */
 
 #include "service_context.h"
-#include "src/istio/control/attribute_names.h"
+#include "include/istio/utils/attribute_names.h"
 #include "src/istio/control/http/attributes_builder.h"
 
 using ::istio::mixer::v1::Attributes;
@@ -91,7 +91,8 @@ void ServiceContext::AddApiAttributes(CheckData *check_data,
 
   std::string api_key;
   if (api_spec_parser_->ExtractApiKey(check_data, &api_key)) {
-    (*request->attributes.mutable_attributes())[AttributeName::kRequestApiKey]
+    (*request->attributes
+          .mutable_attributes())[istio::utils::AttributeName::kRequestApiKey]
         .set_string_value(api_key);
   }
 }

--- a/src/istio/control/tcp/BUILD
+++ b/src/istio/control/tcp/BUILD
@@ -28,7 +28,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//include/istio/control/tcp:headers_lib",
-        "//include/istio/utils:attribute_names_lib",
+        "//include/istio/utils:attribute_names_header",
         "//src/istio/control:common_lib",
         "//src/istio/utils:attribute_names_lib",
     ],

--- a/src/istio/control/tcp/BUILD
+++ b/src/istio/control/tcp/BUILD
@@ -28,7 +28,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//include/istio/control/tcp:headers_lib",
+        "//include/istio/utils:attribute_names_lib",
         "//src/istio/control:common_lib",
+        "//src/istio/utils:attribute_names_lib",
     ],
 )
 

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -15,8 +15,8 @@
 
 #include "src/istio/control/tcp/attributes_builder.h"
 
+#include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
-#include "src/istio/control/attribute_names.h"
 
 namespace istio {
 namespace control {
@@ -36,7 +36,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   // TODO(kuat): there is no way to propagate source IP in TCP, so we auto-set
   // it
   if (check_data->GetSourceIpPort(&source_ip, &source_port)) {
-    builder.AddBytes(AttributeName::kSourceIp, source_ip);
+    builder.AddBytes(istio::utils::AttributeName::kSourceIp, source_ip);
   }
 
   // TODO(diemtvu): add TCP authn filter similar to http case, and use authn
@@ -45,19 +45,22 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   if (check_data->GetSourceUser(&source_user)) {
     // TODO(diemtvu): remove kSourceUser once migration to source.principal is
     // over. https://github.com/istio/istio/issues/4689
-    builder.AddString(AttributeName::kSourceUser, source_user);
-    builder.AddString(AttributeName::kSourcePrincipal, source_user);
+    builder.AddString(istio::utils::AttributeName::kSourceUser, source_user);
+    builder.AddString(istio::utils::AttributeName::kSourcePrincipal,
+                      source_user);
   }
-  builder.AddBool(AttributeName::kConnectionMtls, check_data->IsMutualTLS());
+  builder.AddBool(istio::utils::AttributeName::kConnectionMtls,
+                  check_data->IsMutualTLS());
 
-  builder.AddTimestamp(AttributeName::kContextTime,
+  builder.AddTimestamp(istio::utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());
-  builder.AddString(AttributeName::kContextProtocol, "tcp");
-  builder.AddString(AttributeName::kConnectionEvent, kConnectionOpen);
+  builder.AddString(istio::utils::AttributeName::kContextProtocol, "tcp");
+  builder.AddString(istio::utils::AttributeName::kConnectionEvent,
+                    kConnectionOpen);
 
   // Get unique downstream connection ID, which is <uuid>-<connection id>.
   std::string connection_id = check_data->GetConnectionId();
-  builder.AddString(AttributeName::kConnectionId, connection_id);
+  builder.AddString(istio::utils::AttributeName::kConnectionId, connection_id);
 }
 
 void AttributesBuilder::ExtractReportAttributes(
@@ -67,47 +70,52 @@ void AttributesBuilder::ExtractReportAttributes(
 
   ReportData::ReportInfo info;
   report_data->GetReportInfo(&info);
-  builder.AddInt64(AttributeName::kConnectionReceviedBytes,
+  builder.AddInt64(istio::utils::AttributeName::kConnectionReceviedBytes,
                    info.received_bytes - last_report_info->received_bytes);
-  builder.AddInt64(AttributeName::kConnectionReceviedTotalBytes,
+  builder.AddInt64(istio::utils::AttributeName::kConnectionReceviedTotalBytes,
                    info.received_bytes);
-  builder.AddInt64(AttributeName::kConnectionSendBytes,
+  builder.AddInt64(istio::utils::AttributeName::kConnectionSendBytes,
                    info.send_bytes - last_report_info->send_bytes);
-  builder.AddInt64(AttributeName::kConnectionSendTotalBytes, info.send_bytes);
+  builder.AddInt64(istio::utils::AttributeName::kConnectionSendTotalBytes,
+                   info.send_bytes);
 
   if (is_final_report) {
-    builder.AddDuration(AttributeName::kConnectionDuration, info.duration);
+    builder.AddDuration(istio::utils::AttributeName::kConnectionDuration,
+                        info.duration);
     if (!request_->check_status.ok()) {
-      builder.AddInt64(AttributeName::kCheckErrorCode,
+      builder.AddInt64(istio::utils::AttributeName::kCheckErrorCode,
                        request_->check_status.error_code());
-      builder.AddString(AttributeName::kCheckErrorMessage,
+      builder.AddString(istio::utils::AttributeName::kCheckErrorMessage,
                         request_->check_status.ToString());
     }
-    builder.AddString(AttributeName::kConnectionEvent, kConnectionClose);
+    builder.AddString(istio::utils::AttributeName::kConnectionEvent,
+                      kConnectionClose);
   } else {
     last_report_info->received_bytes = info.received_bytes;
     last_report_info->send_bytes = info.send_bytes;
-    builder.AddString(AttributeName::kConnectionEvent, kConnectionContinue);
+    builder.AddString(istio::utils::AttributeName::kConnectionEvent,
+                      kConnectionContinue);
   }
 
   std::string dest_ip;
   int dest_port;
   // Do not overwrite destination IP and port if it has already been set.
   if (report_data->GetDestinationIpPort(&dest_ip, &dest_port)) {
-    if (!builder.HasAttribute(AttributeName::kDestinationIp)) {
-      builder.AddBytes(AttributeName::kDestinationIp, dest_ip);
+    if (!builder.HasAttribute(istio::utils::AttributeName::kDestinationIp)) {
+      builder.AddBytes(istio::utils::AttributeName::kDestinationIp, dest_ip);
     }
-    if (!builder.HasAttribute(AttributeName::kDestinationPort)) {
-      builder.AddInt64(AttributeName::kDestinationPort, dest_port);
+    if (!builder.HasAttribute(istio::utils::AttributeName::kDestinationPort)) {
+      builder.AddInt64(istio::utils::AttributeName::kDestinationPort,
+                       dest_port);
     }
   }
 
   std::string uid;
   if (report_data->GetDestinationUID(&uid)) {
-    builder.AddString(AttributeName::kDestinationUID, uid);
+    builder.AddString(istio::utils::AttributeName::kDestinationUID, uid);
   }
 
-  builder.AddTimestamp(AttributeName::kContextTime,
+  builder.AddTimestamp(istio::utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());
 }
 

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -36,7 +36,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   // TODO(kuat): there is no way to propagate source IP in TCP, so we auto-set
   // it
   if (check_data->GetSourceIpPort(&source_ip, &source_port)) {
-    builder.AddBytes(istio::utils::AttributeName::kSourceIp, source_ip);
+    builder.AddBytes(utils::AttributeName::kSourceIp, source_ip);
   }
 
   // TODO(diemtvu): add TCP authn filter similar to http case, and use authn
@@ -45,22 +45,20 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   if (check_data->GetSourceUser(&source_user)) {
     // TODO(diemtvu): remove kSourceUser once migration to source.principal is
     // over. https://github.com/istio/istio/issues/4689
-    builder.AddString(istio::utils::AttributeName::kSourceUser, source_user);
-    builder.AddString(istio::utils::AttributeName::kSourcePrincipal,
-                      source_user);
+    builder.AddString(utils::AttributeName::kSourceUser, source_user);
+    builder.AddString(utils::AttributeName::kSourcePrincipal, source_user);
   }
-  builder.AddBool(istio::utils::AttributeName::kConnectionMtls,
+  builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 
-  builder.AddTimestamp(istio::utils::AttributeName::kContextTime,
+  builder.AddTimestamp(utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());
-  builder.AddString(istio::utils::AttributeName::kContextProtocol, "tcp");
-  builder.AddString(istio::utils::AttributeName::kConnectionEvent,
-                    kConnectionOpen);
+  builder.AddString(utils::AttributeName::kContextProtocol, "tcp");
+  builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionOpen);
 
   // Get unique downstream connection ID, which is <uuid>-<connection id>.
   std::string connection_id = check_data->GetConnectionId();
-  builder.AddString(istio::utils::AttributeName::kConnectionId, connection_id);
+  builder.AddString(utils::AttributeName::kConnectionId, connection_id);
 }
 
 void AttributesBuilder::ExtractReportAttributes(
@@ -70,30 +68,29 @@ void AttributesBuilder::ExtractReportAttributes(
 
   ReportData::ReportInfo info;
   report_data->GetReportInfo(&info);
-  builder.AddInt64(istio::utils::AttributeName::kConnectionReceviedBytes,
+  builder.AddInt64(utils::AttributeName::kConnectionReceviedBytes,
                    info.received_bytes - last_report_info->received_bytes);
-  builder.AddInt64(istio::utils::AttributeName::kConnectionReceviedTotalBytes,
+  builder.AddInt64(utils::AttributeName::kConnectionReceviedTotalBytes,
                    info.received_bytes);
-  builder.AddInt64(istio::utils::AttributeName::kConnectionSendBytes,
+  builder.AddInt64(utils::AttributeName::kConnectionSendBytes,
                    info.send_bytes - last_report_info->send_bytes);
-  builder.AddInt64(istio::utils::AttributeName::kConnectionSendTotalBytes,
+  builder.AddInt64(utils::AttributeName::kConnectionSendTotalBytes,
                    info.send_bytes);
 
   if (is_final_report) {
-    builder.AddDuration(istio::utils::AttributeName::kConnectionDuration,
+    builder.AddDuration(utils::AttributeName::kConnectionDuration,
                         info.duration);
     if (!request_->check_status.ok()) {
-      builder.AddInt64(istio::utils::AttributeName::kCheckErrorCode,
+      builder.AddInt64(utils::AttributeName::kCheckErrorCode,
                        request_->check_status.error_code());
-      builder.AddString(istio::utils::AttributeName::kCheckErrorMessage,
+      builder.AddString(utils::AttributeName::kCheckErrorMessage,
                         request_->check_status.ToString());
     }
-    builder.AddString(istio::utils::AttributeName::kConnectionEvent,
-                      kConnectionClose);
+    builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionClose);
   } else {
     last_report_info->received_bytes = info.received_bytes;
     last_report_info->send_bytes = info.send_bytes;
-    builder.AddString(istio::utils::AttributeName::kConnectionEvent,
+    builder.AddString(utils::AttributeName::kConnectionEvent,
                       kConnectionContinue);
   }
 
@@ -101,21 +98,20 @@ void AttributesBuilder::ExtractReportAttributes(
   int dest_port;
   // Do not overwrite destination IP and port if it has already been set.
   if (report_data->GetDestinationIpPort(&dest_ip, &dest_port)) {
-    if (!builder.HasAttribute(istio::utils::AttributeName::kDestinationIp)) {
-      builder.AddBytes(istio::utils::AttributeName::kDestinationIp, dest_ip);
+    if (!builder.HasAttribute(utils::AttributeName::kDestinationIp)) {
+      builder.AddBytes(utils::AttributeName::kDestinationIp, dest_ip);
     }
-    if (!builder.HasAttribute(istio::utils::AttributeName::kDestinationPort)) {
-      builder.AddInt64(istio::utils::AttributeName::kDestinationPort,
-                       dest_port);
+    if (!builder.HasAttribute(utils::AttributeName::kDestinationPort)) {
+      builder.AddInt64(utils::AttributeName::kDestinationPort, dest_port);
     }
   }
 
   std::string uid;
   if (report_data->GetDestinationUID(&uid)) {
-    builder.AddString(istio::utils::AttributeName::kDestinationUID, uid);
+    builder.AddString(utils::AttributeName::kDestinationUID, uid);
   }
 
-  builder.AddTimestamp(istio::utils::AttributeName::kContextTime,
+  builder.AddTimestamp(utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());
 }
 

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -285,7 +285,7 @@ void ClearContextTime(RequestContext* request) {
   // Override timestamp with -
   utils::AttributesBuilder builder(&request->attributes);
   std::chrono::time_point<std::chrono::system_clock> time0;
-  builder.AddTimestamp(istio::utils::AttributeName::kContextTime, time0);
+  builder.AddTimestamp(utils::AttributeName::kContextTime, time0);
 }
 
 TEST(AttributesBuilderTest, TestCheckAttributes) {

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -18,8 +18,8 @@
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
+#include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
-#include "src/istio/control/attribute_names.h"
 #include "src/istio/control/tcp/mock_check_data.h"
 #include "src/istio/control/tcp/mock_report_data.h"
 
@@ -285,7 +285,7 @@ void ClearContextTime(RequestContext* request) {
   // Override timestamp with -
   utils::AttributesBuilder builder(&request->attributes);
   std::chrono::time_point<std::chrono::system_clock> time0;
-  builder.AddTimestamp(AttributeName::kContextTime, time0);
+  builder.AddTimestamp(istio::utils::AttributeName::kContextTime, time0);
 }
 
 TEST(AttributesBuilderTest, TestCheckAttributes) {

--- a/src/istio/utils/BUILD
+++ b/src/istio/utils/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2017 Istio Authors. All Rights Reserved.
+# Copyright 2018 Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,5 +64,16 @@ cc_test(
     deps = [
         ":md5_lib",
         "//external:googletest_main",
+    ],
+)
+
+cc_library(
+    name = "attribute_names_lib",
+    srcs = [
+        "attribute_names.cc",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//include/istio/utils:attribute_names_lib",
     ],
 )

--- a/src/istio/utils/BUILD
+++ b/src/istio/utils/BUILD
@@ -74,6 +74,6 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//include/istio/utils:attribute_names_lib",
+        "//include/istio/utils:attribute_names_header",
     ],
 )

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -1,4 +1,4 @@
-/* Copyright 2017 Istio Authors. All Rights Reserved.
+/* Copyright 2018 Istio Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-#include "attribute_names.h"
+#include "include/istio/utils/attribute_names.h"
 
 namespace istio {
-namespace control {
+namespace utils {
 
 // Define attribute names
 const char AttributeName::kSourceUser[] = "source.user";
@@ -84,5 +84,5 @@ const char AttributeName::kRequestAuthRawClaims[] = "request.auth.raw_claims";
 const char AttributeName::kResponseGrpcStatus[] = "response.grpc_status";
 const char AttributeName::kResponseGrpcMessage[] = "response.grpc_message";
 
-}  // namespace control
+}  // namespace utils
 }  // namespace istio


### PR DESCRIPTION
Support to pass the auth attributes in metadata for later use in RBAC filter.

See istio/istio#6377

Signed-off-by: Yangmin Zhu <ymzhu@google.com>
