### PR TITLE
Rename filter to follow naming convention.

### DIFF
--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -82,12 +82,23 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
   }
 };
 
+// For backward compatible. This can be removed once pilot switch to use the new name.
+class AliasAuthnFilterConfig : public AuthnFilterConfig {
+ public:
+  std::string name() override {
+    return "istio_authn";
+};
+
 /**
  * Static registration for the Authn filter. @see RegisterFactory.
  */
 static Registry::RegisterFactory<AuthnFilterConfig,
                                  NamedHttpFilterConfigFactory>
     register_;
+
+static Registry::RegisterFactory<AliasAuthnFilterConfig,
+                                 NamedHttpFilterConfigFactory>
+    register_alias_;
 
 }  // namespace Configuration
 }  // namespace Server

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -82,12 +82,11 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
   }
 };
 
-// For backward compatible. This can be removed once pilot switch to use the new name.
+// For backward compatible. This can be removed once pilot switch to use the new
+// name.
 class AliasAuthnFilterConfig : public AuthnFilterConfig {
  public:
-  std::string name() override {
-    return "istio_authn";
-  }
+  std::string name() override { return "istio_authn"; }
 };
 
 /**

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -87,6 +87,7 @@ class AliasAuthnFilterConfig : public AuthnFilterConfig {
  public:
   std::string name() override {
     return "istio_authn";
+  }
 };
 
 /**

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -44,7 +44,7 @@ static const Http::TestHeaderMapImpl kSimpleRequestHeader{{
 static const char kJwtIssuer[] = "some@issuer";
 
 static const char kAuthnFilterWithJwt[] = R"(
-    name: istio_authn
+    name: istio.authn
     config:
       policy:
         origins:
@@ -85,7 +85,7 @@ INSTANTIATE_TEST_CASE_P(
     HttpProtocolIntegrationTest::protocolTestParamsToString);
 
 TEST_P(AuthenticationFilterIntegrationTest, EmptyPolicy) {
-  config_helper_.addFilter("name: istio_authn");
+  config_helper_.addFilter("name: istio.authn");
   initialize();
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
@@ -104,7 +104,7 @@ TEST_P(AuthenticationFilterIntegrationTest, EmptyPolicy) {
 
 TEST_P(AuthenticationFilterIntegrationTest, SourceMTlsFail) {
   config_helper_.addFilter(R"(
-    name: istio_authn
+    name: istio.authn
     config:
       policy:
         peers:

--- a/src/envoy/http/jwt_auth/http_filter_factory.cc
+++ b/src/envoy/http/jwt_auth/http_filter_factory.cc
@@ -64,12 +64,22 @@ class JwtVerificationFilterConfig : public NamedHttpFilterConfigFactory {
   }
 };
 
+// For backward compatible. This can be removed once pilot switch to use the new name.
+class AliasJwtVerificationFilterConfig : public JwtVerificationFilterConfig {
+ public:
+  std::string name() override { return "jwt-auth"; }
+};
+
 /**
  * Static registration for this JWT verification filter. @see RegisterFactory.
  */
 static Registry::RegisterFactory<JwtVerificationFilterConfig,
                                  NamedHttpFilterConfigFactory>
     register_;
+
+static Registry::RegisterFactory<AliasJwtVerificationFilterConfig,
+                                 NamedHttpFilterConfigFactory>
+    register_alias_;
 
 }  // namespace Configuration
 }  // namespace Server

--- a/src/envoy/http/jwt_auth/http_filter_factory.cc
+++ b/src/envoy/http/jwt_auth/http_filter_factory.cc
@@ -64,7 +64,8 @@ class JwtVerificationFilterConfig : public NamedHttpFilterConfigFactory {
   }
 };
 
-// For backward compatible. This can be removed once pilot switch to use the new name.
+// For backward compatible. This can be removed once pilot switch to use the new
+// name.
 class AliasJwtVerificationFilterConfig : public JwtVerificationFilterConfig {
  public:
   std::string name() override { return "jwt-auth"; }

--- a/src/envoy/http/jwt_auth/integration_test/envoy.conf
+++ b/src/envoy/http/jwt_auth/integration_test/envoy.conf
@@ -32,7 +32,7 @@
             "filters": [
               {
                 "type": "decoder",
-                "name": "jwt-auth",
+                "name": "istio.jwt",
                 "config": {}
               },
               {

--- a/src/envoy/http/jwt_auth/integration_test/envoy.conf.jwk
+++ b/src/envoy/http/jwt_auth/integration_test/envoy.conf.jwk
@@ -32,7 +32,7 @@
             "filters": [
               {
                 "type": "decoder",
-                "name": "jwt-auth",
+                "name": "istio.jwt",
                 "config": {
                    "rules": [
                      {

--- a/src/envoy/http/jwt_auth/integration_test/envoy_allow_missing_or_failed_jwt.conf.jwk
+++ b/src/envoy/http/jwt_auth/integration_test/envoy_allow_missing_or_failed_jwt.conf.jwk
@@ -32,7 +32,7 @@
             "filters": [
               {
                 "type": "decoder",
-                "name": "jwt-auth",
+                "name": "istio.jwt",
                 "config": {
                    "rules": [
                      {

--- a/src/envoy/utils/filter_names.cc
+++ b/src/envoy/utils/filter_names.cc
@@ -18,9 +18,8 @@
 namespace Envoy {
 namespace Utils {
 
-// TODO: using more standard naming, e.g istio.jwt, istio.authn
-const char IstioFilterName::kJwt[] = "jwt-auth";
-const char IstioFilterName::kAuthentication[] = "istio_authn";
+const char IstioFilterName::kJwt[] = "istio.jwt";
+const char IstioFilterName::kAuthentication[] = "istio.authn";
 
 }  // namespace Utils
 }  // namespace Envoy


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `istio.` prefix for filter name.

**Special notes for your reviewer**:

**Release note**:
This PR should be followed with change in [Pilot](https://github.com/istio/istio/blob/master/pilot/pkg/networking/plugin/authn/authentication.go#L42) when updating proxy SHA 