### PR TITLE
Provide source version information in the binary.

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,7 +1,7 @@
 # Copied from https://github.com/envoyproxy/envoy/blob/master/tools/bazel.rc
 # Envoy specific Bazel build/test options.
 
-#build --workspace_status_command=bazel/get_workspace_status
+build --workspace_status_command=tools/bazel_get_workspace_status
 
 # Basic ASAN/UBSAN that works for gcc
 build:asan --define ENVOY_CONFIG_ASAN=1

--- a/tools/bazel.rc.ci
+++ b/tools/bazel.rc.ci
@@ -1,3 +1,5 @@
+build --workspace_status_command=tools/bazel_get_workspace_status
+
 # This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
 startup --host_jvm_args=-Xmx8192m
 startup --host_jvm_args=-Xms8192m

--- a/tools/bazel.rc.cloudbuilder
+++ b/tools/bazel.rc.cloudbuilder
@@ -1,3 +1,5 @@
+build --workspace_status_command=tools/bazel_get_workspace_status
+
 # This is from Bazel's former travis setup, to avoid blowing up the RAM usage.
 startup --host_jvm_args=-Xmx8192m
 startup --host_jvm_args=-Xms8192m

--- a/tools/bazel_get_workspace_status
+++ b/tools/bazel_get_workspace_status
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2016 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+if git rev-parse --verify --quiet HEAD >/dev/null; then
+  echo "BUILD_SCM_REVISION $(git rev-parse --verify HEAD)"
+else
+  exit 1
+fi
+
+if git diff-index --quiet HEAD; then
+  echo "BUILD_SCM_STATUS Clean"
+else
+  echo "BUILD_SCM_STATUS Modified"
+fi


### PR DESCRIPTION
Before:

    $ bazel-bin/src/envoy/envoy --version

    bazel-bin/src/envoy/envoy  version: 0/1.8.0-dev//DEBUG

After:

    $ bazel-bin/src/envoy/envoy --version

    bazel-bin/src/envoy/envoy  version: f315a32fc7c6f727fc9645cc1ca27d4160c1d0e0/1.8.0-dev/Clean/DEBUG

Fixes #1803.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>