### PR TITLE
attributes: extract origin IP

### DIFF
--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -60,6 +60,7 @@ struct AttributeName {
   static const char kDestinationIp[];
   static const char kDestinationPort[];
   static const char kDestinationUID[];
+  static const char kOriginIp[];
   static const char kConnectionReceviedBytes[];
   static const char kConnectionReceviedTotalBytes[];
   static const char kConnectionSendBytes[];

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -160,6 +160,13 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData *check_data) {
 
   utils::AttributesBuilder builder(&request_->attributes);
 
+  // connection remote IP is always reported as origin IP
+  std::string source_ip;
+  int source_port;
+  if (check_data->GetSourceIpPort(&source_ip, &source_port)) {
+    builder.AddBytes(utils::AttributeName::kOriginIp, source_ip);
+  }
+
   builder.AddBool(utils::AttributeName::kConnectionMtls,
                   check_data->IsMutualTLS());
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -108,6 +108,12 @@ attributes {
   }
 }
 attributes {
+  key: "origin.ip"
+  value {
+    bytes_value: "1.2.3.4"
+  }
+}
+attributes {
   key: "destination.principal"
   value {
     string_value: "destination_user"
@@ -307,6 +313,12 @@ TEST(AttributesBuilderTest, TestCheckAttributes) {
         *name = "www.google.com";
         return true;
       }));
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _))
+      .WillOnce(Invoke([](std::string *ip, int *port) -> bool {
+        *ip = "1.2.3.4";
+        *port = 8080;
+        return true;
+      }));
   EXPECT_CALL(mock_data, GetRequestHeaders())
       .WillOnce(Invoke([]() -> std::map<std::string, std::string> {
         std::map<std::string, std::string> map;
@@ -365,6 +377,12 @@ TEST(AttributesBuilderTest, TestCheckAttributesWithAuthNResult) {
   EXPECT_CALL(mock_data, GetRequestedServerName(_))
       .WillOnce(Invoke([](std::string *name) -> bool {
         *name = "www.google.com";
+        return true;
+      }));
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _))
+      .WillOnce(Invoke([](std::string *ip, int *port) -> bool {
+        *ip = "1.2.3.4";
+        *port = 8080;
         return true;
       }));
   EXPECT_CALL(mock_data, GetRequestHeaders())

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -172,7 +172,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should NOT be called.
@@ -193,7 +193,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
 TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
@@ -221,7 +221,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
 TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
@@ -254,7 +254,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
 TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   ServiceConfig route_config;
@@ -369,7 +369,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteApiSpec) {
 TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
+  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -37,6 +37,8 @@ void AttributesBuilder::ExtractCheckAttributes(CheckData* check_data) {
   // it
   if (check_data->GetSourceIpPort(&source_ip, &source_port)) {
     builder.AddBytes(utils::AttributeName::kSourceIp, source_ip);
+    // connection remote IP is always reported as origin IP
+    builder.AddBytes(utils::AttributeName::kOriginIp, source_ip);
   }
 
   // TODO(diemtvu): add TCP authn filter similar to http case, and use authn

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -56,6 +56,12 @@ attributes {
   }
 }
 attributes {
+  key: "origin.ip"
+  value {
+    bytes_value: "1.2.3.4"
+  }
+}
+attributes {
   key: "connection.mtls"
   value {
     bool_value: true

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -50,6 +50,7 @@ const char AttributeName::kSourcePort[] = "source.port";
 const char AttributeName::kDestinationIp[] = "destination.ip";
 const char AttributeName::kDestinationPort[] = "destination.port";
 const char AttributeName::kDestinationUID[] = "destination.uid";
+const char AttributeName::kOriginIp[] = "origin.ip";
 const char AttributeName::kConnectionReceviedBytes[] =
     "connection.received.bytes";
 const char AttributeName::kConnectionReceviedTotalBytes[] =


### PR DESCRIPTION
note: partial revert of https://github.com/istio/proxy/commit/a5299762eda826b6ce34243745fbfbe182a379da

Extract connection remote IP as attribute `origin.ip` instead of `source.ip`. This is important for gateways, since gateways are modeled as client proxies, and source IP is naturally set to be the proxy IP. This means we have lost the origin IP, which is degradation from previous functionality. In particular, user requests such as https://groups.google.com/forum/#!topic/istio-users/juu0LebZaB0 are impossible to implement currently in the policy engine.

Due to the fact that this is a degradation from previous releases (as another consequence of gateway changes), I think we should include this in 1.0.

/cc @hklai @geeknoid 

