### PR TITLE
Fix the peerIsOptional and originIsOptional for authn filter.

### DIFF
--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -54,15 +54,15 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
 
   Payload payload;
 
-  if (!filter_config_.policy().peer_is_optional() &&
-      !createPeerAuthenticator(filter_context_.get())->run(&payload)) {
+  if (!createPeerAuthenticator(filter_context_.get())->run(&payload) &&
+      !filter_config_.policy().peer_is_optional()) {
     rejectRequest("Peer authentication failed.");
     return FilterHeadersStatus::StopIteration;
   }
 
   bool success =
-      filter_config_.policy().origin_is_optional() ||
-      createOriginAuthenticator(filter_context_.get())->run(&payload);
+      createOriginAuthenticator(filter_context_.get())->run(&payload) ||
+      filter_config_.policy().origin_is_optional();
 
   if (!success) {
     rejectRequest("Origin authentication failed.");

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -135,7 +135,7 @@ TEST_F(AuthenticationFilterTest, PeerFail) {
       request_info.dynamicMetadata()));
 }
 
-TEST_F(AuthenticationFilterTest, PeerPassOrginFail) {
+TEST_F(AuthenticationFilterTest, PeerPassOriginFail) {
   // Peer pass thus origin authentication must be called. Final result should
   // fail as origin authn fails.
   EXPECT_CALL(filter_, createPeerAuthenticator(_))
@@ -210,8 +210,66 @@ TEST_F(AuthenticationFilterTest, IgnoreBothFail) {
   *filter_config_.mutable_policy() = policy_;
   StrictMock<MockAuthenticationFilter> filter(filter_config_);
   filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  EXPECT_CALL(filter, createPeerAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysFailAuthenticator));
+  EXPECT_CALL(filter, createOriginAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysFailAuthenticator));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter.decodeHeaders(request_headers_, true));
+}
+
+TEST_F(AuthenticationFilterTest, IgnoreBothPass) {
+  iaapi::Policy policy_;
+  ASSERT_TRUE(
+      Protobuf::TextFormat::ParseFromString(ingoreBothPolicy, &policy_));
+  *filter_config_.mutable_policy() = policy_;
+  StrictMock<MockAuthenticationFilter> filter(filter_config_);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  EXPECT_CALL(filter, createPeerAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysPassAuthenticator));
+  EXPECT_CALL(filter, createOriginAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysPassAuthenticator));
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  EXPECT_CALL(decoder_callbacks_, requestInfo())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(request_info));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter.decodeHeaders(request_headers_, true));
+
+  EXPECT_EQ(1, request_info.dynamicMetadata().filter_metadata_size());
+  const auto *data = Utils::Authentication::GetResultFromMetadata(
+      request_info.dynamicMetadata());
+  ASSERT_TRUE(data);
+
+  ProtobufWkt::Struct expected_data;
+  ASSERT_TRUE(Protobuf::TextFormat::ParseFromString(R"(
+       fields {
+         key: "source.namespace"
+         value {
+           string_value: "test_ns"
+         }
+       }
+       fields {
+         key: "source.principal"
+         value {
+           string_value: "cluster.local/sa/test_user/ns/test_ns/"
+         }
+       }
+       fields {
+         key: "source.user"
+         value {
+           string_value: "cluster.local/sa/test_user/ns/test_ns/"
+         }
+       })",
+                                                    &expected_data));
+  EXPECT_TRUE(TestUtility::protoEqual(expected_data, *data));
 }
 
 }  // namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the bug that we forgot to evaluate the peer/jwt when  peerIsOptional/originIsOptional is true, otherwise the next layer (i.e. rbac) won't be able to get the authenticated attributes.

**Which issue this PR fixes**: fixes #1892 #1958

**Special notes for your reviewer**:
Next step is to revert the deprecate mark and add a new tutorial in istio.io to demonstrate how to use it.
