### PR TITLE
Implement destination.principal attribute extraction

### DIFF
--- a/include/istio/control/http/check_data.h
+++ b/include/istio/control/http/check_data.h
@@ -38,8 +38,11 @@ class CheckData {
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string *ip, int *port) const = 0;
 
-  // If SSL is used, get origin user name.
-  virtual bool GetSourceUser(std::string *user) const = 0;
+  // If SSL is used, get peer SAN URI.
+  virtual bool GetPeerPrincipal(std::string *user) const = 0;
+
+  // If SSL is used, get local SAN URI.
+  virtual bool GetLocalPrincipal(std::string *user) const = 0;
 
   // Get request HTTP headers
   virtual std::map<std::string, std::string> GetRequestHeaders() const = 0;

--- a/include/istio/control/http/check_data.h
+++ b/include/istio/control/http/check_data.h
@@ -38,7 +38,7 @@ class CheckData {
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string *ip, int *port) const = 0;
 
-  // If SSL is used, get certificate SAN URI.
+  // If SSL is used, get peer or local certificate SAN URI.
   virtual bool GetPrincipal(bool peer, std::string *user) const = 0;
 
   // Get request HTTP headers

--- a/include/istio/control/http/check_data.h
+++ b/include/istio/control/http/check_data.h
@@ -38,11 +38,8 @@ class CheckData {
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string *ip, int *port) const = 0;
 
-  // If SSL is used, get peer SAN URI.
-  virtual bool GetPeerPrincipal(std::string *user) const = 0;
-
-  // If SSL is used, get local SAN URI.
-  virtual bool GetLocalPrincipal(std::string *user) const = 0;
+  // If SSL is used, get certificate SAN URI.
+  virtual bool GetPrincipal(bool peer, std::string *user) const = 0;
 
   // Get request HTTP headers
   virtual std::map<std::string, std::string> GetRequestHeaders() const = 0;

--- a/include/istio/control/tcp/check_data.h
+++ b/include/istio/control/tcp/check_data.h
@@ -31,11 +31,8 @@ class CheckData {
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string* ip, int* port) const = 0;
 
-  // If SSL is used, get peer URI.
-  virtual bool GetPeerPrincipal(std::string* user) const = 0;
-
-  // If SSL is used, get local URI.
-  virtual bool GetLocalPrincipal(std::string* user) const = 0;
+  // If SSL is used, get certificate SAN URI.
+  virtual bool GetPrincipal(bool peer, std::string* user) const = 0;
 
   // Returns true if connection is mutual TLS enabled.
   virtual bool IsMutualTLS() const = 0;

--- a/include/istio/control/tcp/check_data.h
+++ b/include/istio/control/tcp/check_data.h
@@ -31,8 +31,11 @@ class CheckData {
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string* ip, int* port) const = 0;
 
-  // If SSL is used, get origin user name.
-  virtual bool GetSourceUser(std::string* user) const = 0;
+  // If SSL is used, get peer URI.
+  virtual bool GetPeerPrincipal(std::string* user) const = 0;
+
+  // If SSL is used, get local URI.
+  virtual bool GetLocalPrincipal(std::string* user) const = 0;
 
   // Returns true if connection is mutual TLS enabled.
   virtual bool IsMutualTLS() const = 0;

