### PR TITLE
Update Envoy SHA to latest with LcTrie optimizations (release-1.0).

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "280baee6dc45e48a4bf38ac03d32711fe5eaeee1"
+ENVOY_SHA = "73bd3d95cd0b6a23de0b6357f1b3065b9014651a"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "280baee6dc45e48a4bf38ac03d32711fe5eaeee1"
+		"lastStableSHA": "73bd3d95cd0b6a23de0b6357f1b3065b9014651a"
 	}
 ]

--- a/src/envoy/http/jwt_auth/integration_test/http_filter_integration_test.cc
+++ b/src/envoy/http/jwt_auth/integration_test/http_filter_integration_test.cc
@@ -136,13 +136,14 @@ class JwtVerificationFilterIntegrationTest
     // Empty issuer_response_body indicates issuer will not be called.
     // Mock a response from an issuer server.
     if (!issuer_response_body.empty()) {
-      fake_upstream_connection_issuer =
-          fake_upstreams_[1]->waitForHttpConnection(*dispatcher_);
-      request_stream_issuer =
-          fake_upstream_connection_issuer->waitForNewStream(*dispatcher_);
-      request_stream_issuer->waitForEndStream(*dispatcher_);
+      ASSERT_TRUE(fake_upstreams_[1]->waitForHttpConnection(
+          *dispatcher_, fake_upstream_connection_issuer));
+      ASSERT_TRUE(fake_upstream_connection_issuer->waitForNewStream(
+          *dispatcher_, request_stream_issuer));
+      ASSERT_TRUE(request_stream_issuer->waitForEndStream(*dispatcher_));
 
-      request_stream_issuer->encodeHeaders(issuer_response_headers, false);
+      request_stream_issuer->encodeHeaders(
+          Http::HeaderMapImpl(issuer_response_headers), false);
       Buffer::OwnedImpl body(issuer_response_body);
       request_stream_issuer->encodeData(body, true);
     }
@@ -150,12 +151,11 @@ class JwtVerificationFilterIntegrationTest
     // Valid JWT case.
     // Check if the request sent to the backend includes the expected one.
     if (verification_success) {
-      fake_upstream_connection_backend =
-          fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-      request_stream_backend =
-          fake_upstream_connection_backend->waitForNewStream(*dispatcher_);
-      request_stream_backend->waitForEndStream(*dispatcher_);
-
+      ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(
+          *dispatcher_, fake_upstream_connection_backend));
+      ASSERT_TRUE(fake_upstream_connection_backend->waitForNewStream(
+          *dispatcher_, request_stream_backend));
+      ASSERT_TRUE(request_stream_backend->waitForEndStream(*dispatcher_));
       EXPECT_TRUE(request_stream_backend->complete());
 
       ExpectHeaderIncluded(expected_headers, request_stream_backend->headers());
@@ -180,12 +180,12 @@ class JwtVerificationFilterIntegrationTest
 
     codec_client->close();
     if (!issuer_response_body.empty()) {
-      fake_upstream_connection_issuer->close();
-      fake_upstream_connection_issuer->waitForDisconnect();
+      ASSERT_TRUE(fake_upstream_connection_issuer->close());
+      ASSERT_TRUE(fake_upstream_connection_issuer->waitForDisconnect());
     }
     if (verification_success) {
-      fake_upstream_connection_backend->close();
-      fake_upstream_connection_backend->waitForDisconnect();
+      ASSERT_TRUE(fake_upstream_connection_backend->close());
+      ASSERT_TRUE(fake_upstream_connection_backend->waitForDisconnect());
     }
   }
 
@@ -373,11 +373,11 @@ TEST_P(JwtVerificationFilterIntegrationTestWithInjectedJwtResult,
   codec_client = makeHttpConnection(lookupPort("http"));
   // Send a request to Envoy.
   response = codec_client->makeHeaderOnlyRequest(headers);
-  fake_upstream_connection_backend =
-      fake_upstreams_[0]->waitForHttpConnection(*dispatcher_);
-  request_stream_backend =
-      fake_upstream_connection_backend->waitForNewStream(*dispatcher_);
-  request_stream_backend->waitForEndStream(*dispatcher_);
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(
+      *dispatcher_, fake_upstream_connection_backend));
+  ASSERT_TRUE(fake_upstream_connection_backend->waitForNewStream(
+      *dispatcher_, request_stream_backend));
+  ASSERT_TRUE(request_stream_backend->waitForEndStream(*dispatcher_));
   EXPECT_TRUE(request_stream_backend->complete());
 
   // With sanitization, the headers received by the backend should not
