### PR TITLE
Update Envoy SHA to latest.

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -14,7 +14,7 @@ RUN sudo sh -c 'echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-5.
 
 RUN sudo apt-get update && \
     sudo apt-get -y install \
-    wget software-properties-common make cmake python python-pip \
+    wget software-properties-common make cmake python python-pip pkg-config \
     zlib1g-dev bash-completion bc libtool automake zip time g++-6 gcc-6 \
     clang-5.0 rsync
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all"
     resource_class: xlarge
     steps:
+      - run: sudo apt-get update && sudo apt-get install -y pkg-config
       - checkout
       - restore_cache:
           keys:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "3b05bffcbaedaf6d112ba38ad58121ba5aa5af51"
+ENVOY_SHA = "a0b22efd0750a1f503d605b22e0c041e279a08b3"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "3b05bffcbaedaf6d112ba38ad58121ba5aa5af51"
+		"lastStableSHA": "a0b22efd0750a1f503d605b22e0c041e279a08b3"
 	}
 ]

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -100,7 +100,7 @@ class ReportData : public ::istio::control::http::ReportData {
 
   bool GetDestinationUID(std::string *uid) const override {
     if (info_.upstreamHost()) {
-      return Utils::GetDestinationUID(info_.upstreamHost()->metadata(), uid);
+      return Utils::GetDestinationUID(*info_.upstreamHost()->metadata(), uid);
     }
     return false;
   }

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -173,7 +173,7 @@ bool Filter::GetDestinationIpPort(std::string* str_ip, int* port) const {
 bool Filter::GetDestinationUID(std::string* uid) const {
   if (filter_callbacks_->upstreamHost()) {
     return Utils::GetDestinationUID(
-        filter_callbacks_->upstreamHost()->metadata(), uid);
+        *filter_callbacks_->upstreamHost()->metadata(), uid);
   }
   return false;
 }


### PR DESCRIPTION
This version includes fix for a memory leak in Lua filters, see:
https://github.com/envoyproxy/envoy/issues/3570