### PR TITLE
mixer: clear route cache on header update

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -245,7 +245,9 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
   if (nullptr != headers_) {
     UpdateHeaders(*headers_, route_directive_.request_header_operations());
     headers_ = nullptr;
-    decoder_callbacks_->clearRouteCache();
+    if (route_directive_.request_header_operations().size() > 0) {
+      decoder_callbacks_->clearRouteCache();
+    }
   }
 
   if (!initiating_call_) {

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -245,6 +245,7 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
   if (nullptr != headers_) {
     UpdateHeaders(*headers_, route_directive_.request_header_operations());
     headers_ = nullptr;
+    decoder_callbacks_->clearRouteCache();
   }
 
   if (!initiating_call_) {


### PR DESCRIPTION
Clear HTTP route table on header change. This allows mixer to re-route the traffic.

/assign @lizan 
/assign @PiotrSikora 