### PR TITLE
Add context.proxy_error_code to http report attributes

### DIFF
--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -40,6 +40,7 @@ class ReportData {
     uint64_t response_body_size;
     std::chrono::nanoseconds duration;
     int response_code;
+    std::string response_flags;
   };
   virtual void GetReportInfo(ReportInfo* info) const = 0;
 

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -75,6 +75,7 @@ struct AttributeName {
   // Context attributes
   static const char kContextProtocol[];
   static const char kContextTime[];
+  static const char kContextProxyErrorCode[];
 
   // Check error code and message.
   static const char kCheckErrorCode[];

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "common/request_info/utility.h"
 #include "envoy/http/header_map.h"
 #include "envoy/request_info/request_info.h"
 #include "include/istio/control/http/controller.h"
@@ -88,6 +89,8 @@ class ReportData : public ::istio::control::http::ReportData {
     // responseCode is for the backend response. If it is not valid, the request
     // is rejected by Envoy. Set the response code for such requests as 500.
     data->response_code = info_.responseCode().value_or(500);
+
+    data->response_flags = RequestInfo::ResponseFlagUtils::toShortString(info_);
   }
 
   bool GetDestinationIpPort(std::string *str_ip, int *port) const override {

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -226,6 +226,9 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
     builder.AddString(utils::AttributeName::kResponseGrpcMessage,
                       grpc_status.message);
   }
+
+  builder.AddString(utils::AttributeName::kContextProxyErrorCode,
+                    info.response_flags);
 }
 
 }  // namespace http

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -336,6 +336,12 @@ attributes {
     }
   }
 }
+attributes {
+  key: "context.proxy_error_code"
+  value {
+    string_value: "NR"
+  }
+}
 )";
 
 void ClearContextTime(const std::string &name, RequestContext *request) {
@@ -547,6 +553,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         info->request_total_size = 240;
         info->duration = std::chrono::nanoseconds(1);
         info->response_code = 404;
+        info->response_flags = "NR";
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_))
       .WillOnce(Invoke([](ReportData::GrpcStatus *status) -> bool {
@@ -600,6 +607,7 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
         info->request_total_size = 240;
         info->duration = std::chrono::nanoseconds(1);
         info->response_code = 404;
+        info->response_flags = "NR";
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_)).WillOnce(testing::Return(false));
 

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -70,6 +70,7 @@ const char AttributeName::kConnectionEvent[] = "connection.event";
 // Context attributes
 const char AttributeName::kContextProtocol[] = "context.protocol";
 const char AttributeName::kContextTime[] = "context.time";
+const char AttributeName::kContextProxyErrorCode[] = "context.proxy_error_code";
 
 // Check error code and message.
 const char AttributeName::kCheckErrorCode[] = "check.error_code";


### PR DESCRIPTION
Adds context.proxy_error_code = %RESPONSE_FLAGS% to report attributes.