### PR TITLE
send rbac shadow policies metrics to mixer

### DIFF
--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -42,7 +42,6 @@ class ReportData {
     int response_code;
     std::string response_flags;
   };
-
   virtual void GetReportInfo(ReportInfo* info) const = 0;
 
   // Get destination ip/port.
@@ -53,7 +52,7 @@ class ReportData {
     std::string permissive_resp_code;
     std::string permissive_policy_id;
   };
-  virtual void GetRbacReportInfo(RbacReportInfo* rbacReportInfo) const = 0;
+  virtual bool GetRbacReportInfo(RbacReportInfo* report_info) const = 0;
 
   // Get upstream host UID. This value overrides the value in the report bag.
   virtual bool GetDestinationUID(std::string* uid) const = 0;

--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -42,14 +42,18 @@ class ReportData {
     int response_code;
     std::string response_flags;
   };
+
   virtual void GetReportInfo(ReportInfo* info) const = 0;
 
   // Get destination ip/port.
   virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
 
-  // Get rbac permissive mode policy attributes.
-  virtual void GetRBACPermissiveAttributes(std::string* resp_code,
-                                           std::string* policy_id) const = 0;
+  // Get Rbac attributes.
+  struct RbacReportInfo {
+    std::string permissive_resp_code;
+    std::string permissive_policy_id;
+  };
+  virtual void GetRbacReportInfo(RbacReportInfo* rbacReportInfo) const = 0;
 
   // Get upstream host UID. This value overrides the value in the report bag.
   virtual bool GetDestinationUID(std::string* uid) const = 0;

