### PR TITLE
Add report of tcp connection open event

### DIFF
--- a/include/istio/control/tcp/report_data.h
+++ b/include/istio/control/tcp/report_data.h
@@ -42,6 +42,14 @@ class ReportData {
 
   // Get upstream host UID. This value overrides the value in the report bag.
   virtual bool GetDestinationUID(std::string* uid) const = 0;
+
+  // ConnectionEvent is used to indicates the tcp connection event in Report
+  // call.
+  enum ConnectionEvent {
+    OPEN = 0,
+    CLOSE,
+    CONTINUE,
+  };
 };
 
 }  // namespace tcp

--- a/include/istio/control/tcp/request_handler.h
+++ b/include/istio/control/tcp/request_handler.h
@@ -45,7 +45,8 @@ class RequestHandler {
   // Make report call.
   // If is_final_report is true, report all attributes. Otherwise, report delta
   // attributes.
-  virtual void Report(ReportData* report_data, bool is_final_report) = 0;
+  virtual void Report(ReportData* report_data, bool is_first_report,
+                      bool is_final_report) = 0;
 };
 
 }  // namespace tcp

--- a/include/istio/control/tcp/request_handler.h
+++ b/include/istio/control/tcp/request_handler.h
@@ -43,7 +43,8 @@ class RequestHandler {
   virtual void Report(ReportData* report_data) = 0;
 
   // Make report call.
-  // If is_final_report is true, report all attributes. Otherwise, report delta
+  // If is_first_report is true, report connection open event. If
+  // is_final_report is true, report all attributes. Otherwise, report delta
   // attributes.
   virtual void Report(ReportData* report_data, bool is_first_report,
                       bool is_final_report) = 0;

--- a/include/istio/control/tcp/request_handler.h
+++ b/include/istio/control/tcp/request_handler.h
@@ -36,18 +36,8 @@ class RequestHandler {
       CheckData* check_data, ::istio::mixerclient::CheckDoneFunc on_done) = 0;
 
   // Make report call.
-  // This can be called multiple times for long connection.
-  // TODO(JimmyCYJ): Let TCP filter use
-  // void Report(ReportData* report_data, bool is_final_report), and deprecate
-  // this method.
-  virtual void Report(ReportData* report_data) = 0;
-
-  // Make report call.
-  // If is_first_report is true, report connection open event. If
-  // is_final_report is true, report all attributes. Otherwise, report delta
-  // attributes.
-  virtual void Report(ReportData* report_data, bool is_first_report,
-                      bool is_final_report) = 0;
+  virtual void Report(ReportData* report_data,
+                      ReportData::ConnectionEvent event) = 0;
 };
 
 }  // namespace tcp

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -117,8 +117,7 @@ void Filter::completeCheck(const Status& status) {
     if (!calling_check_) {
       filter_callbacks_->continueReading();
     }
-    handler_->Report(this, /* is_first_report */ true,
-                     /* is_final_report */ false);
+    handler_->Report(this, ConnectionEvent::OPEN);
     report_timer_ =
         control_.dispatcher().createTimer([this]() { OnReportTimer(); });
     report_timer_->enableTimer(control_.config().report_interval_ms());
@@ -141,8 +140,7 @@ void Filter::onEvent(Network::ConnectionEvent event) {
       if (report_timer_) {
         report_timer_->disableTimer();
       }
-      handler_->Report(this, /* is_first_report */ false,
-                       /* is_final_report */ true);
+      handler_->Report(this, ConnectionEvent::CLOSE);
     }
     cancelCheck();
   }
@@ -196,8 +194,7 @@ std::string Filter::GetConnectionId() const {
 }
 
 void Filter::OnReportTimer() {
-  handler_->Report(this, /* is_first_report */ false,
-                   /* is_final_report */ false);
+  handler_->Report(this, ConnectionEvent::CONTINUE);
   report_timer_->enableTimer(control_.config().report_interval_ms());
 }
 

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -117,6 +117,8 @@ void Filter::completeCheck(const Status& status) {
     if (!calling_check_) {
       filter_callbacks_->continueReading();
     }
+    handler_->Report(this, /* is_first_report */ true,
+                     /* is_final_report */ false);
     report_timer_ =
         control_.dispatcher().createTimer([this]() { OnReportTimer(); });
     report_timer_->enableTimer(control_.config().report_interval_ms());
@@ -139,7 +141,8 @@ void Filter::onEvent(Network::ConnectionEvent event) {
       if (report_timer_) {
         report_timer_->disableTimer();
       }
-      handler_->Report(this, /* is_final_report */ true);
+      handler_->Report(this, /* is_first_report */ false,
+                       /* is_final_report */ true);
     }
     cancelCheck();
   }
