### PR TITLE
Update Envoy SHA to latest with MetricImpl optimizations.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "73bd3d95cd0b6a23de0b6357f1b3065b9014651a"
+ENVOY_SHA = "c1cc68dda009452e90d485da22ee9c74c08b328d"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "73bd3d95cd0b6a23de0b6357f1b3065b9014651a"
+		"lastStableSHA": "c1cc68dda009452e90d485da22ee9c74c08b328d"
 	}
 ]

--- a/src/envoy/alts/tsi_transport_socket.h
+++ b/src/envoy/alts/tsi_transport_socket.h
@@ -57,7 +57,6 @@ class TsiSocket : public Network::TransportSocket,
       Envoy::Network::TransportSocketCallbacks& callbacks) override;
   std::string protocol() const override;
   bool canFlushClose() override { return handshake_complete_; }
-  Envoy::Ssl::Connection* ssl() override { return nullptr; }
   const Envoy::Ssl::Connection* ssl() const override { return nullptr; }
   Network::IoResult doWrite(Buffer::Instance& buffer, bool end_stream) override;
   void closeSocket(Network::ConnectionEvent event) override;


### PR DESCRIPTION
This is far from finished, but it reduces memory usage by ~10%.

Pulling the following changes from github.com/envoyproxy/envoy:

c1cc68dda stats: refactoring MetricImpl without strings (#4190)
36809d80a fuzz: coverage profile generation instructions. (#4193)
ba40cc933 upstream: rebuild cluster when health check config is changed (#4075)
05c0d52d3 build: use clang-6.0. (#4168)
01f403ec4 thrift_proxy: introduce header transport (#4082)
564d256fb tcp: allow connection pool callers to store protocol state (#4131)
3e1d643b9 configs: match latest API changes (#4185)
bc6a10c2f Fix wrong mock function name. (#4187)
e994c1c0b Bump yaml-cpp so it builds with Visual Studio 15.8 (#4182)
3d1325e89 Converting envoy configs to V2 (#2957)
8d0680feb Add timestamp to HealthCheckEvent definition (#4119)
497efb95b server: handle non-EnvoyExceptions safely if thrown in constructor. (#4173)
6d6fafdb3 config: strengthen validation for gRPC config sources. (#4171)
132302caf fuzz: reduce log level when running under fuzz engine. (#4161)
7c04ac255 test: fix V6EmptyOptions in coverage with IPv6 enable (#4155)
1b2219bd7 ci: remove deprecated bazel --batch option (#4166)
2db6a4ce1 ci: update clang to version 6.0 in the Ubuntu build image. (#4157)
71152b710 ratelimit: Add ratelimit custom response headers (#4015)
306287418 ssl: make Ssl::Connection const everywhere (#4179)
706e26238 Handle validation of non expiring tokens in jwt_authn filter (#4007)
f06e9588a fuzz: tag trivial fuzzers with no_fuzz. (#4156)
27fb1d353 thrift_proxy: add service name matching to router implementation (#4130)
8c189a552 Make over provisioning factor configurable (#4003)
6c08fb43c Making test less flaky (#4149)
592775b7b fuzz: bare bones HCM fuzzer. (#4118)

For istio/istio#7912.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>