--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -47,9 +47,9 @@ class ReportData {
   // Get destination ip/port.
   virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
 
-  // Get rbac shadow attributes.
-  virtual void GetRBACShadowAttributes(std::string* resp_code,
-                                       std::string* policy_id) const = 0;
+  // Get rbac permissive mode policy attributes.
+  virtual void GetRBACPermissiveAttributes(std::string* resp_code,
+                                           std::string* policy_id) const = 0;
 
   // Get upstream host UID. This value overrides the value in the report bag.
   virtual bool GetDestinationUID(std::string* uid) const = 0;

--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -47,6 +47,10 @@ class ReportData {
   // Get destination ip/port.
   virtual bool GetDestinationIpPort(std::string* ip, int* port) const = 0;
 
+  // Get rbac shadow attributes.
+  virtual void GetRBACShadowAttributes(std::string* resp_code,
+                                       std::string* policy_id) const = 0;
+
   // Get upstream host UID. This value overrides the value in the report bag.
   virtual bool GetDestinationUID(std::string* uid) const = 0;
 

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -96,8 +96,8 @@ struct AttributeName {
   static const char kResponseGrpcStatus[];
   static const char kResponseGrpcMessage[];
 
-  static const char kRbacShadowResponseCode[];
-  static const char kRbacShadowPolicyId[];
+  static const char kRbacPermissiveResponseCode[];
+  static const char kRbacPermissivePolicyId[];
 };
 
 }  // namespace utils

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -95,6 +95,9 @@ struct AttributeName {
 
   static const char kResponseGrpcStatus[];
   static const char kResponseGrpcMessage[];
+
+  static const char kRbacShadowResponseCode[];
+  static const char kRbacShadowPolicyId[];
 };
 
 }  // namespace utils

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -25,9 +25,8 @@
 namespace Envoy {
 namespace Http {
 namespace Mixer {
-static const std::string permissive_policy_id_field =
-    "shadow_effective_policyID";
-static const std::string permissive_resp_code_field = "shadow_response_code";
+static const std::string permissivePolicyIDField = "shadow_effective_policyID";
+static const std::string permissiveRespCodeField = "shadow_response_code";
 
 namespace {
 // Set of headers excluded from response.headers attribute.
@@ -120,9 +119,8 @@ class ReportData : public ::istio::control::http::ReportData {
            ExtractGrpcStatus(headers_, status);
   }
 
-  // Get rbac permissive policy attributes.
-  void GetRBACPermissiveAttributes(std::string *resp_code,
-                                   std::string *policy_id) const override {
+  // Get Rbac related attributes.
+  void GetRbacReportInfo(RbacReportInfo *rbacReportInfo) const override {
     const auto filter_meta = info_.dynamicMetadata().filter_metadata();
     const auto filter_it =
         filter_meta.find(Extensions::HttpFilters::HttpFilterNames::get().Rbac);
@@ -132,15 +130,17 @@ class ReportData : public ::istio::control::http::ReportData {
 
     const auto &data_struct = filter_it->second;
     const auto resp_code_it =
-        data_struct.fields().find(permissive_resp_code_field);
+        data_struct.fields().find(permissiveRespCodeField);
     if (resp_code_it != data_struct.fields().end()) {
-      *resp_code = resp_code_it->second.string_value();
+      rbacReportInfo->permissive_resp_code =
+          resp_code_it->second.string_value();
     }
 
     const auto policy_id_it =
-        data_struct.fields().find(permissive_policy_id_field);
+        data_struct.fields().find(permissivePolicyIDField);
     if (policy_id_it != data_struct.fields().end()) {
-      *policy_id = policy_id_it->second.string_value();
+      rbacReportInfo->permissive_policy_id =
+          policy_id_it->second.string_value();
     }
   }
 };

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -25,8 +25,9 @@
 namespace Envoy {
 namespace Http {
 namespace Mixer {
-static const std::string permissivePolicyIDField = "shadow_effective_policyID";
-static const std::string permissiveRespCodeField = "shadow_response_code";
+static const std::string kRbacPermissivePolicyIDField =
+    "shadow_effective_policyID";
+static const std::string kRbacPermissiveRespCodeField = "shadow_response_code";
 
 namespace {
 // Set of headers excluded from response.headers attribute.
@@ -120,28 +121,28 @@ class ReportData : public ::istio::control::http::ReportData {
   }
 
   // Get Rbac related attributes.
-  void GetRbacReportInfo(RbacReportInfo *rbacReportInfo) const override {
+  bool GetRbacReportInfo(RbacReportInfo *report_info) const override {
     const auto filter_meta = info_.dynamicMetadata().filter_metadata();
     const auto filter_it =
         filter_meta.find(Extensions::HttpFilters::HttpFilterNames::get().Rbac);
     if (filter_it == filter_meta.end()) {
-      return;
+      return false;
     }
 
     const auto &data_struct = filter_it->second;
     const auto resp_code_it =
-        data_struct.fields().find(permissiveRespCodeField);
+        data_struct.fields().find(kRbacPermissiveRespCodeField);
     if (resp_code_it != data_struct.fields().end()) {
-      rbacReportInfo->permissive_resp_code =
-          resp_code_it->second.string_value();
+      report_info->permissive_resp_code = resp_code_it->second.string_value();
     }
 
     const auto policy_id_it =
-        data_struct.fields().find(permissivePolicyIDField);
+        data_struct.fields().find(kRbacPermissivePolicyIDField);
     if (policy_id_it != data_struct.fields().end()) {
-      rbacReportInfo->permissive_policy_id =
-          policy_id_it->second.string_value();
+      report_info->permissive_policy_id = policy_id_it->second.string_value();
     }
+
+    return true;
   }
 };
 

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -25,8 +25,9 @@
 namespace Envoy {
 namespace Http {
 namespace Mixer {
-static const std::string shadow_policy_id_field = "shadow_effective_policyID";
-static const std::string shadow_resp_code_field = "shadow_response_code";
+static const std::string permissive_policy_id_field =
+    "shadow_effective_policyID";
+static const std::string permissive_resp_code_field = "shadow_response_code";
 
 namespace {
 // Set of headers excluded from response.headers attribute.
@@ -119,9 +120,9 @@ class ReportData : public ::istio::control::http::ReportData {
            ExtractGrpcStatus(headers_, status);
   }
 
-  // Get rbac shadow attributes.
-  void GetRBACShadowAttributes(std::string *resp_code,
-                               std::string *policy_id) const override {
+  // Get rbac permissive policy attributes.
+  void GetRBACPermissiveAttributes(std::string *resp_code,
+                                   std::string *policy_id) const override {
     const auto filter_meta = info_.dynamicMetadata().filter_metadata();
     const auto filter_it =
         filter_meta.find(Extensions::HttpFilters::HttpFilterNames::get().Rbac);
@@ -130,12 +131,14 @@ class ReportData : public ::istio::control::http::ReportData {
     }
 
     const auto &data_struct = filter_it->second;
-    const auto resp_code_it = data_struct.fields().find(shadow_resp_code_field);
+    const auto resp_code_it =
+        data_struct.fields().find(permissive_resp_code_field);
     if (resp_code_it != data_struct.fields().end()) {
       *resp_code = resp_code_it->second.string_value();
     }
 
-    const auto policy_id_it = data_struct.fields().find(shadow_policy_id_field);
+    const auto policy_id_it =
+        data_struct.fields().find(permissive_policy_id_field);
     if (policy_id_it != data_struct.fields().end()) {
       *policy_id = policy_id_it->second.string_value();
     }

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -25,11 +25,10 @@
 namespace Envoy {
 namespace Http {
 namespace Mixer {
-static const std::string kRbacPermissivePolicyIDField =
-    "shadow_effective_policyID";
-static const std::string kRbacPermissiveRespCodeField = "shadow_response_code";
-
 namespace {
+const std::string kRbacPermissivePolicyIDField = "shadow_effective_policyID";
+const std::string kRbacPermissiveRespCodeField = "shadow_response_code";
+
 // Set of headers excluded from response.headers attribute.
 const std::set<std::string> ResponseHeaderExclusives = {};
 
@@ -142,7 +141,8 @@ class ReportData : public ::istio::control::http::ReportData {
       report_info->permissive_policy_id = policy_id_it->second.string_value();
     }
 
-    return true;
+    return !report_info->permissive_resp_code.empty() ||
+           !report_info->permissive_policy_id.empty();
   }
 };
 

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -230,17 +230,15 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   builder.AddString(utils::AttributeName::kContextProxyErrorCode,
                     info.response_flags);
 
-  std::string rbac_permissive_resp_code;
-  std::string rbac_permissive_policy_id;
-  report_data->GetRBACPermissiveAttributes(&rbac_permissive_resp_code,
-                                           &rbac_permissive_policy_id);
-  if (!rbac_permissive_resp_code.empty()) {
+  ReportData::RbacReportInfo rbac_info;
+  report_data->GetRbacReportInfo(&rbac_info);
+  if (!rbac_info.permissive_resp_code.empty()) {
     builder.AddString(utils::AttributeName::kRbacPermissiveResponseCode,
-                      rbac_permissive_resp_code);
+                      rbac_info.permissive_resp_code);
   }
-  if (!rbac_permissive_policy_id.empty()) {
+  if (!rbac_info.permissive_policy_id.empty()) {
     builder.AddString(utils::AttributeName::kRbacPermissivePolicyId,
-                      rbac_permissive_policy_id);
+                      rbac_info.permissive_policy_id);
   }
 }
 

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -230,17 +230,17 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
   builder.AddString(utils::AttributeName::kContextProxyErrorCode,
                     info.response_flags);
 
-  std::string rbac_shadow_resp_code;
-  std::string rbac_shadow_policy_id;
-  report_data->GetRBACShadowAttributes(&rbac_shadow_resp_code,
-                                       &rbac_shadow_policy_id);
-  if (!rbac_shadow_resp_code.empty()) {
-    builder.AddString(utils::AttributeName::kRbacShadowResponseCode,
-                      rbac_shadow_resp_code);
+  std::string rbac_permissive_resp_code;
+  std::string rbac_permissive_policy_id;
+  report_data->GetRBACPermissiveAttributes(&rbac_permissive_resp_code,
+                                           &rbac_permissive_policy_id);
+  if (!rbac_permissive_resp_code.empty()) {
+    builder.AddString(utils::AttributeName::kRbacPermissiveResponseCode,
+                      rbac_permissive_resp_code);
   }
-  if (!rbac_shadow_policy_id.empty()) {
-    builder.AddString(utils::AttributeName::kRbacShadowPolicyId,
-                      rbac_shadow_policy_id);
+  if (!rbac_permissive_policy_id.empty()) {
+    builder.AddString(utils::AttributeName::kRbacPermissivePolicyId,
+                      rbac_permissive_policy_id);
   }
 }
 

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -229,6 +229,19 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
 
   builder.AddString(utils::AttributeName::kContextProxyErrorCode,
                     info.response_flags);
+
+  std::string rbac_shadow_resp_code;
+  std::string rbac_shadow_policy_id;
+  report_data->GetRBACShadowAttributes(&rbac_shadow_resp_code,
+                                       &rbac_shadow_policy_id);
+  if (!rbac_shadow_resp_code.empty()) {
+    builder.AddString(utils::AttributeName::kRbacShadowResponseCode,
+                      rbac_shadow_resp_code);
+  }
+  if (!rbac_shadow_policy_id.empty()) {
+    builder.AddString(utils::AttributeName::kRbacShadowPolicyId,
+                      rbac_shadow_policy_id);
+  }
 }
 
 }  // namespace http

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -231,14 +231,15 @@ void AttributesBuilder::ExtractReportAttributes(ReportData *report_data) {
                     info.response_flags);
 
   ReportData::RbacReportInfo rbac_info;
-  report_data->GetRbacReportInfo(&rbac_info);
-  if (!rbac_info.permissive_resp_code.empty()) {
-    builder.AddString(utils::AttributeName::kRbacPermissiveResponseCode,
-                      rbac_info.permissive_resp_code);
-  }
-  if (!rbac_info.permissive_policy_id.empty()) {
-    builder.AddString(utils::AttributeName::kRbacPermissivePolicyId,
-                      rbac_info.permissive_policy_id);
+  if (report_data->GetRbacReportInfo(&rbac_info)) {
+    if (!rbac_info.permissive_resp_code.empty()) {
+      builder.AddString(utils::AttributeName::kRbacPermissiveResponseCode,
+                        rbac_info.permissive_resp_code);
+    }
+    if (!rbac_info.permissive_policy_id.empty()) {
+      builder.AddString(utils::AttributeName::kRbacPermissivePolicyId,
+                        rbac_info.permissive_policy_id);
+    }
   }
 }
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -573,10 +573,10 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         status->message = "grpc-message";
         return true;
       }));
-  EXPECT_CALL(mock_data, GetRBACPermissiveAttributes(_, _))
-      .WillOnce(Invoke([](std::string *code, std::string *id) {
-        *code = "403";
-        *id = "policy-foo";
+  EXPECT_CALL(mock_data, GetRbacReportInfo(_))
+      .WillOnce(Invoke([](ReportData::RbacReportInfo *rbacReportInfo) {
+        rbacReportInfo->permissive_resp_code = "403";
+        rbacReportInfo->permissive_policy_id = "policy-foo";
       }));
 
   RequestContext request;
@@ -627,10 +627,10 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
         info->response_flags = "NR";
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_)).WillOnce(testing::Return(false));
-  EXPECT_CALL(mock_data, GetRBACPermissiveAttributes(_, _))
-      .WillOnce(Invoke([](std::string *code, std::string *id) {
-        *code = "403";
-        *id = "policy-foo";
+  EXPECT_CALL(mock_data, GetRbacReportInfo(_))
+      .WillOnce(Invoke([](ReportData::RbacReportInfo *rbacReportInfo) {
+        rbacReportInfo->permissive_resp_code = "403";
+        rbacReportInfo->permissive_policy_id = "policy-foo";
       }));
 
   RequestContext request;

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -574,9 +574,10 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         return true;
       }));
   EXPECT_CALL(mock_data, GetRbacReportInfo(_))
-      .WillOnce(Invoke([](ReportData::RbacReportInfo *rbacReportInfo) {
-        rbacReportInfo->permissive_resp_code = "403";
-        rbacReportInfo->permissive_policy_id = "policy-foo";
+      .WillOnce(Invoke([](ReportData::RbacReportInfo *report_info) -> bool {
+        report_info->permissive_resp_code = "403";
+        report_info->permissive_policy_id = "policy-foo";
+        return true;
       }));
 
   RequestContext request;
@@ -628,9 +629,10 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_)).WillOnce(testing::Return(false));
   EXPECT_CALL(mock_data, GetRbacReportInfo(_))
-      .WillOnce(Invoke([](ReportData::RbacReportInfo *rbacReportInfo) {
-        rbacReportInfo->permissive_resp_code = "403";
-        rbacReportInfo->permissive_policy_id = "policy-foo";
+      .WillOnce(Invoke([](ReportData::RbacReportInfo *report_info) -> bool {
+        report_info->permissive_resp_code = "403";
+        report_info->permissive_policy_id = "policy-foo";
+        return true;
       }));
 
   RequestContext request;

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -343,13 +343,13 @@ attributes {
   }
 }
 attributes {
-  key: "rbac.shadow.response_code"
+  key: "rbac.permissive.response_code"
   value {
     string_value: "403"
   }
 }
 attributes {
-  key: "rbac.shadow.effective_policy_id"
+  key: "rbac.permissive.effective_policy_id"
   value {
     string_value: "policy-foo"
   }
@@ -573,7 +573,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         status->message = "grpc-message";
         return true;
       }));
-  EXPECT_CALL(mock_data, GetRBACShadowAttributes(_, _))
+  EXPECT_CALL(mock_data, GetRBACPermissiveAttributes(_, _))
       .WillOnce(Invoke([](std::string *code, std::string *id) {
         *code = "403";
         *id = "policy-foo";
@@ -627,7 +627,7 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
         info->response_flags = "NR";
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_)).WillOnce(testing::Return(false));
-  EXPECT_CALL(mock_data, GetRBACShadowAttributes(_, _))
+  EXPECT_CALL(mock_data, GetRBACPermissiveAttributes(_, _))
       .WillOnce(Invoke([](std::string *code, std::string *id) {
         *code = "403";
         *id = "policy-foo";

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -342,6 +342,18 @@ attributes {
     string_value: "NR"
   }
 }
+attributes {
+  key: "rbac.shadow.response_code"
+  value {
+    string_value: "403"
+  }
+}
+attributes {
+  key: "rbac.shadow.effective_policy_id"
+  value {
+    string_value: "policy-foo"
+  }
+}
 )";
 
 void ClearContextTime(const std::string &name, RequestContext *request) {
@@ -561,6 +573,11 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         status->message = "grpc-message";
         return true;
       }));
+  EXPECT_CALL(mock_data, GetRBACShadowAttributes(_, _))
+      .WillOnce(Invoke([](std::string *code, std::string *id) {
+        *code = "403";
+        *id = "policy-foo";
+      }));
 
   RequestContext request;
   AttributesBuilder builder(&request);
@@ -610,6 +627,11 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
         info->response_flags = "NR";
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_)).WillOnce(testing::Return(false));
+  EXPECT_CALL(mock_data, GetRBACShadowAttributes(_, _))
+      .WillOnce(Invoke([](std::string *code, std::string *id) {
+        *code = "403";
+        *id = "policy-foo";
+      }));
 
   RequestContext request;
   SetDestinationIp(&request, "1.2.3.4");

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -31,7 +31,7 @@ class MockReportData : public ReportData {
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string* ip));
   MOCK_CONST_METHOD1(GetGrpcStatus, bool(GrpcStatus* status));
-  MOCK_CONST_METHOD2(GetRBACShadowAttributes,
+  MOCK_CONST_METHOD2(GetRBACPermissiveAttributes,
                      void(std::string* code, std::string* id));
 };
 

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -31,8 +31,7 @@ class MockReportData : public ReportData {
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string* ip));
   MOCK_CONST_METHOD1(GetGrpcStatus, bool(GrpcStatus* status));
-  MOCK_CONST_METHOD2(GetRBACPermissiveAttributes,
-                     void(std::string* code, std::string* id));
+  MOCK_CONST_METHOD1(GetRbacReportInfo, void(RbacReportInfo* info));
 };
 
 }  // namespace http

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -31,6 +31,8 @@ class MockReportData : public ReportData {
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string* ip));
   MOCK_CONST_METHOD1(GetGrpcStatus, bool(GrpcStatus* status));
+  MOCK_CONST_METHOD2(GetRBACShadowAttributes,
+                     void(std::string* code, std::string* id));
 };
 
 }  // namespace http

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -31,7 +31,7 @@ class MockReportData : public ReportData {
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string* ip, int* port));
   MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string* ip));
   MOCK_CONST_METHOD1(GetGrpcStatus, bool(GrpcStatus* status));
-  MOCK_CONST_METHOD1(GetRbacReportInfo, void(RbacReportInfo* info));
+  MOCK_CONST_METHOD1(GetRbacReportInfo, bool(RbacReportInfo* info));
 };
 
 }  // namespace http

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -92,10 +92,10 @@ const char AttributeName::kResponseGrpcStatus[] = "response.grpc_status";
 const char AttributeName::kResponseGrpcMessage[] = "response.grpc_message";
 
 // Rbac attributes
