### PR TITLE
mixerfilter: populate source user without authn

### DIFF
--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -113,6 +113,14 @@ void AttributesBuilder::ExtractAuthAttributes(CheckData *check_data) {
       builder.AddProtoStructStringMap(utils::AttributeName::kRequestAuthClaims,
                                       claims->second.struct_value());
     }
+    return;
+  }
+
+  // Fallback to source.principal extracted from mTLS if no authentication
+  // filter is installed
+  std::string source_user;
+  if (check_data->GetPrincipal(true, &source_user)) {
+    builder.AddString(utils::AttributeName::kSourcePrincipal, source_user);
   }
 }
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -136,6 +136,12 @@ attributes {
     string_value: "/books"
   }
 }
+attributes {
+  key: "source.principal"
+  value {
+    string_value: "test_user"
+  }
+}
 )";
 
 const char kCheckAttributes[] = R"(

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -173,7 +173,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Report is enabled so Attributes are extracted.
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -194,7 +194,7 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -222,7 +222,7 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
@@ -255,7 +255,7 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   ServiceConfig route_config;
   auto map3 = route_config.mutable_mixer_attributes()->mutable_attributes();
@@ -370,7 +370,7 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(1);
+  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(1);


### PR DESCRIPTION
Partial revert of https://github.com/istio/proxy/pull/1887.

Mixerfilter should be able to report source user without authn filter installed.
We should not be putting config dependency on authn filter on telemetry path to mixer.
If for any reason pilot is malfunctioning, we should get reasonable telemetry (considering destination principal is always reported).

/assign @qiwzhang 
/assign @diemtvu 
 