@@ -193,7 +196,8 @@ std::string Filter::GetConnectionId() const {
 }
 
 void Filter::OnReportTimer() {
-  handler_->Report(this, /* is_final_report */ false);
+  handler_->Report(this, /* is_first_report */ false,
+                   /* is_final_report */ false);
   report_timer_->enableTimer(control_.config().report_interval_ms());
 }
 

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -67,7 +67,6 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   builder.AddTimestamp(utils::AttributeName::kContextTime,
                        std::chrono::system_clock::now());
   builder.AddString(utils::AttributeName::kContextProtocol, "tcp");
-  builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionOpen);
 
   // Get unique downstream connection ID, which is <uuid>-<connection id>.
   std::string connection_id = check_data->GetConnectionId();
@@ -75,7 +74,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
 }
 
 void AttributesBuilder::ExtractReportAttributes(
-    ReportData* report_data, bool is_final_report,
+    ReportData* report_data, bool is_first_report, bool is_final_report,
     ReportData::ReportInfo* last_report_info) {
   utils::AttributesBuilder builder(&request_->attributes);
 
@@ -100,6 +99,8 @@ void AttributesBuilder::ExtractReportAttributes(
                         request_->check_status.ToString());
     }
     builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionClose);
+  } else if (is_first_report) {
+    builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionOpen);
   } else {
     last_report_info->received_bytes = info.received_bytes;
     last_report_info->send_bytes = info.send_bytes;

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -74,7 +74,7 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
 }
 
 void AttributesBuilder::ExtractReportAttributes(
-    ReportData* report_data, bool is_first_report, bool is_final_report,
+    ReportData* report_data, ReportData::ConnectionEvent event,
     ReportData::ReportInfo* last_report_info) {
   utils::AttributesBuilder builder(&request_->attributes);
 
@@ -89,7 +89,7 @@ void AttributesBuilder::ExtractReportAttributes(
   builder.AddInt64(utils::AttributeName::kConnectionSendTotalBytes,
                    info.send_bytes);
 
-  if (is_final_report) {
+  if (event == ReportData::ConnectionEvent::CLOSE) {
     builder.AddDuration(utils::AttributeName::kConnectionDuration,
                         info.duration);
     if (!request_->check_status.ok()) {
@@ -99,7 +99,7 @@ void AttributesBuilder::ExtractReportAttributes(
                         request_->check_status.ToString());
     }
     builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionClose);
-  } else if (is_first_report) {
+  } else if (event == ReportData::ConnectionEvent::OPEN) {
     builder.AddString(utils::AttributeName::kConnectionEvent, kConnectionOpen);
   } else {
     last_report_info->received_bytes = info.received_bytes;

--- a/src/istio/control/tcp/attributes_builder.h
+++ b/src/istio/control/tcp/attributes_builder.h
@@ -32,8 +32,8 @@ class AttributesBuilder {
   // Extract attributes for Check.
   void ExtractCheckAttributes(CheckData* check_data);
   // Extract attributes for Report.
-  void ExtractReportAttributes(ReportData* report_data, bool is_first_report,
-                               bool is_final_report,
+  void ExtractReportAttributes(ReportData* report_data,
+                               ReportData::ConnectionEvent event,
                                ReportData::ReportInfo* last_report_info);
 
  private:

--- a/src/istio/control/tcp/attributes_builder.h
+++ b/src/istio/control/tcp/attributes_builder.h
@@ -32,7 +32,8 @@ class AttributesBuilder {
   // Extract attributes for Check.
   void ExtractCheckAttributes(CheckData* check_data);
   // Extract attributes for Report.
-  void ExtractReportAttributes(ReportData* report_data, bool is_final_report,
+  void ExtractReportAttributes(ReportData* report_data, bool is_first_report,
+                               bool is_final_report,
                                ReportData::ReportInfo* last_report_info);
 
  private:

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -441,8 +441,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   ReportData::ReportInfo last_report_info{0ULL, 0ULL,
                                           std::chrono::nanoseconds::zero()};
   // Verify first open report
-  builder.ExtractReportAttributes(&mock_data, /* is_first_report */ true,
-                                  /* is_final_report */ false,
+  builder.ExtractReportAttributes(&mock_data, ReportData::ConnectionEvent::OPEN,
                                   &last_report_info);
   ClearContextTime(&request);
 
@@ -459,9 +458,8 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   EXPECT_EQ(0, last_report_info.send_bytes);
 
   // Verify delta one report
-  builder.ExtractReportAttributes(&mock_data, /* is_first_report */ false,
-                                  /* is_final_report */ false,
-                                  &last_report_info);
+  builder.ExtractReportAttributes(
+      &mock_data, ReportData::ConnectionEvent::CONTINUE, &last_report_info);
   ClearContextTime(&request);
 
   TextFormat::PrintToString(request.attributes, &out_str);
@@ -476,9 +474,8 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   EXPECT_EQ(200, last_report_info.send_bytes);
 
   // Verify delta two report
-  builder.ExtractReportAttributes(&mock_data, /* is_first_report */ false,
-                                  /* is_final_report */ false,
-                                  &last_report_info);
+  builder.ExtractReportAttributes(
+      &mock_data, ReportData::ConnectionEvent::CONTINUE, &last_report_info);
   ClearContextTime(&request);
 
   out_str.clear();
@@ -494,9 +491,8 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   EXPECT_EQ(404, last_report_info.send_bytes);
 
   // Verify final report
-  builder.ExtractReportAttributes(&mock_data, /* is_first_report */ false,
-                                  /* is_final_report */ true,
-                                  &last_report_info);
+  builder.ExtractReportAttributes(
+      &mock_data, ReportData::ConnectionEvent::CLOSE, &last_report_info);
   ClearContextTime(&request);
 
   out_str.clear();

--- a/src/istio/control/tcp/request_handler_impl.cc
+++ b/src/istio/control/tcp/request_handler_impl.cc
@@ -55,16 +55,17 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
 
 // Make remote report call.
 void RequestHandlerImpl::Report(ReportData* report_data) {
-  Report(report_data, /* is_final_report */ true);
+  Report(report_data, /* is_first_report */ false, /* is_final_report */ true);
 }
 
-void RequestHandlerImpl::Report(ReportData* report_data, bool is_final_report) {
+void RequestHandlerImpl::Report(ReportData* report_data, bool is_first_report,
+                                bool is_final_report) {
   if (!client_context_->enable_mixer_report()) {
     return;
   }
 
   AttributesBuilder builder(&request_context_);
-  builder.ExtractReportAttributes(report_data, is_final_report,
+  builder.ExtractReportAttributes(report_data, is_first_report, is_final_report,
                                   &last_report_info_);
 
   client_context_->SendReport(request_context_);

--- a/src/istio/control/tcp/request_handler_impl.cc
+++ b/src/istio/control/tcp/request_handler_impl.cc
@@ -53,20 +53,14 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
   return client_context_->SendCheck(nullptr, on_done, &request_context_);
 }
 
-// Make remote report call.
-void RequestHandlerImpl::Report(ReportData* report_data) {
-  Report(report_data, /* is_first_report */ false, /* is_final_report */ true);
-}
-
-void RequestHandlerImpl::Report(ReportData* report_data, bool is_first_report,
-                                bool is_final_report) {
+void RequestHandlerImpl::Report(ReportData* report_data,
+                                ReportData::ConnectionEvent event) {
   if (!client_context_->enable_mixer_report()) {
     return;
   }
 
   AttributesBuilder builder(&request_context_);
-  builder.ExtractReportAttributes(report_data, is_first_report, is_final_report,
-                                  &last_report_info_);
+  builder.ExtractReportAttributes(report_data, event, &last_report_info_);
 
   client_context_->SendReport(request_context_);
 }

--- a/src/istio/control/tcp/request_handler_impl.h
+++ b/src/istio/control/tcp/request_handler_impl.h
@@ -35,15 +35,8 @@ class RequestHandlerImpl : public RequestHandler {
       ::istio::mixerclient::CheckDoneFunc on_done) override;
 
   // Make a Report call.
-  // TODO(JimmyCYJ): Let TCP filter use
-  // void Report(ReportData* report_data, bool is_final_report), and deprecate
-  // this method.
-  void Report(ReportData* report_data) override;
-
-  // Make a Report call. If is_final_report is true, then report all attributes,
-  // otherwise, report delta attributes.
-  void Report(ReportData* report_data, bool is_first_report,
-              bool is_final_report) override;
+  void Report(ReportData* report_data,
+              ReportData::ConnectionEvent event) override;
 
  private:
   // The request context object.

--- a/src/istio/control/tcp/request_handler_impl.h
+++ b/src/istio/control/tcp/request_handler_impl.h
@@ -42,7 +42,8 @@ class RequestHandlerImpl : public RequestHandler {
 
   // Make a Report call. If is_final_report is true, then report all attributes,
   // otherwise, report delta attributes.
-  void Report(ReportData* report_data, bool is_final_report) override;
+  void Report(ReportData* report_data, bool is_first_report,
+              bool is_final_report) override;
 
  private:
   // The request context object.

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -111,7 +111,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerReport) {
   EXPECT_CALL(*mock_client_, Report(_)).Times(1);
 
   auto handler = controller_->CreateRequestHandler();
-  handler->Report(&mock_data);
+  handler->Report(&mock_data, ReportData::CONTINUE);
 }
 
 }  // namespace tcp


### PR DESCRIPTION
Add a report call after tcp check finishes and before report timer starts, which record tcp connection open event. fix #1835