### PR TITLE
Update Envoy SHA to latest with reverted TCP proxy changes (release-1.0).

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,12 +30,12 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "c1cc68dda009452e90d485da22ee9c74c08b328d"
+ENVOY_SHA = "2d8386532f68899ca1fe6476dc458b0df1260b29"
 
 http_archive(
     name = "envoy",
     strip_prefix = "envoy-" + ENVOY_SHA,
-    url = "https://github.com/envoyproxy/envoy/archive/" + ENVOY_SHA + ".zip",
+    url = "https://github.com/istio/envoy/archive/" + ENVOY_SHA + ".zip",
 )
 
 load("@envoy//bazel:repositories.bzl", "envoy_dependencies")

--- a/istio.deps
+++ b/istio.deps
@@ -9,8 +9,8 @@
 	{
 		"_comment": "",
 		"name": "ENVOY_SHA",
-		"repoName": "envoyproxy/envoy",
+		"repoName": "istio/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "c1cc68dda009452e90d485da22ee9c74c08b328d"
+		"lastStableSHA": "2d8386532f68899ca1fe6476dc458b0df1260b29"
 	}
 ]


### PR DESCRIPTION
Pulling the following changes from github.com/istio/envoy:

2d8386532 Disable broken thrift_proxy tests for TCP connection pool.
828847db1 Revert "tcp_proxy: convert TCP proxy to use TCP connection pool (#4067)"

Fixes istio/istio#8310 (once pulled into istio/istio).

Signed-off-by: Piotr Sikora <piotrsikora@google.com>