-const char AttributeName::kRbacShadowResponseCode[] =
-    "rbac.shadow.response_code";
-const char AttributeName::kRbacShadowPolicyId[] =
-    "rbac.shadow.effective_policy_id";
+const char AttributeName::kRbacPermissiveResponseCode[] =
+    "rbac.permissive.response_code";
+const char AttributeName::kRbacPermissivePolicyId[] =
+    "rbac.permissive.effective_policy_id";
 
 }  // namespace utils
 }  // namespace istio

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -91,5 +91,11 @@ const char AttributeName::kRequestAuthRawClaims[] = "request.auth.raw_claims";
 const char AttributeName::kResponseGrpcStatus[] = "response.grpc_status";
 const char AttributeName::kResponseGrpcMessage[] = "response.grpc_message";
 
+// Rbac attributes
+const char AttributeName::kRbacShadowResponseCode[] =
+    "rbac.shadow.response_code";
+const char AttributeName::kRbacShadowPolicyId[] =
+    "rbac.shadow.effective_policy_id";
+
 }  // namespace utils
 }  // namespace istio


### PR DESCRIPTION
https://github.com/envoyproxy/envoy/pull/4062 put rbac shadow policy running metrics to requestInfo.metadata, this PR parse those metrics inside mixer filter and report to mixer. 