### PR TITLE
Add connection requested server name attribute to TCP read filter

### DIFF
--- a/include/istio/control/http/check_data.h
+++ b/include/istio/control/http/check_data.h
@@ -47,6 +47,9 @@ class CheckData {
   // Returns true if connection is mutual TLS enabled.
   virtual bool IsMutualTLS() const = 0;
 
+  // Get requested server name, SNI in case of TLS
+  virtual std::string GetRequestedServerName() const = 0;
+
   // These headers are extracted into top level attributes.
   // This is for standard HTTP headers.  It supports both HTTP/1.1 and HTTP2
   // They can be retrieved at O(1) speed by environment (Envoy).

--- a/include/istio/control/tcp/check_data.h
+++ b/include/istio/control/tcp/check_data.h
@@ -37,6 +37,9 @@ class CheckData {
   // Returns true if connection is mutual TLS enabled.
   virtual bool IsMutualTLS() const = 0;
 
+  // Get requested server name, SNI in case of TLS
+  virtual std::string GetRequestedServerName() const = 0;
+
   // Get downstream tcp connection id.
   virtual std::string GetConnectionId() const = 0;
 };

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -65,6 +65,7 @@ struct AttributeName {
   static const char kConnectionSendTotalBytes[];
   static const char kConnectionDuration[];
   static const char kConnectionMtls[];
+  static const char kConnectionRequestedServerName[];
   static const char kConnectionId[];
   // Record TCP connection status: open, continue, close
   static const char kConnectionEvent[];

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -77,6 +77,10 @@ std::map<std::string, std::string> CheckData::GetRequestHeaders() const {
 
 bool CheckData::IsMutualTLS() const { return Utils::IsMutualTLS(connection_); }
 
+std::string GetRequestedServerName() const {
+  return connection_.requestedServerName();
+}
+
 bool CheckData::FindHeaderByType(HttpCheckData::HeaderType header_type,
                                  std::string* value) const {
   switch (header_type) {

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -78,7 +78,11 @@ std::map<std::string, std::string> CheckData::GetRequestHeaders() const {
 bool CheckData::IsMutualTLS() const { return Utils::IsMutualTLS(connection_); }
 
 std::string CheckData::GetRequestedServerName() const {
-  return connection_.requestedServerName();
+  if (connection_) {
+    return connection_->requestedServerName();
+  }
+
+  return "";
 }
 
 bool CheckData::FindHeaderByType(HttpCheckData::HeaderType header_type,

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -79,7 +79,7 @@ bool CheckData::IsMutualTLS() const { return Utils::IsMutualTLS(connection_); }
 
 std::string CheckData::GetRequestedServerName() const {
   if (connection_) {
-    return connection_->requestedServerName();
+    return std::string(connection_->requestedServerName());
   }
 
   return "";

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -77,7 +77,7 @@ std::map<std::string, std::string> CheckData::GetRequestHeaders() const {
 
 bool CheckData::IsMutualTLS() const { return Utils::IsMutualTLS(connection_); }
 
-std::string GetRequestedServerName() const {
+std::string CheckData::GetRequestedServerName() const {
   return connection_.requestedServerName();
 }
 

--- a/src/envoy/http/mixer/check_data.h
+++ b/src/envoy/http/mixer/check_data.h
@@ -41,6 +41,7 @@ class CheckData : public ::istio::control::http::CheckData,
   std::map<std::string, std::string> GetRequestHeaders() const override;
 
   bool IsMutualTLS() const override;
+  std::string GetRequestedServerName() const override;
 
   bool FindHeaderByType(
       ::istio::control::http::CheckData::HeaderType header_type,

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -158,7 +158,7 @@ bool Filter::IsMutualTLS() const {
 }
 
 std::string Filter::GetRequestedServerName() const {
-  return filter_callbacks->connection().requestedServerName()
+  return filter_callbacks_->connection().requestedServerName();
 }
 
 bool Filter::GetDestinationIpPort(std::string* str_ip, int* port) const {

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -158,7 +158,7 @@ bool Filter::IsMutualTLS() const {
 }
 
 std::string Filter::GetRequestedServerName() const {
-  return filter_callbacks_->connection().requestedServerName();
+  return std::string(filter_callbacks_->connection().requestedServerName());
 }
 
 bool Filter::GetDestinationIpPort(std::string* str_ip, int* port) const {

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -157,6 +157,10 @@ bool Filter::IsMutualTLS() const {
   return Utils::IsMutualTLS(&filter_callbacks_->connection());
 }
 
+std::string Filter::GetRequestedServerName() const {
+  return filter_callbacks->connection().requestedServerName()
+}
+
 bool Filter::GetDestinationIpPort(std::string* str_ip, int* port) const {
   if (filter_callbacks_->upstreamHost() &&
       filter_callbacks_->upstreamHost()->address()) {

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -53,6 +53,7 @@ class Filter : public Network::Filter,
   bool GetSourceIpPort(std::string* str_ip, int* port) const override;
   bool GetSourceUser(std::string* user) const override;
   bool IsMutualTLS() const override;
+  std::string GetRequestedServerName() const override;
 
   // ReportData virtual functions.
   bool GetDestinationIpPort(std::string* str_ip, int* port) const override;

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -157,6 +157,12 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
   builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 
+  std::string requested_server_name = check_data->GetRequestedServerName();
+  if (!requested_server_name.empty()) {
+    builder.AddString(utils::AttributeName::kConnectionRequestedServerName,
+                      requested_server_name);
+  }
+
   builder.AddTimestamp(utils::AttributeName::kRequestTime,
                        std::chrono::system_clock::now());
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -349,6 +349,8 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
     return true;
   }));
+  EXPECT_CALL(mock_data, GetRequestedServerName())
+      .WillOnce(testing::Return("www.google.com"));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -90,6 +90,12 @@ attributes {
   }
 }
 attributes {
+  key: "connection.requested_server_name"
+  value {
+    string_value: "www.google.com"
+  }
+}
+attributes {
   key: "source.principal"
   value {
     string_value: "test_user"
@@ -286,6 +292,8 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
   EXPECT_CALL(mock_data, IsMutualTLS()).WillOnce(Invoke([]() -> bool {
     return true;
   }));
+  EXPECT_CALL(mock_data, GetRequestedServerName())
+      .WillOnce(Return("www.google.com"));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -293,7 +293,7 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
     return true;
   }));
   EXPECT_CALL(mock_data, GetRequestedServerName())
-      .WillOnce(Return("www.google.com"));
+      .WillOnce(testing::Return("www.google.com"));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;

--- a/src/istio/control/http/mock_check_data.h
+++ b/src/istio/control/http/mock_check_data.h
@@ -44,6 +44,7 @@ class MockCheckData : public CheckData {
   MOCK_CONST_METHOD1(GetAuthenticationResult,
                      bool(istio::authn::Result *result));
   MOCK_CONST_METHOD0(IsMutualTLS, bool());
+  MOCK_CONST_METHOD0(GetRequestedServerName, std::string());
 };
 
 // The mock object for HeaderUpdate interface.

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -51,8 +51,11 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 
-  builder.AddString(utils::AttributeName::kConnectionRequestedServerName,
-                    check_data->GetRequestedServerName());
+  std::string requested_server_name = check_data->GetRequestedServerName());
+  if (!requested_server_name.empty()) {
+    builder.AddString(utils::AttributeName::kConnectionRequestedServerName,
+                      requested_server_name);
+  }
 
   builder.AddTimestamp(utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -51,7 +51,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 
-  std::string requested_server_name = check_data->GetRequestedServerName());
+  std::string requested_server_name = check_data->GetRequestedServerName();
   if (!requested_server_name.empty()) {
     builder.AddString(utils::AttributeName::kConnectionRequestedServerName,
                       requested_server_name);

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -51,6 +51,9 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 
+  builder.AddString(utils::AttributeName::kConnectionRequestedServerName,
+                    check_data->GetRequestedServerName());
+
   builder.AddTimestamp(utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());
   builder.AddString(utils::AttributeName::kContextProtocol, "tcp");

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -68,6 +68,12 @@ attributes {
   }
 }
 attributes {
+  key: "connection.requested_server_name"
+  value {
+    string_value: "www.google.com"
+  }
+}
+attributes {
   key: "source.principal"
   value {
     string_value: "test_user"
@@ -305,6 +311,8 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         return true;
       }));
   EXPECT_CALL(mock_data, GetConnectionId()).WillOnce(Return("1234-5"));
+  EXPECT_CALL(mock_data, GetRequestedServerName())
+      .WillOnce(Return("www.google.com"));
 
   RequestContext request;
   AttributesBuilder builder(&request);

--- a/src/istio/control/tcp/mock_check_data.h
+++ b/src/istio/control/tcp/mock_check_data.h
@@ -29,6 +29,7 @@ class MockCheckData : public CheckData {
   MOCK_CONST_METHOD2(GetSourceIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetSourceUser, bool(std::string* user));
   MOCK_CONST_METHOD0(IsMutualTLS, bool());
+  MOCK_CONST_METHOD0(GetRequestedServerName, std::string());
   MOCK_CONST_METHOD0(GetConnectionId, std::string());
 };
 

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -58,7 +58,8 @@ const char AttributeName::kConnectionSendTotalBytes[] =
     "connection.sent.bytes_total";
 const char AttributeName::kConnectionDuration[] = "connection.duration";
 const char AttributeName::kConnectionMtls[] = "connection.mtls";
-const char AttributeName::kConnectionRequestedServerName[] = "connection.requested_server_name";
+const char AttributeName::kConnectionRequestedServerName[] =
+    "connection.requested_server_name";
 
 // Downstream TCP connection id.
 const char AttributeName::kConnectionId[] = "connection.id";

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -58,6 +58,8 @@ const char AttributeName::kConnectionSendTotalBytes[] =
     "connection.sent.bytes_total";
 const char AttributeName::kConnectionDuration[] = "connection.duration";
 const char AttributeName::kConnectionMtls[] = "connection.mtls";
+const char AttributeName::kConnectionRequestedServerName[] = "connection.requested_server_name";
+
 // Downstream TCP connection id.
 const char AttributeName::kConnectionId[] = "connection.id";
 const char AttributeName::kConnectionEvent[] = "connection.event";


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds SNI attribute to the TCP read filter, to be used in telemetry reports and policy checks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: implements #https://github.com/istio/istio/issues/6810


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
SNI report and check in TCP filter
```