### PR TITLE
Update Envoy SHA to latest, include health check tracing fix, trace s…

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "6d3d5d72986c2131a40268467c3ddcc57ef7bbc7"
+ENVOY_SHA = "15706964a29e595c045a5d7ef0646d04f347dcc1"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "6d3d5d72986c2131a40268467c3ddcc57ef7bbc7"
+		"lastStableSHA": "15706964a29e595c045a5d7ef0646d04f347dcc1"
 	}
 ]

--- a/protobuf.bzl
+++ b/protobuf.bzl
@@ -20,7 +20,7 @@ def protobuf_repositories(load_repo=True, bind=True):
     if load_repo:
         git_repository(
             name = "com_google_protobuf",
-            commit = "2761122b810fe8861004ae785cc3ab39f384d342",  # v3.5.0
+            commit = "6a4fec616ec4b20f54d5fb530808b855cb664390",  # Match SHA used by Envoy
             remote = "https://github.com/google/protobuf.git",
         )
 

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -61,6 +61,7 @@ class AuthenticationFilterIntegrationTest
 
   void TearDown() override {
     test_server_.reset();
+    fake_upstream_connection_.reset();
     fake_upstreams_.clear();
   }
 


### PR DESCRIPTION
…ampling config, etc

Signed-off-by: Gary Brown <gary@brownuk.com>

**What this PR does / why we need it**:

Update to latest Envoy SHA which includes fix for avoiding tracing of health check probe and v2 trace sampling configuration.