@@ -387,8 +387,8 @@ TEST_P(JwtVerificationFilterIntegrationTestWithInjectedJwtResult,
 
   response->waitForEndStream();
   codec_client->close();
-  fake_upstream_connection_backend->close();
-  fake_upstream_connection_backend->waitForDisconnect();
+  ASSERT_TRUE(fake_upstream_connection_backend->close());
+  ASSERT_TRUE(fake_upstream_connection_backend->waitForDisconnect());
 }
 
 }  // namespace Envoy


### PR DESCRIPTION
Pulling the following changes from github.com/envoyproxy/envoy:

73bd3d95c http_filter: add addEncodedTrailers and addDecodedTrailers (#3980)
c3652aad5 rbac/fuzz: fix build (#4150)
07bc27c05 fix flaky RBAC integration test. (#4147)
b150d61a9 header_map: copy constructor for HeaderMapImpl. (#4129)
f345c8b23 test: moving websocket tests to using HTTP codec. (#4143)
da500d20f upstream: init host hc value based on hc value from other priorities (#3959)
da6194b94 test: add tests for corner-cases around sending requests before run() starts or after run() ends. (#4114)
3527f7799 perf: reduce the memory usage of LC Trie construction (#4117)
b538e46d8 test: moving redundant code in websocket_integration_test to utilities (#4127)
a3c55bf7b test: make YamlLoadFromStringFail less picky about error msg. (#4141)
c283439b6 rbac: add rbac network filter. (#4083)
5a7152d21 fuzz: route lookup and header finalization fuzzer. (#4116)
589467360 Set content-type and content-length (#4113)
714ae130a fault: use FractionalPercent for percent (#3978)
fde378705 test: Fix inverted exact match logic in IntegrationTcpClient::waitForData() (#4134)
794a00126 Added cluster_name to load assignment config for static cluster (#4123)
19f51e5e1 ssl: refactor ContextConfig to use TlsCertificateConfig (#4115)
0a4bffc5a syscall: refactor OsSysCalls for deeper errno latching (#4111)
ec0d98e5e thrift_proxy: fix oneway bugs (#4025)
1381673ad Do not crash when converting YAML to JSON fails (#4110)
2662bf1f2 config: allow unknown fields flag (take 2) (#4096)
1ab839c1f Use a jittered backoff strategy for handling HdsDelegate stream/connection failures (#4108)
7309c14cf bazel: use GCS remote cache (#4050)
5fe4e14f0 Add thread local cache of overload action states (#4090)
3bb7fbc5f Added TCP healthcheck capabilities to the HdsDelegate (#4079)
98037ed37 secret: add secret provider interface and use it for TlsCertificates (#4086)
3e15c9490 upstream: allow custom extension protocol options (#4098)
9b33c49d1 Rename message types in hds.proto to improve readability (#4109)
bb70b42bb fuzz: router header formatter/parser fuzz test. (#4105)
fe57f6b33 fuzz: http parsing utility fuzzer. (#4107)
73dfedc95 ci: link ninja-buid to ninja for centos (#4106)
1cd509ef1 docs: add curl to Ubuntu deps (#4104)
45b900829 Handling updates from the management server on HDS (#4077)
510994c6a Don't use SIGTERM for admin /quitquitquit, just shut down directly. (#4099)
29b60291e fuzz: access log formatter fuzz test. (#4102)
765cac42f Destroy pending updates when updating a cluster (#4084)
aafdf6037 authz_client_fix: fixed ext_authz http client when request contains content-length greater than 0 (#3888)
22ae0ab93 HttpConnectionManager and upstream counters for total completed requests (#3995)
04616d676  tcp_proxy: convert TCP proxy to use TCP connection pool (#4067)
e759eab17 buffer: add prepend functions to Buffer::Instance (#4064)
14baa40ea fuzz: h1_capture_fuzz with direct response (#3787)
d47365a9a Per endpoint load report (#4044)
70e9878ed Fix bug in `HostSetImpl::chooseLocality()` (#4061)
797e82484 deps: update gRPC to 1.14.0 (#4047)
628730666 Remove std::string cast in upstream impl lib and tests. (#4080)
33ab6ddac bot: exempt label "no stalebot" for PRs (#4081)
699c008d6 Absl string view to std string in dynamic metadata (#4078)
e9dc1090e collect metrics for RBAC shadow policy (#4062)
e9d81e179 Combine query-params into admin API's path, with API access from MainCommon sinking to main thread (#4059)
fccaeade9 Revert "Revert "Basic Implementation of HDS (#3973)" (#4063)" (#4068)
e96d4a6c4 http: fix upstream_rq stat increment  (#4055)
14140ad83 Add overload manager to bootstrap config (#4038)
b14dee5ee thrift_proxy: introduce MessageMetadata to track message headers and other metadata (#3991)
9ee2b2759 authz: correct stat names (#4074)
c68063c05 Stats interface atomization (#4071)
82e3541b0 docs: fix incorrect doc about cluster warming in CDS (#4040)
3868326bd Support ListValue for metadata matcher (#3964)
4e5258953 Revert "Basic Implementation of HDS (#3973)" (#4063)
f3b0f8580 Basic Implementation of HDS (#3973)
7b03f2ef5 tracing: Fixes issue with small LightStep reports. (#3989)
fd517b356 request_info: initial implementation of dynamic metadata object (#3918)
d5bbd1e0c Ability to specify a test or a test group when building with docker release (#4030)
a1c646102 Remove stats_impl.h (#4057)
7bf713a93 fuzz: H2 codec fuzzer. (#4017)
a614808b9 upstream: fix typo (s/lb_type/lb_policy/g) in previous commit. (#4051)
346059548 upstream: require opt-in for the x-envoy-original-dst-host header. (#4046)
f2c9652a9 owners: add Dhi is maintainer (#4042)
6a1868dff Revert "tcp_proxy: convert TCP proxy to use TCP connection pool (#3938)" (#4043)
cc3657797 docs: document request_timeout in version_history (#4041)
a3364380a rest-api: make request timeout configurable (#4006)
fa628c44e logging: optional details for ASSERT (#3934)
55606ec3f bump abseil-cpp commit (#4034)
4c3219c0c owners: promote Stephan and Greg to senior maintainer! (#4039)
ddd661ac0 hot restarter: Log errno for 'panic: cannot open shared memory' error (#4032)
cb3356fc5 Sds: Ssl socket factory owns ContextConfig (#4028)
9bc047226 Refactor TransportSocketFactoryContext and Cluster interfaces. (#4026)
f8f21c26d Rename duplicated ads integration test case name (#4035)
02281809b fix duplicate listeners in lds response (#4029)
61421bddf upstream: fix duplicate clusters (#4012)
1f1166167 split up stats_impl_test to match the *impl.h and and *impl.cc files. (#4024)
5ec8b37da Remove "DO NOT SUBMIT" comment. (#4020)
882c49832 Add more information to errors about rejected cipher suite configuration. (#4019)
ffc8258e5 Rename common/stats/stats_impl.* to common/stats/source_impl.* and fix refs (#4021)
891135e38 Fix overload manager unit test build (#4022)
c2f204cc7 Add stats for overload manager (#4001)
aec92237a remove unused variables (#4013)
e999cfacc Re-order functions in stats_impl to group classes together (#4004)
d5805b171 typos (#4009)
aeb3f2875 Fix perf_annotation_test compilation under gcc 8.1.1 (#4000)
da3c1eaf8 test/mock: Add 3 new gmock matchers (#3972)
6a8b84384 test: Add timeouts to methods that could wait forever in test/integration/fake_upstream.h. (#3936)
d0f10faff HeapStatData with a distinct allocation mechanism for RawStatData (#3710)
2012c3e4c rds: make RouteConfigProvider unique_ptr (#3967)
62441f9fe Add option for merging cluster updates (#3941)
eb5ea98ff fuzz: fixes oss-fuzz: 9599, 9600 (#3979)
b27068bd0 listener: add socket api in os sys calls for additional tests (#3968)
83b9e2da8 Add overload manager for Envoy (#3954)
f0ca75415 Fix prometheus typo. (#3999)
028387a3b tcp_proxy: convert TCP proxy to use TCP connection pool (#3938)
f882e74dc syscall: use Api::SysCallResult in buffer impl (#3976)
7d61b0017 fuzz: fixes oss-fuzz: 9621 (#3988)
dc03a9a41 docs: fix grammar errors (#3983)
ed131cfa9 docs: minor typo and grammar fixups (#3984)
08fadcc41 http: fix segfault when idle timer fires before request headers received. (#3970)
8b9fd9aa7 Refactor setSocketOption for better errno latching (#3915)
6b65dbe3a Change drop_percentage to FractionalPercent (#3974)
f28dc53f4 Remove deprecated handling of mutating admin requests from GET. (#3975)
324e628b7 syscall: refactor address APIs for deeper errno latching (#3897)

Signed-off-by: Piotr Sikora <piotrsikora@google.com>