### PR TITLE
Remove fallback for attribute builder when authn filter is not available

### DIFF
--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -111,34 +111,6 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
                           origin.raw_claims());
       }
     }
-    return;
-  }
-
-  // Fallback to extract from jwt filter directly. This can be removed once
-  // authn filter is in place.
-  std::map<std::string, std::string> payload;
-  if (check_data->GetJWTPayload(&payload) && !payload.empty()) {
-    // Populate auth attributes.
-    if (payload.count("iss") > 0 && payload.count("sub") > 0) {
-      builder.AddString(utils::AttributeName::kRequestAuthPrincipal,
-                        payload["iss"] + "/" + payload["sub"]);
-    }
-    if (payload.count("aud") > 0) {
-      builder.AddString(utils::AttributeName::kRequestAuthAudiences,
-                        payload["aud"]);
-    }
-    if (payload.count("azp") > 0) {
-      builder.AddString(utils::AttributeName::kRequestAuthPresenter,
-                        payload["azp"]);
-    }
-    builder.AddStringMap(utils::AttributeName::kRequestAuthClaims, payload);
-  }
-  std::string source_user;
-  if (check_data->GetPrincipal(true, &source_user)) {
-    // TODO(diemtvu): remove kSourceUser once migration to source.principal is
-    // over. https://github.com/istio/istio/issues/4689
-    builder.AddString(utils::AttributeName::kSourceUser, source_user);
-    builder.AddString(utils::AttributeName::kSourcePrincipal, source_user);
   }
 }  // namespace http
 

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -173,7 +173,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -194,7 +194,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -222,7 +222,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -255,7 +255,7 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
 
   ServiceConfig route_config;
   auto map3 = route_config.mutable_mixer_attributes()->mutable_attributes();
@@ -370,7 +370,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(1);


### PR DESCRIPTION
**What this PR does / why we need it**:

Clean up unused fallback logic for (mixer) attribute builder for authn attributes.

This fallback is needed during early implementation/integration of authn filter to avoid breaking (POC) end-user authentication. Since Istio 0.8, authn filter is added whenever mTLS or JWT is used, so authentication result (output from authn filter) should always available. There is no need to fallback to read JWT payload directly (also note, this JWT payload won't be available any more, as it from a deprecated hard-coded location).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/istio/proxy/issues/1880

-->
```NONE
```
