### PR TITLE
Fix macOS build on CircleCI (release-1.0).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all"
     steps:
       - run: sudo ntpdate -vu time.apple.com
-      - run: brew install automake bazel cmake coreutils go libtool ninja wget
+      - run: brew install bazel cmake coreutils go libtool ninja wget
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
Apparently, automake is now installed automatically,
which broke the brew install step.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>