### PR TITLE
Not to send Authorization header to mixer

### DIFF
--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -15,6 +15,7 @@
 
 #include "src/envoy/http/mixer/check_data.h"
 #include "common/common/base64.h"
+#include "common/http/headers.h"
 #include "src/envoy/http/jwt_auth/jwt.h"
 #include "src/envoy/http/jwt_auth/jwt_authenticator.h"
 #include "src/envoy/utils/authn.h"
@@ -32,6 +33,7 @@ const LowerCaseString kRefererHeaderKey("referer");
 
 // Set of headers excluded from request.headers attribute.
 const std::set<std::string> RequestHeaderExclusives = {
+    Http::Headers::get().Authorization.get(),
     Utils::HeaderUpdate::IstioAttributeHeader().get(),
 };
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

**What this PR does / why we need it**:

Not to send Authorization header to mixer

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
None
```
