### PR TITLE
Update Envoy SHA for WebSocket fix

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "a0b22efd0750a1f503d605b22e0c041e279a08b3"
+		"lastStableSHA": "95c3e1343de707edee58defbec03ba87c9e969de"
 	}
 ]


### PR DESCRIPTION
This fix allows filters to be respected for websocket connections, i.e. mixer will be
invoked for websocket connections. Previously, all filters were bypassed for websockets.
(Note: This SHA is before @piotrsiokra 's filter chain match SHA)

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>