### PR TITLE
Add the connection.requested_server_name attribute to the TCP read filter

### DIFF
--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -116,6 +116,16 @@ bool IsMutualTLS(const Network::Connection* connection) {
          connection->ssl()->peerCertificatePresented();
 }
 
+bool GetRequestedServerName(const Network::Connection* connection*,
+                            std::string* name) {
+  if (connection) {
+    *name = std::string(connection->requestedServerName());
+    return true;
+  }
+
+  return false;
+}
+
 Status ParseJsonMessage(const std::string& json, Message* output) {
   ::google::protobuf::util::JsonParseOptions options;
   options.ignore_unknown_fields = true;

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -43,6 +43,10 @@ bool GetSourceUser(const Network::Connection* connection, std::string* user);
 // Returns true if connection is mutual TLS enabled.
 bool IsMutualTLS(const Network::Connection* connection);
 
+// Get requested server name, SNI in case of TLS
+bool GetRequestedServerName(const Network::Connection* connection*,
+                            std::string* name);
+
 // Parse JSON string into message.
 ::google::protobuf::util::Status ParseJsonMessage(
     const std::string& json, ::google::protobuf::Message* output);


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds SNI attribute to the TCP read filter, to be used in telemetry reports and policy checks. This is a resubmission of a previously merged and reverted PR https://github.com/istio/proxy/pull/1843.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: implements #https://github.com/istio/istio/issues/6810


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
SNI report and check in TCP filter
```