--- a/include/istio/control/tcp/check_data.h
+++ b/include/istio/control/tcp/check_data.h
@@ -31,7 +31,7 @@ class CheckData {
   // Get downstream tcp connection ip and port.
   virtual bool GetSourceIpPort(std::string* ip, int* port) const = 0;
 
-  // If SSL is used, get certificate SAN URI.
+  // If SSL is used, get peer or local certificate SAN URI.
   virtual bool GetPrincipal(bool peer, std::string* user) const = 0;
 
   // Returns true if connection is mutual TLS enabled.

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -27,6 +27,7 @@ struct AttributeName {
   // https://github.com/istio/istio/issues/4689
   static const char kSourceUser[];
   static const char kSourcePrincipal[];
+  static const char kDestinationPrincipal[];
 
   static const char kRequestHeaders[];
   static const char kRequestHost[];

--- a/src/envoy/http/authn/authenticator_base.cc
+++ b/src/envoy/http/authn/authenticator_base.cc
@@ -43,8 +43,8 @@ bool AuthenticatorBase::validateX509(const iaapi::MutualTls& mtls,
   const bool has_user =
       connection->ssl() != nullptr &&
       connection->ssl()->peerCertificatePresented() &&
-      Utils::GetPeerPrincipal(connection,
-                              payload->mutable_x509()->mutable_user());
+      Utils::GetPrincipal(connection, true,
+                          payload->mutable_x509()->mutable_user());
 
   ENVOY_LOG(debug, "validateX509 mode {}: ssl={}, has_user={}",
             iaapi::MutualTls::Mode_Name(mtls.mode()),

--- a/src/envoy/http/authn/authenticator_base.cc
+++ b/src/envoy/http/authn/authenticator_base.cc
@@ -43,7 +43,8 @@ bool AuthenticatorBase::validateX509(const iaapi::MutualTls& mtls,
   const bool has_user =
       connection->ssl() != nullptr &&
       connection->ssl()->peerCertificatePresented() &&
-      Utils::GetSourceUser(connection, payload->mutable_x509()->mutable_user());
+      Utils::GetPeerPrincipal(connection,
+                              payload->mutable_x509()->mutable_user());
 
   ENVOY_LOG(debug, "validateX509 mode {}: ssl={}, has_user={}",
             iaapi::MutualTls::Mode_Name(mtls.mode()),

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -65,8 +65,12 @@ bool CheckData::GetSourceIpPort(std::string* ip, int* port) const {
   return false;
 }
 
-bool CheckData::GetSourceUser(std::string* user) const {
-  return Utils::GetSourceUser(connection_, user);
+bool CheckData::GetPeerPrincipal(std::string* user) const {
+  return Utils::GetPeerPrincipal(connection_, user);
+}
+
+bool CheckData::GetLocalPrincipal(std::string* user) const {
+  return Utils::GetLocalPrincipal(connection_, user);
 }
 
 std::map<std::string, std::string> CheckData::GetRequestHeaders() const {

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -65,12 +65,8 @@ bool CheckData::GetSourceIpPort(std::string* ip, int* port) const {
   return false;
 }
 
-bool CheckData::GetPeerPrincipal(std::string* user) const {
-  return Utils::GetPeerPrincipal(connection_, user);
-}
-
-bool CheckData::GetLocalPrincipal(std::string* user) const {
-  return Utils::GetLocalPrincipal(connection_, user);
+bool CheckData::GetPrincipal(bool peer, std::string* user) const {
+  return Utils::GetPrincipal(connection_, peer, user);
 }
 
 std::map<std::string, std::string> CheckData::GetRequestHeaders() const {

--- a/src/envoy/http/mixer/check_data.h
+++ b/src/envoy/http/mixer/check_data.h
@@ -36,7 +36,9 @@ class CheckData : public ::istio::control::http::CheckData,
 
   bool GetSourceIpPort(std::string* ip, int* port) const override;
 
-  bool GetSourceUser(std::string* user) const override;
+  bool GetPeerPrincipal(std::string* user) const override;
+
+  bool GetLocalPrincipal(std::string* user) const override;
 
   std::map<std::string, std::string> GetRequestHeaders() const override;
 

--- a/src/envoy/http/mixer/check_data.h
+++ b/src/envoy/http/mixer/check_data.h
@@ -36,9 +36,7 @@ class CheckData : public ::istio::control::http::CheckData,
 
   bool GetSourceIpPort(std::string* ip, int* port) const override;
 
-  bool GetPeerPrincipal(std::string* user) const override;
-
-  bool GetLocalPrincipal(std::string* user) const override;
+  bool GetPrincipal(bool peer, std::string* user) const override;
 
   std::map<std::string, std::string> GetRequestHeaders() const override;
 

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -149,12 +149,8 @@ bool Filter::GetSourceIpPort(std::string* str_ip, int* port) const {
   return Utils::GetIpPort(filter_callbacks_->connection().remoteAddress()->ip(),
                           str_ip, port);
 }
-bool Filter::GetPeerPrincipal(std::string* user) const {
-  return Utils::GetPeerPrincipal(&filter_callbacks_->connection(), user);
-}
-
-bool Filter::GetLocalPrincipal(std::string* user) const {
-  return Utils::GetLocalPrincipal(&filter_callbacks_->connection(), user);
+bool Filter::GetPrincipal(bool peer, std::string* user) const {
+  return Utils::GetPrincipal(&filter_callbacks_->connection(), peer, user);
 }
 
 bool Filter::IsMutualTLS() const {

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -149,8 +149,12 @@ bool Filter::GetSourceIpPort(std::string* str_ip, int* port) const {
   return Utils::GetIpPort(filter_callbacks_->connection().remoteAddress()->ip(),
                           str_ip, port);
 }
-bool Filter::GetSourceUser(std::string* user) const {
-  return Utils::GetSourceUser(&filter_callbacks_->connection(), user);
+bool Filter::GetPeerPrincipal(std::string* user) const {
+  return Utils::GetPeerPrincipal(&filter_callbacks_->connection(), user);
+}
+
+bool Filter::GetLocalPrincipal(std::string* user) const {
+  return Utils::GetLocalPrincipal(&filter_callbacks_->connection(), user);
 }
 
 bool Filter::IsMutualTLS() const {

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -51,8 +51,7 @@ class Filter : public Network::Filter,
 
   // CheckData virtual functions.
   bool GetSourceIpPort(std::string* str_ip, int* port) const override;
-  bool GetPeerPrincipal(std::string* user) const override;
-  bool GetLocalPrincipal(std::string* user) const override;
+  bool GetPrincipal(bool peer, std::string* user) const override;
   bool IsMutualTLS() const override;
 
   // ReportData virtual functions.

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -51,7 +51,8 @@ class Filter : public Network::Filter,
 
   // CheckData virtual functions.
   bool GetSourceIpPort(std::string* str_ip, int* port) const override;
-  bool GetSourceUser(std::string* user) const override;
+  bool GetPeerPrincipal(std::string* user) const override;
+  bool GetLocalPrincipal(std::string* user) const override;
   bool IsMutualTLS() const override;
 
   // ReportData virtual functions.

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -90,34 +90,18 @@ bool GetDestinationUID(const envoy::api::v2::core::Metadata& metadata,
   return true;
 }
 
-bool GetPeerPrincipal(const Network::Connection* connection,
-                      std::string* principal) {
+bool GetPrincipal(const Network::Connection* connection, bool peer,
+                  std::string* principal) {
   if (connection) {
     Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());
     if (ssl != nullptr) {
-      std::string result = ssl->uriSanPeerCertificate();
-      if (result.empty()) {  // empty result is not allowed
-        return false;
-      }
-      if (result.length() >= kSPIFFEPrefix.length() &&
-          result.compare(0, kSPIFFEPrefix.length(), kSPIFFEPrefix) == 0) {
-        // Strip out the prefix "spiffe://" in the identity.
-        *principal = result.substr(kSPIFFEPrefix.size());
+      std::string result;
+      if (peer) {
+        result = ssl->uriSanPeerCertificate();
       } else {
-        *principal = result;
+        result = ssl->uriSanLocalCertificate();
       }
-      return true;
-    }
-  }
-  return false;
-}
 
-bool GetLocalPrincipal(const Network::Connection* connection,
-                       std::string* principal) {
-  if (connection) {
-    Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());
-    if (ssl != nullptr) {
-      std::string result = ssl->uriSanLocalCertificate();
       if (result.empty()) {  // empty result is not allowed
         return false;
       }

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -90,20 +90,43 @@ bool GetDestinationUID(const envoy::api::v2::core::Metadata& metadata,
   return true;
 }
 
-bool GetSourceUser(const Network::Connection* connection, std::string* user) {
+bool GetPeerPrincipal(const Network::Connection* connection,
+                      std::string* principal) {
   if (connection) {
     Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());
     if (ssl != nullptr) {
       std::string result = ssl->uriSanPeerCertificate();
-      if (result.empty()) {  // empty source user is not allowed
+      if (result.empty()) {  // empty result is not allowed
         return false;
       }
       if (result.length() >= kSPIFFEPrefix.length() &&
           result.compare(0, kSPIFFEPrefix.length(), kSPIFFEPrefix) == 0) {
         // Strip out the prefix "spiffe://" in the identity.
-        *user = result.substr(kSPIFFEPrefix.size());
+        *principal = result.substr(kSPIFFEPrefix.size());
       } else {
-        *user = result;
+        *principal = result;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+
+bool GetLocalPrincipal(const Network::Connection* connection,
+                       std::string* principal) {
+  if (connection) {
+    Ssl::Connection* ssl = const_cast<Ssl::Connection*>(connection->ssl());
+    if (ssl != nullptr) {
+      std::string result = ssl->uriSanLocalCertificate();
+      if (result.empty()) {  // empty result is not allowed
+        return false;
+      }
+      if (result.length() >= kSPIFFEPrefix.length() &&
+          result.compare(0, kSPIFFEPrefix.length(), kSPIFFEPrefix) == 0) {
+        // Strip out the prefix "spiffe://" in the identity.
+        *principal = result.substr(kSPIFFEPrefix.size());
+      } else {
+        *principal = result;
       }
       return true;
     }

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -37,8 +37,13 @@ bool GetIpPort(const Network::Address::Ip* ip, std::string* str_ip, int* port);
 bool GetDestinationUID(const envoy::api::v2::core::Metadata& metadata,
                        std::string* uid);
 
-// Get user id from ssl.
-bool GetSourceUser(const Network::Connection* connection, std::string* user);
+// Get peer principal URI.
+bool GetPeerPrincipal(const Network::Connection* connection,
+                      std::string* principal);
+
+// Get local principal URI.
+bool GetLocalPrincipal(const Network::Connection* connection,
+                       std::string* principal);
 
 // Returns true if connection is mutual TLS enabled.
 bool IsMutualTLS(const Network::Connection* connection);

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -37,13 +37,9 @@ bool GetIpPort(const Network::Address::Ip* ip, std::string* str_ip, int* port);
 bool GetDestinationUID(const envoy::api::v2::core::Metadata& metadata,
                        std::string* uid);
 
-// Get peer principal URI.
-bool GetPeerPrincipal(const Network::Connection* connection,
-                      std::string* principal);
-
-// Get local principal URI.
-bool GetLocalPrincipal(const Network::Connection* connection,
-                       std::string* principal);
+// Get peer or local principal URI.
+bool GetPrincipal(const Network::Connection* connection, bool peer,
+                  std::string* principal);
 
 // Returns true if connection is mutual TLS enabled.
 bool IsMutualTLS(const Network::Connection* connection);

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -128,7 +128,7 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
     builder.AddStringMap(utils::AttributeName::kRequestAuthClaims, payload);
   }
   std::string source_user;
-  if (check_data->GetPeerPrincipal(&source_user)) {
+  if (check_data->GetPrincipal(true, &source_user)) {
     // TODO(diemtvu): remove kSourceUser once migration to source.principal is
     // over. https://github.com/istio/istio/issues/4689
     builder.AddString(utils::AttributeName::kSourceUser, source_user);
@@ -136,7 +136,7 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
   }
 
   std::string destination_principal;
-  if (check_data->GetLocalPrincipal(&destination_principal)) {
+  if (check_data->GetPrincipal(false, &destination_principal)) {
     builder.AddString(utils::AttributeName::kDestinationPrincipal,
                       destination_principal);
   }

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -128,11 +128,17 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
     builder.AddStringMap(utils::AttributeName::kRequestAuthClaims, payload);
   }
   std::string source_user;
-  if (check_data->GetSourceUser(&source_user)) {
+  if (check_data->GetPeerPrincipal(&source_user)) {
     // TODO(diemtvu): remove kSourceUser once migration to source.principal is
     // over. https://github.com/istio/istio/issues/4689
     builder.AddString(utils::AttributeName::kSourceUser, source_user);
     builder.AddString(utils::AttributeName::kSourcePrincipal, source_user);
+  }
+
+  std::string destination_principal;
+  if (check_data->GetLocalPrincipal(&destination_principal)) {
+    builder.AddString(utils::AttributeName::kDestinationPrincipal,
+                      destination_principal);
   }
 }  // namespace http
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -284,14 +284,13 @@ TEST(AttributesBuilderTest, TestForwardAttributes) {
 
 TEST(AttributesBuilderTest, TestCheckAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_))
-      .WillOnce(Invoke([](std::string *user) -> bool {
-        *user = "test_user";
-        return true;
-      }));
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_))
-      .WillOnce(Invoke([](std::string *user) -> bool {
-        *user = "destination_user";
+  EXPECT_CALL(mock_data, GetPrincipal(_, _))
+      .WillRepeatedly(Invoke([](bool peer, std::string *user) -> bool {
+        if (peer) {
+          *user = "test_user";
+        } else {
+          *user = "destination_user";
+        }
         return true;
       }));
   EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {

--- a/src/istio/control/http/mock_check_data.h
+++ b/src/istio/control/http/mock_check_data.h
@@ -29,7 +29,8 @@ class MockCheckData : public CheckData {
   MOCK_CONST_METHOD1(ExtractIstioAttributes, bool(std::string *data));
 
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string *ip, int *port));
-  MOCK_CONST_METHOD1(GetSourceUser, bool(std::string *user));
+  MOCK_CONST_METHOD1(GetPeerPrincipal, bool(std::string *user));
+  MOCK_CONST_METHOD1(GetLocalPrincipal, bool(std::string *user));
   MOCK_CONST_METHOD0(GetRequestHeaders, std::map<std::string, std::string>());
   MOCK_CONST_METHOD2(FindHeaderByType,
                      bool(HeaderType header_type, std::string *value));

--- a/src/istio/control/http/mock_check_data.h
+++ b/src/istio/control/http/mock_check_data.h
@@ -29,8 +29,7 @@ class MockCheckData : public CheckData {
   MOCK_CONST_METHOD1(ExtractIstioAttributes, bool(std::string *data));
 
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string *ip, int *port));
-  MOCK_CONST_METHOD1(GetPeerPrincipal, bool(std::string *user));
-  MOCK_CONST_METHOD1(GetLocalPrincipal, bool(std::string *user));
+  MOCK_CONST_METHOD2(GetPrincipal, bool(bool peer, std::string *user));
   MOCK_CONST_METHOD0(GetRequestHeaders, std::map<std::string, std::string>());
   MOCK_CONST_METHOD2(FindHeaderByType,
                      bool(HeaderType header_type, std::string *value));

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -150,7 +150,8 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheckReport) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Not to extract attributes since both Check and Report are disabled.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(0);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(0);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(0);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -173,7 +174,8 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -194,7 +196,8 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -222,7 +225,8 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -255,7 +259,8 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   ServiceConfig route_config;
   auto map3 = route_config.mutable_mixer_attributes()->mutable_attributes();
@@ -370,7 +375,8 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(1);
@@ -454,7 +460,8 @@ TEST_F(RequestHandlerImplTest, TestEmptyConfig) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Not to extract attributes since both Check and Report are disabled.
   EXPECT_CALL(mock_check, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_check, GetSourceUser(_)).Times(0);
+  EXPECT_CALL(mock_check, GetPeerPrincipal(_)).Times(0);
+  EXPECT_CALL(mock_check, GetLocalPrincipal(_)).Times(0);
 
   // Attributes is forwarded.
   EXPECT_CALL(mock_header, AddIstioAttributes(_))

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -150,8 +150,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheckReport) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Not to extract attributes since both Check and Report are disabled.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(0);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(0);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(0);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -174,8 +173,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -196,8 +194,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -225,8 +222,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -259,8 +255,7 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   ServiceConfig route_config;
   auto map3 = route_config.mutable_mixer_attributes()->mutable_attributes();
@@ -375,8 +370,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(1);
@@ -460,8 +454,7 @@ TEST_F(RequestHandlerImplTest, TestEmptyConfig) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Not to extract attributes since both Check and Report are disabled.
   EXPECT_CALL(mock_check, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_check, GetPeerPrincipal(_)).Times(0);
-  EXPECT_CALL(mock_check, GetLocalPrincipal(_)).Times(0);
+  EXPECT_CALL(mock_check, GetPrincipal(_, _)).Times(0);
 
   // Attributes is forwarded.
   EXPECT_CALL(mock_header, AddIstioAttributes(_))

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -42,7 +42,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   // TODO(diemtvu): add TCP authn filter similar to http case, and use authn
   // result output here instead.
   std::string source_user;
-  if (check_data->GetPeerPrincipal(&source_user)) {
+  if (check_data->GetPrincipal(true, &source_user)) {
     // TODO(diemtvu): remove kSourceUser once migration to source.principal is
     // over. https://github.com/istio/istio/issues/4689
     builder.AddString(utils::AttributeName::kSourceUser, source_user);
@@ -50,7 +50,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   }
 
   std::string destination_principal;
-  if (check_data->GetLocalPrincipal(&destination_principal)) {
+  if (check_data->GetPrincipal(false, &destination_principal)) {
     builder.AddString(utils::AttributeName::kDestinationPrincipal,
                       destination_principal);
   }

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -42,12 +42,19 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   // TODO(diemtvu): add TCP authn filter similar to http case, and use authn
   // result output here instead.
   std::string source_user;
-  if (check_data->GetSourceUser(&source_user)) {
+  if (check_data->GetPeerPrincipal(&source_user)) {
     // TODO(diemtvu): remove kSourceUser once migration to source.principal is
     // over. https://github.com/istio/istio/issues/4689
     builder.AddString(utils::AttributeName::kSourceUser, source_user);
     builder.AddString(utils::AttributeName::kSourcePrincipal, source_user);
   }
+
+  std::string destination_principal;
+  if (check_data->GetLocalPrincipal(&destination_principal)) {
+    builder.AddString(utils::AttributeName::kDestinationPrincipal,
+                      destination_principal);
+  }
+
   builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -305,14 +305,13 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
   EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
     return true;
   }));
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_))
-      .WillOnce(Invoke([](std::string* user) -> bool {
-        *user = "test_user";
-        return true;
-      }));
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_))
-      .WillOnce(Invoke([](std::string* user) -> bool {
-        *user = "destination_user";
+  EXPECT_CALL(mock_data, GetPrincipal(_, _))
+      .WillRepeatedly(Invoke([](bool peer, std::string* user) -> bool {
+        if (peer) {
+          *user = "test_user";
+        } else {
+          *user = "destination_user";
+        }
         return true;
       }));
   EXPECT_CALL(mock_data, GetConnectionId()).WillOnce(Return("1234-5"));

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -80,6 +80,12 @@ attributes {
   }
 }
 attributes {
+  key: "destination.principal"
+  value {
+    string_value: "destination_user"
+  }
+}
+attributes {
   key: "connection.id"
   value {
     string_value: "1234-5"
@@ -299,9 +305,14 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
   EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
     return true;
   }));
-  EXPECT_CALL(mock_data, GetSourceUser(_))
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_))
       .WillOnce(Invoke([](std::string* user) -> bool {
         *user = "test_user";
+        return true;
+      }));
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_))
+      .WillOnce(Invoke([](std::string* user) -> bool {
+        *user = "destination_user";
         return true;
       }));
   EXPECT_CALL(mock_data, GetConnectionId()).WillOnce(Return("1234-5"));

--- a/src/istio/control/tcp/mock_check_data.h
+++ b/src/istio/control/tcp/mock_check_data.h
@@ -27,8 +27,7 @@ namespace tcp {
 class MockCheckData : public CheckData {
  public:
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string* ip, int* port));
-  MOCK_CONST_METHOD1(GetPeerPrincipal, bool(std::string* user));
-  MOCK_CONST_METHOD1(GetLocalPrincipal, bool(std::string* user));
+  MOCK_CONST_METHOD2(GetPrincipal, bool(bool peer, std::string* user));
   MOCK_CONST_METHOD0(IsMutualTLS, bool());
   MOCK_CONST_METHOD0(GetConnectionId, std::string());
 };

--- a/src/istio/control/tcp/mock_check_data.h
+++ b/src/istio/control/tcp/mock_check_data.h
@@ -27,7 +27,8 @@ namespace tcp {
 class MockCheckData : public CheckData {
  public:
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string* ip, int* port));
-  MOCK_CONST_METHOD1(GetSourceUser, bool(std::string* user));
+  MOCK_CONST_METHOD1(GetPeerPrincipal, bool(std::string* user));
+  MOCK_CONST_METHOD1(GetLocalPrincipal, bool(std::string* user));
   MOCK_CONST_METHOD0(IsMutualTLS, bool());
   MOCK_CONST_METHOD0(GetConnectionId, std::string());
 };

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -66,7 +66,7 @@ class RequestHandlerImplTest : public ::testing::Test {
 TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
 
   // Check should not be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -81,7 +81,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
 TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetSourceUser(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -67,6 +67,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   // Check should not be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -82,6 +83,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -66,8 +66,7 @@ class RequestHandlerImplTest : public ::testing::Test {
 TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should not be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -82,8 +81,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
 TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPeerPrincipal(_)).Times(1);
-  EXPECT_CALL(mock_data, GetLocalPrincipal(_)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -21,6 +21,7 @@ namespace utils {
 // Define attribute names
 const char AttributeName::kSourceUser[] = "source.user";
 const char AttributeName::kSourcePrincipal[] = "source.principal";
+const char AttributeName::kDestinationPrincipal[] = "destination.principal";
 
 const char AttributeName::kRequestHeaders[] = "request.headers";
 const char AttributeName::kRequestHost[] = "request.host";


### PR DESCRIPTION
Note to reviewers: in case of JWT-based source user derivation, destination user is not set. We only set destination principal for mTLS.