### PR TITLE
Fix istio deps

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "6a128c56f81639e234cc34dbf40af9532008e467",
+		"lastStableSHA": "6a128c56f81639e234cc34dbf40af9532008e467"
 	},
 	{
 		"_comment": "",


### PR DESCRIPTION
**What this PR does / why we need it**:
Automated dependency update has been failing for proxy because the `istio.dep` file is not valid json and failed the parser. For example, https://k8s-gubernator.appspot.com/build/istio-prow/test-infra-update-deps/5823/

This change fixes `istio.dep` so auto dependency update can be resumed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
