### PR TITLE
Mixer Client uses Node metadata to populate Mixer attributes

### DIFF
--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -19,7 +19,7 @@
 #include "include/istio/control/http/request_handler.h"
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attribute_names.h"
-#include "include/istio/utils/attributes_builder.h"
+#include "include/istio/utils/local_attributes.h"
 #include "mixer/v1/config/client/client_config.pb.h"
 
 namespace istio {

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -72,7 +72,7 @@ class Controller {
   // * optional service config cache size.
   struct Options {
     Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-            const ::istio::utils::LocalAttributes& local_attributes)
+            const ::istio::utils::LocalAttributes* local_attributes)
         : config(config), local_attributes(local_attributes) {}
 
     // Mixer filter config
@@ -86,7 +86,7 @@ class Controller {
     int service_config_cache_size{};
 
     // local attributes
-    const ::istio::utils::LocalAttributes& local_attributes;
+    const ::istio::utils::LocalAttributes* local_attributes;
   };
 
   // The factory function to create a new instance of the controller.

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -72,8 +72,9 @@ class Controller {
   // * optional service config cache size.
   struct Options {
     Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-            const ::istio::utils::LocalAttributes* local_attributes)
-        : config(config), local_attributes(local_attributes) {}
+            std::unique_ptr<const ::istio::utils::LocalAttributes>&
+                local_attributes)
+        : config(config), local_attributes(std::move(local_attributes)) {}
 
     // Mixer filter config
     const ::istio::mixer::v1::config::client::HttpClientConfig& config;
@@ -86,7 +87,7 @@ class Controller {
     int service_config_cache_size{};
 
     // local attributes. not owned by options.
-    const ::istio::utils::LocalAttributes* local_attributes;
+    std::unique_ptr<const ::istio::utils::LocalAttributes> local_attributes;
   };
 
   // The factory function to create a new instance of the controller.

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -16,6 +16,7 @@
 #ifndef ISTIO_CONTROL_HTTP_CONTROLLER_H
 #define ISTIO_CONTROL_HTTP_CONTROLLER_H
 
+#include "envoy/local_info/local_info.h"
 #include "include/istio/control/http/request_handler.h"
 #include "include/istio/mixerclient/client.h"
 #include "mixer/v1/config/client/client_config.pb.h"
@@ -81,6 +82,8 @@ class Controller {
     // The LRU cache size for service config.
     // If not set or is 0 default value, the cache size is 1000.
     int service_config_cache_size{};
+
+    const ::envoy::LocalInfo::LocalInfo& local_info;
   };
 
   // The factory function to create a new instance of the controller.

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -18,8 +18,9 @@
 
 #include "include/istio/control/http/request_handler.h"
 #include "include/istio/mixerclient/client.h"
-#include "mixer/v1/config/client/client_config.pb.h"
 #include "include/istio/utils/attribute_names.h"
+#include "include/istio/utils/attributes_builder.h"
+#include "mixer/v1/config/client/client_config.pb.h"
 
 namespace istio {
 namespace control {
@@ -71,11 +72,8 @@ class Controller {
   // * optional service config cache size.
   struct Options {
     Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-        const ::istio::mixer::v1::Attributes& local_inbound_attributes,
-        const ::istio::mixer::v1::Attributes& local_outbound_attributes,
-        const ::istio::mixer::v1::Attributes& local_forward_attributes)
-        : config(config), local_inbound_attributes(local_inbound_attributes), 
-          local_outbound_attributes(local_outbound_attributes), local_forward_attributes(local_forward_attributes) {}
+            const ::istio::utils::LocalAttributes& local_attributes)
+        : config(config), local_attributes(local_attributes) {}
 
     // Mixer filter config
     const ::istio::mixer::v1::config::client::HttpClientConfig& config;
@@ -87,17 +85,8 @@ class Controller {
     // If not set or is 0 default value, the cache size is 1000.
     int service_config_cache_size{};
 
+    // local attributes
     const ::istio::utils::LocalAttributes& local_attributes;
-
-    // local_inbound attributes
-    const ::istio::mixer::v1::Attributes& local_inbound_attributes;
-
-    // local_outbound attributes
-    const ::istio::mixer::v1::Attributes& local_outbound_attributes;
-
-    // local_forward attributes
-    const ::istio::mixer::v1::Attributes& local_forward_attributes;
-      
   };
 
   // The factory function to create a new instance of the controller.

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -16,10 +16,10 @@
 #ifndef ISTIO_CONTROL_HTTP_CONTROLLER_H
 #define ISTIO_CONTROL_HTTP_CONTROLLER_H
 
-#include "envoy/local_info/local_info.h"
 #include "include/istio/control/http/request_handler.h"
 #include "include/istio/mixerclient/client.h"
 #include "mixer/v1/config/client/client_config.pb.h"
+#include "include/istio/utils/attribute_names.h"
 
 namespace istio {
 namespace control {
@@ -70,8 +70,12 @@ class Controller {
   // * some functions provided by the environment (Envoy)
   // * optional service config cache size.
   struct Options {
-    Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config)
-        : config(config) {}
+    Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
+        const ::istio::mixer::v1::Attributes& local_inbound_attributes,
+        const ::istio::mixer::v1::Attributes& local_outbound_attributes,
+        const ::istio::mixer::v1::Attributes& local_forward_attributes)
+        : config(config), local_inbound_attributes(local_inbound_attributes), 
+          local_outbound_attributes(local_outbound_attributes), local_forward_attributes(local_forward_attributes) {}
 
     // Mixer filter config
     const ::istio::mixer::v1::config::client::HttpClientConfig& config;
@@ -83,7 +87,15 @@ class Controller {
     // If not set or is 0 default value, the cache size is 1000.
     int service_config_cache_size{};
 
-    const ::envoy::LocalInfo::LocalInfo& local_info;
+    // local_inbound attributes
+    const ::istio::mixer::v1::Attributes& local_inbound_attributes;
+
+    // local_outbound attributes
+    const ::istio::mixer::v1::Attributes& local_outbound_attributes;
+
+    // local_forward attributes
+    const ::istio::mixer::v1::Attributes& local_forward_attributes;
+      
   };
 
   // The factory function to create a new instance of the controller.

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -87,6 +87,8 @@ class Controller {
     // If not set or is 0 default value, the cache size is 1000.
     int service_config_cache_size{};
 
+    const ::istio::utils::LocalAttributes& local_attributes;
+
     // local_inbound attributes
     const ::istio::mixer::v1::Attributes& local_inbound_attributes;
 

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -72,9 +72,8 @@ class Controller {
   // * optional service config cache size.
   struct Options {
     Options(const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-            std::unique_ptr<const ::istio::utils::LocalAttributes>&
-                local_attributes)
-        : config(config), local_attributes(std::move(local_attributes)) {}
+            const ::istio::utils::LocalNode local_node)
+        : config(config), local_node(local_node) {}
 
     // Mixer filter config
     const ::istio::mixer::v1::config::client::HttpClientConfig& config;
@@ -86,8 +85,7 @@ class Controller {
     // If not set or is 0 default value, the cache size is 1000.
     int service_config_cache_size{};
 
-    // local attributes. not owned by options.
-    std::unique_ptr<const ::istio::utils::LocalAttributes> local_attributes;
+    const ::istio::utils::LocalNode local_node;
   };
 
   // The factory function to create a new instance of the controller.

--- a/include/istio/control/http/controller.h
+++ b/include/istio/control/http/controller.h
@@ -85,7 +85,7 @@ class Controller {
     // If not set or is 0 default value, the cache size is 1000.
     int service_config_cache_size{};
 
-    // local attributes
+    // local attributes. not owned by options.
     const ::istio::utils::LocalAttributes* local_attributes;
   };
 

--- a/include/istio/utils/BUILD
+++ b/include/istio/utils/BUILD
@@ -18,6 +18,7 @@ cc_library(
     name = "headers_lib",
     hdrs = [
         "attributes_builder.h",
+        "local_attributes.h",
         "md5.h",
         "protobuf.h",
         "status.h",

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -79,6 +79,7 @@ struct AttributeName {
 
   // Context attributes
   static const char kContextProtocol[];
+  static const char kContextReporterKind[];
   static const char kContextTime[];
   static const char kContextProxyErrorCode[];
   static const char kContextReporterUID[];

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -28,6 +28,7 @@ struct AttributeName {
   static const char kSourceUser[];
   static const char kSourcePrincipal[];
   static const char kSourceNamespace[];
+  static const char kSourceUID[];
   static const char kDestinationPrincipal[];
 
   static const char kRequestHeaders[];
@@ -63,6 +64,7 @@ struct AttributeName {
   static const char kDestinationIp[];
   static const char kDestinationPort[];
   static const char kDestinationUID[];
+  static const char kDestinationNamespace[];
   static const char kOriginIp[];
   static const char kConnectionReceviedBytes[];
   static const char kConnectionReceviedTotalBytes[];
@@ -79,6 +81,7 @@ struct AttributeName {
   static const char kContextProtocol[];
   static const char kContextTime[];
   static const char kContextProxyErrorCode[];
+  static const char kContextReporterUID[];
 
   // Check error code and message.
   static const char kCheckErrorCode[];

--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -133,22 +133,6 @@ class AttributesBuilder {
   ::istio::mixer::v1::Attributes* attributes_;
 };
 
-typedef struct LocalAttributes_t {
-  LocalAttributes_t(const ::istio::mixer::v1::Attributes& inbound,
-                    const ::istio::mixer::v1::Attributes& outbound,
-                    const ::istio::mixer::v1::Attributes& forward)
-      : inbound(inbound), outbound(outbound), forward(forward) {}
-
-  // local inbound attributes
-  const ::istio::mixer::v1::Attributes inbound;
-
-  // local outbound attributes
-  const ::istio::mixer::v1::Attributes outbound;
-
-  // local forward attributes
-  const ::istio::mixer::v1::Attributes forward;
-} LocalAttributes;
-
 }  // namespace utils
 }  // namespace istio
 

--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -133,15 +133,33 @@ class AttributesBuilder {
   ::istio::mixer::v1::Attributes* attributes_;
 };
 
-struct LocalAttributes {
-    // local inbound attributes
-    ::istio::mixer::v1::Attributes inbound;
+class LocalAttributes {
+ public:
+  LocalAttributes() {}
 
-    // local outbound attributes
-    ::istio::mixer::v1::Attributes outbound;
+  LocalAttributes(const ::istio::mixer::v1::Attributes inbound,
+                  const ::istio::mixer::v1::Attributes outbound,
+                  const ::istio::mixer::v1::Attributes forward)
+      : inbound_(inbound), outbound_(outbound), forward_(forward) {}
 
-    // local forward attributes
-    ::istio::mixer::v1::Attributes forward;
+  // inbound attributes
+  const ::istio::mixer::v1::Attributes& inbound() const { return inbound_; }
+
+  // outbound attributes
+  const ::istio::mixer::v1::Attributes& outbound() const { return outbound_; }
+
+  // outbound attributes
+  const ::istio::mixer::v1::Attributes& forward() const { return forward_; }
+
+ private:
+  // local inbound attributes
+  const ::istio::mixer::v1::Attributes inbound_;
+
+  // local outbound attributes
+  const ::istio::mixer::v1::Attributes outbound_;
+
+  // local forward attributes
+  const ::istio::mixer::v1::Attributes forward_;
 };
 
 }  // namespace utils

--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -133,6 +133,17 @@ class AttributesBuilder {
   ::istio::mixer::v1::Attributes* attributes_;
 };
 
+struct LocalAttributes {
+    // local inbound attributes
+    ::istio::mixer::v1::Attributes inbound;
+
+    // local outbound attributes
+    ::istio::mixer::v1::Attributes outbound;
+
+    // local forward attributes
+    ::istio::mixer::v1::Attributes forward;
+};
+
 }  // namespace utils
 }  // namespace istio
 

--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -133,34 +133,21 @@ class AttributesBuilder {
   ::istio::mixer::v1::Attributes* attributes_;
 };
 
-class LocalAttributes {
- public:
-  LocalAttributes() {}
+typedef struct LocalAttributes_t {
+  LocalAttributes_t(const ::istio::mixer::v1::Attributes& inbound,
+                    const ::istio::mixer::v1::Attributes& outbound,
+                    const ::istio::mixer::v1::Attributes& forward)
+      : inbound(inbound), outbound(outbound), forward(forward) {}
 
-  LocalAttributes(const ::istio::mixer::v1::Attributes inbound,
-                  const ::istio::mixer::v1::Attributes outbound,
-                  const ::istio::mixer::v1::Attributes forward)
-      : inbound_(inbound), outbound_(outbound), forward_(forward) {}
-
-  // inbound attributes
-  const ::istio::mixer::v1::Attributes& inbound() const { return inbound_; }
-
-  // outbound attributes
-  const ::istio::mixer::v1::Attributes& outbound() const { return outbound_; }
-
-  // outbound attributes
-  const ::istio::mixer::v1::Attributes& forward() const { return forward_; }
-
- private:
   // local inbound attributes
-  const ::istio::mixer::v1::Attributes inbound_;
+  const ::istio::mixer::v1::Attributes inbound;
 
   // local outbound attributes
-  const ::istio::mixer::v1::Attributes outbound_;
+  const ::istio::mixer::v1::Attributes outbound;
 
   // local forward attributes
-  const ::istio::mixer::v1::Attributes forward_;
-};
+  const ::istio::mixer::v1::Attributes forward;
+} LocalAttributes;
 
 }  // namespace utils
 }  // namespace istio

--- a/include/istio/utils/local_attributes.h
+++ b/include/istio/utils/local_attributes.h
@@ -1,0 +1,44 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ISTIO_UTILS_LOCAL_ATTRIBUTES_H
+#define ISTIO_UTILS_LOCAL_ATTRIBUTES_H
+
+#include "mixer/v1/attributes.pb.h"
+
+using ::istio::mixer::v1::Attributes;
+
+namespace istio {
+namespace utils {
+
+typedef struct LocalAttributes_t {
+  LocalAttributes_t(const Attributes& inbound, const Attributes& outbound,
+                    const Attributes& forward)
+      : inbound(inbound), outbound(outbound), forward(forward) {}
+
+  // local inbound attributes
+  const Attributes inbound;
+
+  // local outbound attributes
+  const Attributes outbound;
+
+  // local forward attributes
+  const Attributes forward;
+} LocalAttributes;
+
+}  // namespace utils
+}  // namespace istio
+
+#endif  // ISTIO_UTILS_LOCAL_ATTRIBUTES_H

--- a/include/istio/utils/local_attributes.h
+++ b/include/istio/utils/local_attributes.h
@@ -23,9 +23,9 @@ using ::istio::mixer::v1::Attributes;
 namespace istio {
 namespace utils {
 
-typedef struct LocalAttributes_t {
-  LocalAttributes_t(const Attributes& inbound, const Attributes& outbound,
-                    const Attributes& forward)
+struct LocalAttributes {
+  LocalAttributes(const Attributes& inbound, const Attributes& outbound,
+                  const Attributes& forward)
       : inbound(inbound), outbound(outbound), forward(forward) {}
 
   // local inbound attributes
@@ -36,7 +36,7 @@ typedef struct LocalAttributes_t {
 
   // local forward attributes
   const Attributes forward;
-} LocalAttributes;
+};
 
 }  // namespace utils
 }  // namespace istio

--- a/include/istio/utils/local_attributes.h
+++ b/include/istio/utils/local_attributes.h
@@ -38,6 +38,16 @@ struct LocalAttributes {
   const Attributes forward;
 };
 
+// LocalNode are used to extract information from envoy Node.
+struct LocalNode {
+  std::string ns;
+  std::string ip;
+  std::string uid;
+};
+
+std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
+    const LocalNode& local);
+
 }  // namespace utils
 }  // namespace istio
 

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -16,6 +16,7 @@
 #include "src/envoy/http/mixer/control.h"
 
 using ::istio::mixer::v1::Attributes;
+using ::istio::utils::LocalAttributes;
 
 namespace Envoy {
 namespace Http {
@@ -38,7 +39,7 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 
-  std::unique_ptr<struct Utils::LocalAttributes*> local = Utils::GenerateLocalAttributes(local_info);
+  std::unique_ptr<struct LocalAttributes*> local = Utils::GenerateLocalAttributes(local_info);
   ::istio::control::http::Controller::Options options(config_.config_pb(), (*local)->inbound, (*local)->outbound, (*local)->forward);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -16,7 +16,7 @@
 #include "src/envoy/http/mixer/control.h"
 
 using ::istio::mixer::v1::Attributes;
-using ::istio::utils::LocalAttributes;
+using ::istio::utils::LocalNode;
 
 namespace Envoy {
 namespace Http {
@@ -40,8 +40,11 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 
-  auto ptr = Utils::GenerateLocalAttributes(local_info.node());
-  ::istio::control::http::Controller::Options options(config_.config_pb(), ptr);
+  LocalNode local_node;
+  Utils::Extract(local_info.node(), &local_node);
+
+  ::istio::control::http::Controller::Options options(config_.config_pb(),
+                                                      local_node);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -25,7 +25,8 @@ namespace Mixer {
 Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
-                 Utils::MixerFilterStats& stats, const LocalInfo::LocalInfo& local_info)
+                 Utils::MixerFilterStats& stats,
+                 const LocalInfo::LocalInfo& local_info)
     : config_(config),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.check_cluster(), cm, scope)),
@@ -39,8 +40,8 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 
-  std::unique_ptr<struct LocalAttributes*> local = Utils::GenerateLocalAttributes(local_info);
-  ::istio::control::http::Controller::Options options(config_.config_pb(), (*local)->inbound, (*local)->outbound, (*local)->forward);
+  ::istio::control::http::Controller::Options options(
+      config_.config_pb(), Utils::GenerateLocalAttributes(local_info));
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -22,7 +22,7 @@ namespace Mixer {
 Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
-                 Utils::MixerFilterStats& stats)
+                 Utils::MixerFilterStats& stats, LocalInfo::LocalInfo& local_info)
     : config_(config),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.check_cluster(), cm, scope)),

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -37,6 +37,7 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  [this](::istio::mixerclient::Statistics* stat) -> bool {
                    return GetStats(stat);
                  }) {
+  
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -37,7 +37,6 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  [this](::istio::mixerclient::Statistics* stat) -> bool {
                    return GetStats(stat);
                  }) {
-  
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -40,8 +40,8 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 
-  ::istio::control::http::Controller::Options options(
-      config_.config_pb(), Utils::GenerateLocalAttributes(local_info.node()));
+  auto ptr = Utils::GenerateLocalAttributes(local_info.node());
+  ::istio::control::http::Controller::Options options(config_.config_pb(), ptr);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -41,7 +41,7 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                                       &serialized_forward_attributes_);
 
   ::istio::control::http::Controller::Options options(
-      config_.config_pb(), Utils::GenerateLocalAttributes(local_info));
+      config_.config_pb(), Utils::GenerateLocalAttributes(local_info.node()));
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -39,9 +39,6 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                                       &serialized_forward_attributes_);
 
   std::unique_ptr<struct Utils::LocalAttributes*> local = Utils::GenerateLocalAttributes(local_info);
-  //Attributes inbound;
-  //(*inbound.mutable_attributes())[istio::utils::AttributeName::kDestinationUID].set_string_value(local_info.node().id());
-  
   ::istio::control::http::Controller::Options options(config_.config_pb(), (*local)->inbound, (*local)->outbound, (*local)->forward);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -38,10 +38,11 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
   Utils::SerializeForwardedAttributes(config_.config_pb().transport(),
                                       &serialized_forward_attributes_);
 
+  std::unique_ptr<struct Utils::LocalAttributes*> local = Utils::GenerateLocalAttributes(local_info);
+  //Attributes inbound;
+  //(*inbound.mutable_attributes())[istio::utils::AttributeName::kDestinationUID].set_string_value(local_info.node().id());
   
-  Attributes inbound;
-  (*inbound.mutable_attributes())[istio::utils::AttributeName::kDestinationUID].set_string_value(local_info.node().id());
-  ::istio::control::http::Controller::Options options(config_.config_pb(), inbound, inbound, inbound);
+  ::istio::control::http::Controller::Options options(config_.config_pb(), (*local)->inbound, (*local)->outbound, (*local)->forward);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -21,6 +21,7 @@
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/control/http/controller.h"
+#include "include/istio/utils/attributes_builder.h"
 #include "src/envoy/http/mixer/config.h"
 #include "src/envoy/utils/grpc_transport.h"
 #include "src/envoy/utils/mixer_control.h"

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -17,6 +17,7 @@
 
 #include "envoy/event/dispatcher.h"
 #include "envoy/runtime/runtime.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/control/http/controller.h"
@@ -35,7 +36,7 @@ class Control final : public ThreadLocal::ThreadLocalObject {
   // The constructor.
   Control(const Config& config, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-          Stats::Scope& scope, Utils::MixerFilterStats& stats);
+          Stats::Scope& scope, Utils::MixerFilterStats& stats, LocalInfo::LocalInfo& local_info);
 
   // Get low-level controller object.
   ::istio::control::http::Controller* controller() { return controller_.get(); }

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include "envoy/event/dispatcher.h"
-#include "envoy/runtime/runtime.h"
 #include "envoy/local_info/local_info.h"
+#include "envoy/runtime/runtime.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/control/http/controller.h"
@@ -37,7 +37,8 @@ class Control final : public ThreadLocal::ThreadLocalObject {
   // The constructor.
   Control(const Config& config, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-          Stats::Scope& scope, Utils::MixerFilterStats& stats, const LocalInfo::LocalInfo& local_info);
+          Stats::Scope& scope, Utils::MixerFilterStats& stats,
+          const LocalInfo::LocalInfo& local_info);
 
   // Get low-level controller object.
   ::istio::control::http::Controller* controller() { return controller_.get(); }

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -21,7 +21,7 @@
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/control/http/controller.h"
-#include "include/istio/utils/attributes_builder.h"
+#include "include/istio/utils/local_attributes.h"
 #include "src/envoy/http/mixer/config.h"
 #include "src/envoy/utils/grpc_transport.h"
 #include "src/envoy/utils/mixer_control.h"

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -36,7 +36,7 @@ class Control final : public ThreadLocal::ThreadLocalObject {
   // The constructor.
   Control(const Config& config, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-          Stats::Scope& scope, Utils::MixerFilterStats& stats, LocalInfo::LocalInfo& local_info);
+          Stats::Scope& scope, Utils::MixerFilterStats& stats, const LocalInfo::LocalInfo& local_info);
 
   // Get low-level controller object.
   ::istio::control::http::Controller* controller() { return controller_.get(); }

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -43,11 +43,12 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     Upstream::ClusterManager& cm = context.clusterManager();
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
-    
-    tls_->set([this, &cm, &random, &scope](Event::Dispatcher& dispatcher)
+    LocalInfo::LocalInfo& local_info = context.localInfo()
+
+    tls_->set([this, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
       return std::make_shared<Control>(*config_, cm, dispatcher, random, scope,
-                                       stats_, context.localInfo());
+                                       stats_, local_info);
     });
   }
 

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -43,7 +43,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     Upstream::ClusterManager& cm = context.clusterManager();
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
-    LocalInfo::LocalInfo& local_info = context.localInfo()
+    const LocalInfo::LocalInfo& local_info = context.localInfo();
 
     tls_->set([this, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "common/common/logger.h"
+#include "envoy/local_info/local_info.h"
 #include "src/envoy/http/mixer/control.h"
 #include "src/envoy/utils/stats.h"
 
@@ -42,10 +43,11 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     Upstream::ClusterManager& cm = context.clusterManager();
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
+    
     tls_->set([this, &cm, &random, &scope](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
       return std::make_shared<Control>(*config_, cm, dispatcher, random, scope,
-                                       stats_);
+                                       stats_, context.localInfo());
     });
   }
 

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -45,11 +45,12 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set([this, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
-                  -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<Control>(*config_, cm, dispatcher, random, scope,
-                                       stats_, local_info);
-    });
+    tls_->set(
+        [this, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
+            -> ThreadLocal::ThreadLocalObjectSharedPtr {
+          return std::make_shared<Control>(*config_, cm, dispatcher, random,
+                                           scope, stats_, local_info);
+        });
   }
 
   Control& control() { return tls_->getTyped<Control>(); }

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -93,6 +93,17 @@ envoy_cc_test(
     ],
 )
 
+envoy_cc_test(
+    name = "mixer_control_test",
+    srcs = [
+        "mixer_control_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":utils_lib",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
 
 cc_library(
     name = "filter_names_lib",

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -17,6 +17,7 @@
 #include "src/envoy/utils/grpc_transport.h"
 
 using ::istio::mixerclient::Statistics;
+using ::istio::utils::LocalAttributes;
 
 namespace Envoy {
 namespace Utils {
@@ -142,10 +143,8 @@ std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(const LocalInfo
   inbound[::istio::utils::AttributeName::kDestinationUID].set_string_value(uid);
   inbound[::istio::utils::AttributeName::kContextReporterUID].set_string_value(uid);
   inbound[::istio::utils::AttributeName::kDestinationNamespace].set_string_value(ns);
+  //TODO: mjog check if destination.ip should be setup for inbound.
 
-  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  out:" << la->outbound.DebugString();
-  
-  //TODO: mjog check if destination.ip should be setup here
   auto& outbound = (*la->outbound.mutable_attributes());
   outbound[::istio::utils::AttributeName::kSourceUID].set_string_value(uid);
   outbound[::istio::utils::AttributeName::kContextReporterUID].set_string_value(uid);
@@ -153,9 +152,6 @@ std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(const LocalInfo
  
   auto& forward = (*la->forward.mutable_attributes());
   forward[::istio::utils::AttributeName::kSourceUID].set_string_value(uid);
-  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  out:" << la->outbound.DebugString();
-  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  in" << la->inbound.DebugString();
-  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  forward" << la->forward.DebugString();
   return std::make_unique<struct LocalAttributes*> (la);
 }
 

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -151,7 +151,9 @@ std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(const LocalInfo
  
   auto forward = (*la->forward.mutable_attributes());
   forward[::istio::utils::AttributeName::kSourceUID].set_string_value(uid);
-  
+  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  out:" << la->outbound.DebugString();
+  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  in" << la->inbound.DebugString();
+  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  forward" << la->forward.DebugString();
   return std::make_unique<struct LocalAttributes*> (la);
 }
 

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -138,18 +138,20 @@ std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(const LocalInfo
   std::string ns = std::string(names[1].begin(), names[1].end());
   std::string uid = "kubernetes://" + longname;
 
-  auto inbound = (*la->inbound.mutable_attributes());
+  auto& inbound = (*la->inbound.mutable_attributes());
   inbound[::istio::utils::AttributeName::kDestinationUID].set_string_value(uid);
   inbound[::istio::utils::AttributeName::kContextReporterUID].set_string_value(uid);
   inbound[::istio::utils::AttributeName::kDestinationNamespace].set_string_value(ns);
 
+  GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  out:" << la->outbound.DebugString();
+  
   //TODO: mjog check if destination.ip should be setup here
-  auto outbound = (*la->outbound.mutable_attributes());
+  auto& outbound = (*la->outbound.mutable_attributes());
   outbound[::istio::utils::AttributeName::kSourceUID].set_string_value(uid);
   outbound[::istio::utils::AttributeName::kContextReporterUID].set_string_value(uid);
   outbound[::istio::utils::AttributeName::kSourceNamespace].set_string_value(ns);
  
-  auto forward = (*la->forward.mutable_attributes());
+  auto& forward = (*la->forward.mutable_attributes());
   forward[::istio::utils::AttributeName::kSourceUID].set_string_value(uid);
   GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  out:" << la->outbound.DebugString();
   GOOGLE_LOG(ERROR) << "GenerateLocalAttributes  in" << la->inbound.DebugString();

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -18,8 +18,8 @@
 
 using ::istio::mixerclient::Statistics;
 using ::istio::utils::AttributeName;
-using ::istio::utils::AttributesBuilder;
 using ::istio::utils::LocalAttributes;
+using ::istio::utils::LocalNode;
 
 namespace Envoy {
 namespace Utils {
@@ -112,7 +112,7 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
 // create Local attributes object and return a pointer to it.
 // Should be freed by the caller.
 std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
-    const LocalAttributesArgs &local) {
+    const LocalNode &local) {
   ::istio::mixer::v1::Attributes inbound;
   AttributesBuilder ib(&inbound);
   ib.AddString(AttributeName::kDestinationUID, local.uid);
@@ -189,6 +189,16 @@ bool ExtractInfo(const envoy::api::v2::core::Node &node,
   args->uid = reg + "://" + name + "." + ns;
 
   return true;
+}
+
+bool Extract(const envoy::api::v2::core::Node &node, LocalNode *args) {
+  if (ExtractInfo(node, args)) {
+    return true;
+  }
+  if (ExtractInfoCompat(node.id(), args)) {
+    return true;
+  }
+  return false;
 }
 
 std::unique_ptr<const LocalAttributes> GenerateLocalAttributes(

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -123,14 +123,14 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     namespace
     IP_Address only for inbound.
 **/
-const LocalAttributes GenerateLocalAttributes(
+const LocalAttributes *GenerateLocalAttributes(
     const LocalInfo::LocalInfo &local_info) {
   auto parts = StringUtil::splitToken(local_info.node().id(), "~");
   if (parts.size() < 3) {
     GOOGLE_LOG(ERROR)
         << "GenerateLocalAttributes error len(node.id.split(~))<3: "
         << local_info.node().id();
-    return LocalAttributes();
+    return nullptr;
   }
 
   auto longname = std::string(parts[2].begin(), parts[2].end());
@@ -139,7 +139,7 @@ const LocalAttributes GenerateLocalAttributes(
     GOOGLE_LOG(ERROR)
         << "GenerateLocalAttributes error len(split(longname, '.')) < 3: "
         << longname;
-    return LocalAttributes();
+    return nullptr;
   }
 
   std::string ns = std::string(names[1].begin(), names[1].end());
@@ -161,7 +161,7 @@ const LocalAttributes GenerateLocalAttributes(
   ::istio::mixer::v1::Attributes fwd;
   auto &forward = (*fwd.mutable_attributes());
   forward[AttributeName::kSourceUID].set_string_value(uid);
-  return LocalAttributes(ib, ob, fwd);
+  return new LocalAttributes(ib, ob, fwd);
 }
 
 }  // namespace Utils

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -123,13 +123,15 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
 std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(const LocalInfo::LocalInfo& local_info) {
   struct LocalAttributes* la = new LocalAttributes();
   auto parts = StringUtil::splitToken(local_info.node().id(), "~");
-  if (parts.size() != 3) {
+  if (parts.size() < 3) {
+    GOOGLE_LOG(ERROR) << "GenerateLocalAttributes error len(id)<3: " << local_info.node().id(); 
     return std::make_unique<struct LocalAttributes*> (la);
   }
 
   auto longname = std::string(parts[2].begin(), parts[2].end());
   auto names = StringUtil::splitToken(longname, ".");
-  if (names.size() != 3) {
+  if (names.size() < 2) {
+    GOOGLE_LOG(ERROR) << "GenerateLocalAttributes error len(longname) < 3: " << longname;
     return std::make_unique<struct LocalAttributes*> (la);
   }
 

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -111,7 +111,8 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
 
 // create Local attributes object and return a pointer to it.
 // Should be freed by the caller.
-const LocalAttributes *CreateLocalAttributes(const LocalAttributesArgs &local) {
+std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
+    const LocalAttributesArgs &local) {
   ::istio::mixer::v1::Attributes inbound;
   AttributesBuilder ib(&inbound);
   ib.AddString(AttributeName::kDestinationUID, local.uid);
@@ -131,7 +132,7 @@ const LocalAttributes *CreateLocalAttributes(const LocalAttributesArgs &local) {
   ::istio::mixer::v1::Attributes forward;
   AttributesBuilder(&forward).AddString(AttributeName::kSourceUID, local.uid);
 
-  return new LocalAttributes(inbound, outbound, forward);
+  return std::make_unique<LocalAttributes>(inbound, outbound, forward);
 }
 
 // This function is for compatibility with existing node ids.
@@ -190,7 +191,7 @@ bool ExtractInfo(const envoy::api::v2::core::Node &node,
   return true;
 }
 
-const LocalAttributes *GenerateLocalAttributes(
+std::unique_ptr<const LocalAttributes> GenerateLocalAttributes(
     const envoy::api::v2::core::Node &node) {
   LocalAttributesArgs args;
 

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -62,7 +62,7 @@ struct LocalAttributes {
 */
 
 // return local attributes based on local info.
-const LocalAttributes GenerateLocalAttributes(
+const LocalAttributes *GenerateLocalAttributes(
     const LocalInfo::LocalInfo &local_info);
 
 }  // namespace Utils

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -46,6 +46,13 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
     Stats::Scope &scope);
 
+// localAttributesArgs_t used internally
+typedef struct localAttributesArgs_t {
+  std::string ns;
+  std::string ip;
+  std::string uid;
+} localAttributesArgs;
+
 // return local attributes based on local info.
 const LocalAttributes *GenerateLocalAttributes(
     const LocalInfo::LocalInfo &local_info);

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "envoy/event/dispatcher.h"
+#include "envoy/local_info/local_info.h"
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -21,6 +21,7 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attribute_names.h"
+#include "include/istio/utils/attributes_builder.h"
 #include "include/istio/utils/local_attributes.h"
 #include "src/envoy/utils/config.h"
 

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -20,6 +20,7 @@
 #include "envoy/runtime/runtime.h"
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"
+#include "include/istio/utils/attribute_names.h"
 #include "src/envoy/utils/config.h"
 
 using ::istio::mixer::v1::Attributes;
@@ -42,6 +43,23 @@ void SerializeForwardedAttributes(
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
     Stats::Scope &scope);
+
+
+struct LocalAttributes {
+    public:
+    // local_inbound attributes
+    ::istio::mixer::v1::Attributes inbound;
+
+    // local_outbound attributes
+    ::istio::mixer::v1::Attributes outbound;
+
+    // local_forward attributes
+    ::istio::mixer::v1::Attributes forward;
+};
+
+// return local attributes based on local info.
+std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(
+    const LocalInfo::LocalInfo& local_info);
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -21,13 +21,13 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attribute_names.h"
-#include "include/istio/utils/attributes_builder.h"
 #include "include/istio/utils/local_attributes.h"
 #include "src/envoy/utils/config.h"
 
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::Attributes_AttributeValue;
 using ::istio::utils::LocalAttributes;
+using ::istio::utils::LocalNode;
 
 namespace Envoy {
 namespace Utils {
@@ -48,20 +48,10 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
     Stats::Scope &scope);
 
-// LocalAttributesArgs used internally
-struct LocalAttributesArgs {
-  std::string ns;
-  std::string ip;
-  std::string uid;
-};
-
-// returns local attributes based on local info.
-std::unique_ptr<const LocalAttributes> GenerateLocalAttributes(
-    const envoy::api::v2::core::Node &node);
-
-// only used internally, but exposed for tests.
 std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
-    const LocalAttributesArgs &local);
+    const LocalNode &local);
+
+bool Extract(const envoy::api::v2::core::Node &node, LocalNode *args);
 
 inline bool ReadMap(
     const google::protobuf::Map<std::string, google::protobuf::Value> &meta,

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -47,20 +47,20 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
     Stats::Scope &scope);
 
-// localAttributesArgs_t used internally
-typedef struct localAttributesArgs_t {
+// LocalAttributesArgs used internally
+struct LocalAttributesArgs {
   std::string ns;
   std::string ip;
   std::string uid;
-} localAttributesArgs;
+};
 
 // return local attributes based on local info.
 const LocalAttributes *GenerateLocalAttributes(
     const envoy::api::v2::core::Node &node);
 
-const LocalAttributes *createLocalAttributes(const localAttributesArgs &local);
+const LocalAttributes *CreateLocalAttributes(const LocalAttributesArgs &local);
 
-inline bool readMap(
+inline bool ReadMap(
     const google::protobuf::Map<std::string, google::protobuf::Value> &meta,
     const std::string &key, std::string *val) {
   const auto it = meta.find(key);
@@ -71,7 +71,7 @@ inline bool readMap(
   return false;
 }
 
-inline bool readMap(
+inline bool ReadMap(
     const google::protobuf::Map<std::string, Attributes_AttributeValue> &meta,
     const std::string &key, std::string *val) {
   const auto it = meta.find(key);
@@ -81,28 +81,14 @@ inline bool readMap(
   }
   return false;
 }
-/*
-"NODE_NAME", &name)) {
-    GOOGLE_LOG(ERROR) << "extractInfo  metadata missing NODE_NAME "
-                      << node.metadata().DebugString();
-    return false;
-  }
-  std::string ns;
-  readMap(meta, "NODE_NAMESPACE", &ns);
 
-  std::string ip;
-  readMap(meta, "NODE_IP", &ip);
-
-  std::string reg("kubernetes");
-  readMap(meta, "NODE_REGISTRY",
-  */
-
-typedef struct nodeKey_t {
+// NodeKey are node matadata keys that are expected to be set.
+struct NodeKey {
   static const char kName[];
   static const char kNamespace[];
   static const char kIp[];
   static const char kRegistry[];
-} nodeKey;
+};
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -21,9 +21,11 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attribute_names.h"
+#include "include/istio/utils/attributes_builder.h"
 #include "src/envoy/utils/config.h"
 
 using ::istio::mixer::v1::Attributes;
+using ::istio::utils::LocalAttributes;
 
 namespace Envoy {
 namespace Utils {
@@ -44,7 +46,7 @@ Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
     Stats::Scope &scope);
 
-
+/*
 struct LocalAttributes {
     public:
     // local_inbound attributes
@@ -56,6 +58,8 @@ struct LocalAttributes {
     // local_forward attributes
     ::istio::mixer::v1::Attributes forward;
 };
+
+*/
 
 // return local attributes based on local info.
 std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -55,11 +55,13 @@ struct LocalAttributesArgs {
   std::string uid;
 };
 
-// return local attributes based on local info.
-const LocalAttributes *GenerateLocalAttributes(
+// returns local attributes based on local info.
+std::unique_ptr<const LocalAttributes> GenerateLocalAttributes(
     const envoy::api::v2::core::Node &node);
 
-const LocalAttributes *CreateLocalAttributes(const LocalAttributesArgs &local);
+// only used internally, but exposed for tests.
+std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
+    const LocalAttributesArgs &local);
 
 inline bool ReadMap(
     const google::protobuf::Map<std::string, google::protobuf::Value> &meta,

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -21,7 +21,7 @@
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attribute_names.h"
-#include "include/istio/utils/attributes_builder.h"
+#include "include/istio/utils/local_attributes.h"
 #include "src/envoy/utils/config.h"
 
 using ::istio::mixer::v1::Attributes;
@@ -45,21 +45,6 @@ void SerializeForwardedAttributes(
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
     Stats::Scope &scope);
-
-/*
-struct LocalAttributes {
-    public:
-    // local_inbound attributes
-    ::istio::mixer::v1::Attributes inbound;
-
-    // local_outbound attributes
-    ::istio::mixer::v1::Attributes outbound;
-
-    // local_forward attributes
-    ::istio::mixer::v1::Attributes forward;
-};
-
-*/
 
 // return local attributes based on local info.
 const LocalAttributes *GenerateLocalAttributes(

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -25,6 +25,7 @@
 #include "src/envoy/utils/config.h"
 
 using ::istio::mixer::v1::Attributes;
+using ::istio::mixer::v1::Attributes_AttributeValue;
 using ::istio::utils::LocalAttributes;
 
 namespace Envoy {
@@ -55,7 +56,53 @@ typedef struct localAttributesArgs_t {
 
 // return local attributes based on local info.
 const LocalAttributes *GenerateLocalAttributes(
-    const LocalInfo::LocalInfo &local_info);
+    const envoy::api::v2::core::Node &node);
+
+const LocalAttributes *createLocalAttributes(const localAttributesArgs &local);
+
+inline bool readMap(
+    const google::protobuf::Map<std::string, google::protobuf::Value> &meta,
+    const std::string &key, std::string *val) {
+  const auto it = meta.find(key);
+  if (it != meta.end()) {
+    *val = it->second.string_value();
+    return true;
+  }
+  return false;
+}
+
+inline bool readMap(
+    const google::protobuf::Map<std::string, Attributes_AttributeValue> &meta,
+    const std::string &key, std::string *val) {
+  const auto it = meta.find(key);
+  if (it != meta.end()) {
+    *val = it->second.string_value();
+    return true;
+  }
+  return false;
+}
+/*
+"NODE_NAME", &name)) {
+    GOOGLE_LOG(ERROR) << "extractInfo  metadata missing NODE_NAME "
+                      << node.metadata().DebugString();
+    return false;
+  }
+  std::string ns;
+  readMap(meta, "NODE_NAMESPACE", &ns);
+
+  std::string ip;
+  readMap(meta, "NODE_IP", &ip);
+
+  std::string reg("kubernetes");
+  readMap(meta, "NODE_REGISTRY",
+  */
+
+typedef struct nodeKey_t {
+  static const char kName[];
+  static const char kNamespace[];
+  static const char kIp[];
+  static const char kRegistry[];
+} nodeKey;
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -62,8 +62,8 @@ struct LocalAttributes {
 */
 
 // return local attributes based on local info.
-std::unique_ptr<struct LocalAttributes*> GenerateLocalAttributes(
-    const LocalInfo::LocalInfo& local_info);
+const LocalAttributes GenerateLocalAttributes(
+    const LocalInfo::LocalInfo &local_info);
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -27,13 +27,15 @@ using Envoy::Utils::NodeKey;
 using Envoy::Utils::ParseJsonMessage;
 using Envoy::Utils::ReadMap;
 
-namespace {
+#define assertEqual(laExpect, la)                                              \
+  {                                                                            \
+    EXPECT_EQ((laExpect)->outbound.DebugString(),                              \
+              (la)->outbound.DebugString());                                   \
+    EXPECT_EQ((laExpect)->inbound.DebugString(), (la)->inbound.DebugString()); \
+    EXPECT_EQ((laExpect)->forward.DebugString(), (la)->forward.DebugString()); \
+  };
 
-void assertEqual(const LocalAttributes* laExpect, const LocalAttributes* la) {
-  EXPECT_EQ(laExpect->outbound.DebugString(), la->outbound.DebugString());
-  EXPECT_EQ(laExpect->inbound.DebugString(), la->inbound.DebugString());
-  EXPECT_EQ(laExpect->forward.DebugString(), la->forward.DebugString());
-}
+namespace {
 
 TEST(MixerControlTest, WithMetadata) {
   std::string config_str = R"({
@@ -58,7 +60,7 @@ TEST(MixerControlTest, WithMetadata) {
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
 
-  const LocalAttributes* la = GenerateLocalAttributes(node);
+  auto la = GenerateLocalAttributes(node);
   EXPECT_NE(la, nullptr);
 
   const auto att = la->outbound.attributes();
@@ -93,7 +95,7 @@ TEST(MixerControlTest, NoMetadata) {
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
 
-  const LocalAttributes* la = GenerateLocalAttributes(node);
+  auto la = GenerateLocalAttributes(node);
   EXPECT_NE(la, nullptr);
 
   const auto att = la->outbound.attributes();

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -1,0 +1,117 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/utils/utils.h"
+#include "src/envoy/utils/mixer_control.h"
+#include "mixer/v1/config/client/client_config.pb.h"
+#include "test/test_common/utility.h"
+
+using Envoy::Utils::ParseJsonMessage;
+using Envoy::Utils::readMap;
+using Envoy::Utils::GenerateLocalAttributes;
+using Envoy::Utils::createLocalAttributes;
+using Envoy::Utils::localAttributesArgs;
+using Envoy::Utils::nodeKey;
+using ::istio::utils::AttributeName;
+using ::istio::utils::LocalAttributes;
+
+namespace {
+
+void assertEqual(const LocalAttributes* laExpect, const LocalAttributes* la) {
+  EXPECT_EQ(laExpect->outbound.DebugString(), la->outbound.DebugString());
+  EXPECT_EQ(laExpect->inbound.DebugString(), la->inbound.DebugString());
+  EXPECT_EQ(laExpect->forward.DebugString(), la->forward.DebugString());
+}
+
+TEST(MixerControlTest, WithMetadata) {
+  std::string config_str = R"({
+     "id": "NEWID",
+     "cluster": "fortioclient",
+     "metadata": {
+      "ISTIO_VERSION": "1.0.1",
+      "NODE_NAME": "fortioclient-84469dc8d7-jbbxt",
+      "NODE_IP": "10.36.0.15",
+      "NODE_NAMESPACE": "service-graph",
+      "istio": "sidecar",
+      "INTERCEPTION_MODE": "REDIRECT",
+      "ISTIO_PROXY_VERSION": "1.0.0",
+      "ISTIO_PROXY_SHA": "istio-proxy:2656f34080413d3aec444aa659cc78057508c57b"
+     },
+     "build_version": "0/1.8.0-dev//RELEASE"
+    })";
+  envoy::api::v2::core::Node node;
+
+  auto status = ParseJsonMessage(config_str, &node);
+  EXPECT_OK(status) << status;
+  std::string val;
+
+  localAttributesArgs largs;
+  largs.ip = "10.36.0.15";
+  largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
+  largs.ns = "service-graph";
+
+  const LocalAttributes *la = GenerateLocalAttributes(node);
+  EXPECT_NE(la, nullptr);
+
+  const auto att = la->outbound.attributes();
+
+  EXPECT_EQ(true, readMap(att, AttributeName::kSourceUID, &val));
+  EXPECT_EQ(val, largs.uid);
+
+  EXPECT_EQ(true, readMap(att, AttributeName::kSourceNamespace, &val));
+  EXPECT_EQ(val, largs.ns);
+
+  auto laExpect = createLocalAttributes(largs);
+
+  assertEqual(laExpect, la);
+}
+
+
+TEST(MixerControlTest, NoMetadata) {
+  std::string config_str = R"({
+     "id": "sidecar~10.36.0.15~fortioclient-84469dc8d7-jbbxt.service-graph~service-graph.svc.cluster.local",
+     "cluster": "fortioclient",
+     "metadata": {
+      "ISTIO_VERSION": "1.0.1",
+     },
+     "build_version": "0/1.8.0-dev//RELEASE"
+    })";
+  envoy::api::v2::core::Node node;
+
+  auto status = ParseJsonMessage(config_str, &node);
+  EXPECT_OK(status) << status;
+
+  localAttributesArgs largs;
+  largs.ip = "10.36.0.15";
+  largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
+  largs.ns = "service-graph";
+
+  const LocalAttributes *la = GenerateLocalAttributes(node);
+  EXPECT_NE(la, nullptr);
+
+  const auto att = la->outbound.attributes();
+  std::string val;
+
+  EXPECT_EQ(true, readMap(att, AttributeName::kSourceUID, &val));
+  EXPECT_EQ(val, largs.uid);
+
+  EXPECT_EQ(true, readMap(att, AttributeName::kSourceNamespace, &val));
+  EXPECT_EQ(val, largs.ns);
+
+  auto laExpect = createLocalAttributes(largs);
+
+  assertEqual(laExpect, la);
+}
+}  // namespace

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -13,19 +13,19 @@
  * limitations under the License.
  */
 
-#include "src/envoy/utils/utils.h"
 #include "src/envoy/utils/mixer_control.h"
 #include "mixer/v1/config/client/client_config.pb.h"
+#include "src/envoy/utils/utils.h"
 #include "test/test_common/utility.h"
 
-using Envoy::Utils::ParseJsonMessage;
-using Envoy::Utils::readMap;
+using ::istio::utils::AttributeName;
+using ::istio::utils::LocalAttributes;
 using Envoy::Utils::GenerateLocalAttributes;
+using Envoy::Utils::ParseJsonMessage;
 using Envoy::Utils::createLocalAttributes;
 using Envoy::Utils::localAttributesArgs;
 using Envoy::Utils::nodeKey;
-using ::istio::utils::AttributeName;
-using ::istio::utils::LocalAttributes;
+using Envoy::Utils::readMap;
 
 namespace {
 
@@ -44,10 +44,6 @@ TEST(MixerControlTest, WithMetadata) {
       "NODE_NAME": "fortioclient-84469dc8d7-jbbxt",
       "NODE_IP": "10.36.0.15",
       "NODE_NAMESPACE": "service-graph",
-      "istio": "sidecar",
-      "INTERCEPTION_MODE": "REDIRECT",
-      "ISTIO_PROXY_VERSION": "1.0.0",
-      "ISTIO_PROXY_SHA": "istio-proxy:2656f34080413d3aec444aa659cc78057508c57b"
      },
      "build_version": "0/1.8.0-dev//RELEASE"
     })";
@@ -62,7 +58,7 @@ TEST(MixerControlTest, WithMetadata) {
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
 
-  const LocalAttributes *la = GenerateLocalAttributes(node);
+  const LocalAttributes* la = GenerateLocalAttributes(node);
   EXPECT_NE(la, nullptr);
 
   const auto att = la->outbound.attributes();
@@ -77,7 +73,6 @@ TEST(MixerControlTest, WithMetadata) {
 
   assertEqual(laExpect, la);
 }
-
 
 TEST(MixerControlTest, NoMetadata) {
   std::string config_str = R"({
@@ -98,7 +93,7 @@ TEST(MixerControlTest, NoMetadata) {
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
 
-  const LocalAttributes *la = GenerateLocalAttributes(node);
+  const LocalAttributes* la = GenerateLocalAttributes(node);
   EXPECT_NE(la, nullptr);
 
   const auto att = la->outbound.attributes();

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -19,10 +19,10 @@
 #include "test/test_common/utility.h"
 
 using ::istio::utils::AttributeName;
+using ::istio::utils::CreateLocalAttributes;
 using ::istio::utils::LocalAttributes;
-using Envoy::Utils::CreateLocalAttributes;
-using Envoy::Utils::GenerateLocalAttributes;
-using Envoy::Utils::LocalAttributesArgs;
+using ::istio::utils::LocalNode;
+using Envoy::Utils::Extract;
 using Envoy::Utils::NodeKey;
 using Envoy::Utils::ParseJsonMessage;
 using Envoy::Utils::ReadMap;
@@ -36,6 +36,15 @@ using Envoy::Utils::ReadMap;
   };
 
 namespace {
+
+std::unique_ptr<const LocalAttributes> GenerateLocalAttributes(
+    envoy::api::v2::core::Node& node) {
+  LocalNode largs;
+  if (!Extract(node, &largs)) {
+    return nullptr;
+  }
+  return CreateLocalAttributes(largs);
+}
 
 TEST(MixerControlTest, WithMetadata) {
   std::string config_str = R"({
@@ -55,7 +64,7 @@ TEST(MixerControlTest, WithMetadata) {
   EXPECT_OK(status) << status;
   std::string val;
 
-  LocalAttributesArgs largs;
+  LocalNode largs;
   largs.ip = "10.36.0.15";
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
@@ -90,7 +99,7 @@ TEST(MixerControlTest, NoMetadata) {
   auto status = ParseJsonMessage(config_str, &node);
   EXPECT_OK(status) << status;
 
-  LocalAttributesArgs largs;
+  LocalNode largs;
   largs.ip = "10.36.0.15";
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -18,14 +18,14 @@
 #include "src/envoy/utils/utils.h"
 #include "test/test_common/utility.h"
 
-using ::istio::utils::AttributeName;
-using ::istio::utils::LocalAttributes;
 using Envoy::Utils::CreateLocalAttributes;
 using Envoy::Utils::GenerateLocalAttributes;
 using Envoy::Utils::LocalAttributesArgs;
 using Envoy::Utils::NodeKey;
 using Envoy::Utils::ParseJsonMessage;
 using Envoy::Utils::ReadMap;
+using ::istio::utils::AttributeName;
+using ::istio::utils::LocalAttributes;
 
 #define assertEqual(laExpect, la)                                              \
   {                                                                            \

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -18,14 +18,14 @@
 #include "src/envoy/utils/utils.h"
 #include "test/test_common/utility.h"
 
-using ::istio::utils::AttributeName;
-using ::istio::utils::CreateLocalAttributes;
-using ::istio::utils::LocalAttributes;
-using ::istio::utils::LocalNode;
 using Envoy::Utils::Extract;
 using Envoy::Utils::NodeKey;
 using Envoy::Utils::ParseJsonMessage;
 using Envoy::Utils::ReadMap;
+using ::istio::utils::AttributeName;
+using ::istio::utils::CreateLocalAttributes;
+using ::istio::utils::LocalAttributes;
+using ::istio::utils::LocalNode;
 
 #define assertEqual(laExpect, la)                                              \
   {                                                                            \

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -18,14 +18,14 @@
 #include "src/envoy/utils/utils.h"
 #include "test/test_common/utility.h"
 
+using ::istio::utils::AttributeName;
+using ::istio::utils::LocalAttributes;
 using Envoy::Utils::CreateLocalAttributes;
 using Envoy::Utils::GenerateLocalAttributes;
 using Envoy::Utils::LocalAttributesArgs;
 using Envoy::Utils::NodeKey;
 using Envoy::Utils::ParseJsonMessage;
 using Envoy::Utils::ReadMap;
-using ::istio::utils::AttributeName;
-using ::istio::utils::LocalAttributes;
 
 #define assertEqual(laExpect, la)                                              \
   {                                                                            \

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -20,12 +20,12 @@
 
 using ::istio::utils::AttributeName;
 using ::istio::utils::LocalAttributes;
+using Envoy::Utils::CreateLocalAttributes;
 using Envoy::Utils::GenerateLocalAttributes;
+using Envoy::Utils::LocalAttributesArgs;
+using Envoy::Utils::NodeKey;
 using Envoy::Utils::ParseJsonMessage;
-using Envoy::Utils::createLocalAttributes;
-using Envoy::Utils::localAttributesArgs;
-using Envoy::Utils::nodeKey;
-using Envoy::Utils::readMap;
+using Envoy::Utils::ReadMap;
 
 namespace {
 
@@ -53,7 +53,7 @@ TEST(MixerControlTest, WithMetadata) {
   EXPECT_OK(status) << status;
   std::string val;
 
-  localAttributesArgs largs;
+  LocalAttributesArgs largs;
   largs.ip = "10.36.0.15";
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
@@ -63,13 +63,13 @@ TEST(MixerControlTest, WithMetadata) {
 
   const auto att = la->outbound.attributes();
 
-  EXPECT_EQ(true, readMap(att, AttributeName::kSourceUID, &val));
+  EXPECT_EQ(true, ReadMap(att, AttributeName::kSourceUID, &val));
   EXPECT_EQ(val, largs.uid);
 
-  EXPECT_EQ(true, readMap(att, AttributeName::kSourceNamespace, &val));
+  EXPECT_EQ(true, ReadMap(att, AttributeName::kSourceNamespace, &val));
   EXPECT_EQ(val, largs.ns);
 
-  auto laExpect = createLocalAttributes(largs);
+  auto laExpect = CreateLocalAttributes(largs);
 
   assertEqual(laExpect, la);
 }
@@ -88,7 +88,7 @@ TEST(MixerControlTest, NoMetadata) {
   auto status = ParseJsonMessage(config_str, &node);
   EXPECT_OK(status) << status;
 
-  localAttributesArgs largs;
+  LocalAttributesArgs largs;
   largs.ip = "10.36.0.15";
   largs.uid = "kubernetes://fortioclient-84469dc8d7-jbbxt.service-graph";
   largs.ns = "service-graph";
@@ -99,13 +99,13 @@ TEST(MixerControlTest, NoMetadata) {
   const auto att = la->outbound.attributes();
   std::string val;
 
-  EXPECT_EQ(true, readMap(att, AttributeName::kSourceUID, &val));
+  EXPECT_EQ(true, ReadMap(att, AttributeName::kSourceUID, &val));
   EXPECT_EQ(val, largs.uid);
 
-  EXPECT_EQ(true, readMap(att, AttributeName::kSourceNamespace, &val));
+  EXPECT_EQ(true, ReadMap(att, AttributeName::kSourceNamespace, &val));
   EXPECT_EQ(val, largs.ns);
 
-  auto laExpect = createLocalAttributes(largs);
+  auto laExpect = CreateLocalAttributes(largs);
 
   assertEqual(laExpect, la);
 }

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -16,26 +16,26 @@
 #include "src/istio/control/http/client_context.h"
 #include "include/istio/utils/attribute_names.h"
 
-using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::mixer::v1::Attributes_AttributeValue;
+using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::utils::AttributeName;
 
 namespace istio {
 namespace control {
 namespace http {
-const char*  kReporterOutbound = "outbound";
+const char* kReporterOutbound = "outbound";
 
 namespace {
 
 // isOutbound returns true if this is an outbound listener configuration.
 // It relies on pilot setting context.reporter.kind == outbound;
-static bool isOutbound(const ::istio::mixer::v1::config::client::HttpClientConfig& config) {
+static bool isOutbound(
+    const ::istio::mixer::v1::config::client::HttpClientConfig& config) {
   bool outbound = false;
-    const auto &attributes_map =
-      config.mixer_attributes().attributes();
+  const auto& attributes_map = config.mixer_attributes().attributes();
   const auto it = attributes_map.find(AttributeName::kContextReporterKind);
   if (it != attributes_map.end()) {
-    const Attributes_AttributeValue &value = it->second;
+    const Attributes_AttributeValue& value = it->second;
     if (kReporterOutbound == value.string_value()) {
       outbound = true;
     }
@@ -43,7 +43,7 @@ static bool isOutbound(const ::istio::mixer::v1::config::client::HttpClientConfi
   return outbound;
 }
 
-} // namespace
+}  // namespace
 
 ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
@@ -56,12 +56,12 @@ ClientContext::ClientContext(
     std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
     const ::istio::mixer::v1::config::client::HttpClientConfig& config,
     int service_config_cache_size,
-    const ::istio::utils::LocalAttributes& local_attributes,
-    bool outbound)
+    const ::istio::utils::LocalAttributes* local_attributes, bool outbound)
     : ClientContextBase(std::move(mixer_client)),
       config_(config),
       service_config_cache_size_(service_config_cache_size),
-      local_attributes_(local_attributes), outbound_(outbound) {}
+      local_attributes_(local_attributes),
+      outbound_(outbound) {}
 
 const std::string& ClientContext::GetServiceName(
     const std::string& service_name) const {

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -49,8 +49,9 @@ ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
       config_(data.config),
       service_config_cache_size_(data.service_config_cache_size),
-      // local_attributes_(std::move(data.local_attributes)),
-      outbound_(isOutbound(data.config)) {}
+      outbound_(isOutbound(data.config)) {
+  local_attributes_ = Utils::CreateLocalAttributes(data.local_node);
+}
 
 ClientContext::ClientContext(
     std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -14,28 +14,54 @@
  */
 
 #include "src/istio/control/http/client_context.h"
+#include "include/istio/utils/attribute_names.h"
 
 using ::istio::mixer::v1::config::client::ServiceConfig;
+using ::istio::mixer::v1::Attributes_AttributeValue;
+using ::istio::utils::AttributeName;
 
 namespace istio {
 namespace control {
 namespace http {
+const char*  kReporterOutbound = "outbound";
+
+namespace {
+
+// isOutbound returns true if this is an outbound listener configuration.
+// It relies on pilot setting context.reporter.kind == outbound;
+static bool isOutbound(const ::istio::mixer::v1::config::client::HttpClientConfig& config) {
+  bool outbound = false;
+    const auto &attributes_map =
+      config.mixer_attributes().attributes();
+  const auto it = attributes_map.find(AttributeName::kContextReporterKind);
+  if (it != attributes_map.end()) {
+    const Attributes_AttributeValue &value = it->second;
+    if (kReporterOutbound == value.string_value()) {
+      outbound = true;
+    }
+  }
+  return outbound;
+}
+
+} // namespace
 
 ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
       config_(data.config),
       service_config_cache_size_(data.service_config_cache_size),
-      local_attributes_(data.local_attributes) {}
+      local_attributes_(data.local_attributes),
+      outbound_(isOutbound(data.config)) {}
 
 ClientContext::ClientContext(
     std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
     const ::istio::mixer::v1::config::client::HttpClientConfig& config,
     int service_config_cache_size,
-    const ::istio::utils::LocalAttributes& local_attributes)
+    const ::istio::utils::LocalAttributes& local_attributes,
+    bool outbound)
     : ClientContextBase(std::move(mixer_client)),
       config_(config),
       service_config_cache_size_(service_config_cache_size),
-      local_attributes_(local_attributes) {}
+      local_attributes_(local_attributes), outbound_(outbound) {}
 
 const std::string& ClientContext::GetServiceName(
     const std::string& service_name) const {

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -87,6 +87,30 @@ const ServiceConfig* ClientContext::GetServiceConfig(
   return nullptr;
 }
 
+void ClientContext::AddRequestAttributes(
+    ::istio::mixer::v1::Attributes* request) const {
+  if (local_attributes_ == nullptr) {
+    return;
+  }
+
+  if (outbound_) {
+    request->MergeFrom(local_attributes_->outbound);
+  } else {
+    request->MergeFrom(local_attributes_->inbound);
+  }
+}
+
+void ClientContext::AddForwardAttributes(
+    ::istio::mixer::v1::Attributes* request) const {
+  if (local_attributes_ == nullptr) {
+    return;
+  }
+
+  if (outbound_) {
+    request->MergeFrom(local_attributes_->forward);
+  }
+}
+
 }  // namespace http
 }  // namespace control
 }  // namespace istio

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -24,15 +24,24 @@ namespace http {
 ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
       config_(data.config),
-      service_config_cache_size_(data.service_config_cache_size) {}
+      service_config_cache_size_(data.service_config_cache_size),
+      local_inbound_attributes_(data.local_inbound_attributes),
+      local_outbound_attributes_(data.local_outbound_attributes),
+      local_forward_attributes_(data.local_forward_attributes) {}
 
 ClientContext::ClientContext(
     std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
     const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-    int service_config_cache_size)
+    int service_config_cache_size,
+    const ::istio::mixer::v1::Attributes& local_inbound_attributes,
+    const ::istio::mixer::v1::Attributes& local_outbound_attributes,
+    const ::istio::mixer::v1::Attributes& local_forward_attributes)
     : ClientContextBase(std::move(mixer_client)),
       config_(config),
-      service_config_cache_size_(service_config_cache_size) {}
+      service_config_cache_size_(service_config_cache_size), 
+      local_inbound_attributes_(local_inbound_attributes),
+      local_outbound_attributes_(local_outbound_attributes),
+      local_forward_attributes_(local_forward_attributes) {}
 
 const std::string& ClientContext::GetServiceName(
     const std::string& service_name) const {

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -19,6 +19,7 @@
 using ::istio::mixer::v1::Attributes_AttributeValue;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::utils::AttributeName;
+using ::istio::utils::CreateLocalAttributes;
 
 namespace istio {
 namespace control {
@@ -50,7 +51,7 @@ ClientContext::ClientContext(const Controller::Options& data)
       config_(data.config),
       service_config_cache_size_(data.service_config_cache_size),
       outbound_(isOutbound(data.config)) {
-  local_attributes_ = Utils::CreateLocalAttributes(data.local_node);
+  local_attributes_ = CreateLocalAttributes(data.local_node);
 }
 
 ClientContext::ClientContext(

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -49,18 +49,19 @@ ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
       config_(data.config),
       service_config_cache_size_(data.service_config_cache_size),
-      local_attributes_(data.local_attributes),
+      // local_attributes_(std::move(data.local_attributes)),
       outbound_(isOutbound(data.config)) {}
 
 ClientContext::ClientContext(
     std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
     const ::istio::mixer::v1::config::client::HttpClientConfig& config,
     int service_config_cache_size,
-    const ::istio::utils::LocalAttributes* local_attributes, bool outbound)
+    std::unique_ptr<const ::istio::utils::LocalAttributes> local_attributes,
+    bool outbound)
     : ClientContextBase(std::move(mixer_client)),
       config_(config),
       service_config_cache_size_(service_config_cache_size),
-      local_attributes_(local_attributes),
+      local_attributes_(std::move(local_attributes)),
       outbound_(outbound) {}
 
 const std::string& ClientContext::GetServiceName(

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -25,23 +25,17 @@ ClientContext::ClientContext(const Controller::Options& data)
     : ClientContextBase(data.config.transport(), data.env),
       config_(data.config),
       service_config_cache_size_(data.service_config_cache_size),
-      local_inbound_attributes_(data.local_inbound_attributes),
-      local_outbound_attributes_(data.local_outbound_attributes),
-      local_forward_attributes_(data.local_forward_attributes) {}
+      local_attributes_(data.local_attributes) {}
 
 ClientContext::ClientContext(
     std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
     const ::istio::mixer::v1::config::client::HttpClientConfig& config,
     int service_config_cache_size,
-    const ::istio::mixer::v1::Attributes& local_inbound_attributes,
-    const ::istio::mixer::v1::Attributes& local_outbound_attributes,
-    const ::istio::mixer::v1::Attributes& local_forward_attributes)
+    const ::istio::utils::LocalAttributes& local_attributes)
     : ClientContextBase(std::move(mixer_client)),
       config_(config),
-      service_config_cache_size_(service_config_cache_size), 
-      local_inbound_attributes_(local_inbound_attributes),
-      local_outbound_attributes_(local_outbound_attributes),
-      local_forward_attributes_(local_forward_attributes) {}
+      service_config_cache_size_(service_config_cache_size),
+      local_attributes_(local_attributes) {}
 
 const std::string& ClientContext::GetServiceName(
     const std::string& service_name) const {

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -23,7 +23,7 @@
 namespace istio {
 namespace control {
 namespace http {
-    
+
 // The global context object to hold:
 // * the mixer client config
 // * the mixer client object to call Check/Report with cache.
@@ -35,8 +35,7 @@ class ClientContext : public ClientContextBase {
       std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
       int service_config_cache_size,
-      const ::istio::utils::LocalAttributes& local_attributes,
-      bool outbound);
+      const ::istio::utils::LocalAttributes* local_attributes, bool outbound);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {
@@ -56,10 +55,11 @@ class ClientContext : public ClientContextBase {
   int service_config_cache_size() const { return service_config_cache_size_; }
 
   // local attributes
-  const ::istio::utils::LocalAttributes& local_attributes() const { return local_attributes_;}
+  const ::istio::utils::LocalAttributes* local_attributes() const {
+    return local_attributes_.get();
+  }
 
-  const bool outbound() const { return outbound_;}
-  
+  const bool outbound() const { return outbound_; }
 
  private:
   // The http client config.
@@ -69,7 +69,7 @@ class ClientContext : public ClientContextBase {
   int service_config_cache_size_;
 
   // local attributes - owned by the client context.
-  const ::istio::utils::LocalAttributes local_attributes_;
+  std::unique_ptr<const ::istio::utils::LocalAttributes> local_attributes_;
 
   // if this client context is for an inbound listener or outbound listener.
   bool outbound_;

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -56,13 +56,13 @@ class ClientContext : public ClientContextBase {
   int service_config_cache_size() const { return service_config_cache_size_; }
 
   // local_inbound attributes
-  const ::istio::mixer::v1::Attributes& local_inbound_attributes () { return local_inbound_attributes_; }
+  const ::istio::mixer::v1::Attributes& local_inbound_attributes () const { return local_inbound_attributes_; }
 
   // local_outbound attributes
-  const ::istio::mixer::v1::Attributes& local_outbound_attributes () { return local_outbound_attributes_; }
+  const ::istio::mixer::v1::Attributes& local_outbound_attributes () const { return local_outbound_attributes_; }
 
   // local_forward attributes
-  const ::istio::mixer::v1::Attributes& local_forward_attributes () { return local_forward_attributes_; }
+  const ::istio::mixer::v1::Attributes& local_forward_attributes () const { return local_forward_attributes_; }
 
  private:
   // The http client config.

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -33,7 +33,10 @@ class ClientContext : public ClientContextBase {
   ClientContext(
       std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
-      int service_config_cache_size);
+      int service_config_cache_size,
+      const ::istio::mixer::v1::Attributes& local_inbound_attributes,
+      const ::istio::mixer::v1::Attributes& local_outbound_attributes,
+      const ::istio::mixer::v1::Attributes& local_forward_attributes);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -17,7 +17,7 @@
 #define ISTIO_CONTROL_HTTP_CLIENT_CONTEXT_H
 
 #include "include/istio/control/http/controller.h"
-#include "include/istio/utils/attributes_builder.h"
+#include "include/istio/utils/local_attributes.h"
 #include "src/istio/control/client_context_base.h"
 
 namespace istio {

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -23,7 +23,7 @@
 namespace istio {
 namespace control {
 namespace http {
-
+    
 // The global context object to hold:
 // * the mixer client config
 // * the mixer client object to call Check/Report with cache.
@@ -35,7 +35,8 @@ class ClientContext : public ClientContextBase {
       std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
       int service_config_cache_size,
-      const ::istio::utils::LocalAttributes& local_attributes);
+      const ::istio::utils::LocalAttributes& local_attributes,
+      bool outbound);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {
@@ -55,9 +56,10 @@ class ClientContext : public ClientContextBase {
   int service_config_cache_size() const { return service_config_cache_size_; }
 
   // local attributes
-  const ::istio::utils::LocalAttributes& local_attributes() const {
-    return local_attributes_;
-  }
+  const ::istio::utils::LocalAttributes& local_attributes() const { return local_attributes_;}
+
+  const bool outbound() const { return outbound_;}
+  
 
  private:
   // The http client config.
@@ -66,8 +68,11 @@ class ClientContext : public ClientContextBase {
   // The service config cache size
   int service_config_cache_size_;
 
-  // local attributes
+  // local attributes - owned by the client context.
   const ::istio::utils::LocalAttributes local_attributes_;
+
+  // if this client context is for an inbound listener or outbound listener.
+  bool outbound_;
 };
 
 }  // namespace http

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -18,6 +18,7 @@
 
 #include "include/istio/control/http/controller.h"
 #include "include/istio/utils/local_attributes.h"
+#include "mixer/v1/attributes.pb.h"
 #include "src/istio/control/client_context_base.h"
 
 namespace istio {
@@ -54,12 +55,12 @@ class ClientContext : public ClientContextBase {
   // Get the service config cache size
   int service_config_cache_size() const { return service_config_cache_size_; }
 
-  // local attributes
-  const ::istio::utils::LocalAttributes* local_attributes() const {
-    return local_attributes_.get();
-  }
+  // AddRequestAttributes adds source.* attributes for outbound mixer filter
+  // and adds destination.* attributes for inbound mixer filter.
+  void AddRequestAttributes(::istio::mixer::v1::Attributes* request) const;
 
-  const bool outbound() const { return outbound_; }
+  // AddForwardAttributes add forward attributes for outbound mixer filter.
+  void AddForwardAttributes(::istio::mixer::v1::Attributes* request) const;
 
  private:
   // The http client config.

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -17,6 +17,7 @@
 #define ISTIO_CONTROL_HTTP_CLIENT_CONTEXT_H
 
 #include "include/istio/control/http/controller.h"
+#include "include/istio/utils/attributes_builder.h"
 #include "src/istio/control/client_context_base.h"
 
 namespace istio {
@@ -34,9 +35,7 @@ class ClientContext : public ClientContextBase {
       std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
       int service_config_cache_size,
-      const ::istio::mixer::v1::Attributes& local_inbound_attributes,
-      const ::istio::mixer::v1::Attributes& local_outbound_attributes,
-      const ::istio::mixer::v1::Attributes& local_forward_attributes);
+      const ::istio::utils::LocalAttributes& local_attributes);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {
@@ -55,14 +54,10 @@ class ClientContext : public ClientContextBase {
   // Get the service config cache size
   int service_config_cache_size() const { return service_config_cache_size_; }
 
-  // local_inbound attributes
-  const ::istio::mixer::v1::Attributes& local_inbound_attributes () const { return local_inbound_attributes_; }
-
-  // local_outbound attributes
-  const ::istio::mixer::v1::Attributes& local_outbound_attributes () const { return local_outbound_attributes_; }
-
-  // local_forward attributes
-  const ::istio::mixer::v1::Attributes& local_forward_attributes () const { return local_forward_attributes_; }
+  // local attributes
+  const ::istio::utils::LocalAttributes& local_attributes() const {
+    return local_attributes_;
+  }
 
  private:
   // The http client config.
@@ -71,14 +66,8 @@ class ClientContext : public ClientContextBase {
   // The service config cache size
   int service_config_cache_size_;
 
-  // local_inbound attributes
-  const ::istio::mixer::v1::Attributes& local_inbound_attributes_;
-
-  // local_outbound attributes
-  const ::istio::mixer::v1::Attributes& local_outbound_attributes_;
-
-  // local_forward attributes
-  const ::istio::mixer::v1::Attributes& local_forward_attributes_;
+  // local attributes
+  const ::istio::utils::LocalAttributes local_attributes_;
 };
 
 }  // namespace http

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -36,7 +36,8 @@ class ClientContext : public ClientContextBase {
       std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client,
       const ::istio::mixer::v1::config::client::HttpClientConfig& config,
       int service_config_cache_size,
-      const ::istio::utils::LocalAttributes* local_attributes, bool outbound);
+      std::unique_ptr<const ::istio::utils::LocalAttributes> local_attributes,
+      bool outbound);
 
   // Retrieve mixer client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config() const {

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -52,12 +52,30 @@ class ClientContext : public ClientContextBase {
   // Get the service config cache size
   int service_config_cache_size() const { return service_config_cache_size_; }
 
+  // local_inbound attributes
+  const ::istio::mixer::v1::Attributes& local_inbound_attributes () { return local_inbound_attributes_; }
+
+  // local_outbound attributes
+  const ::istio::mixer::v1::Attributes& local_outbound_attributes () { return local_outbound_attributes_; }
+
+  // local_forward attributes
+  const ::istio::mixer::v1::Attributes& local_forward_attributes () { return local_forward_attributes_; }
+
  private:
   // The http client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config_;
 
   // The service config cache size
   int service_config_cache_size_;
+
+  // local_inbound attributes
+  const ::istio::mixer::v1::Attributes& local_inbound_attributes_;
+
+  // local_outbound attributes
+  const ::istio::mixer::v1::Attributes& local_outbound_attributes_;
+
+  // local_forward attributes
+  const ::istio::mixer::v1::Attributes& local_forward_attributes_;
 };
 
 }  // namespace http

--- a/src/istio/control/http/controller_impl.h
+++ b/src/istio/control/http/controller_impl.h
@@ -22,6 +22,7 @@
 #include "include/istio/control/http/controller.h"
 #include "include/istio/utils/simple_lru_cache.h"
 #include "include/istio/utils/simple_lru_cache_inl.h"
+#include "include/istio/utils/attribute_names.h"
 #include "src/istio/control/http/client_context.h"
 #include "src/istio/control/http/service_context.h"
 

--- a/src/istio/control/http/controller_impl.h
+++ b/src/istio/control/http/controller_impl.h
@@ -20,9 +20,9 @@
 #include <unordered_map>
 
 #include "include/istio/control/http/controller.h"
+#include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/simple_lru_cache.h"
 #include "include/istio/utils/simple_lru_cache_inl.h"
-#include "include/istio/utils/attribute_names.h"
 #include "src/istio/control/http/client_context.h"
 #include "src/istio/control/http/service_context.h"
 

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -152,11 +152,11 @@ class RequestHandlerImplTest : public ::testing::Test {
 
     mock_client_ = new ::testing::NiceMock<MockMixerClient>;
     // set LRU cache size is 3
-    const LocalAttributes* local_attributes =
-        new LocalAttributes(inbound, outbound, forward);
+    auto la = new LocalAttributes(inbound, outbound, forward);
+
     client_context_ = std::make_shared<ClientContext>(
         std::unique_ptr<MixerClient>(mock_client_), client_config_, 3,
-        local_attributes, false);
+        std::unique_ptr<LocalAttributes>(la), false);
     controller_ =
         std::unique_ptr<Controller>(new ControllerImpl(client_context_));
   }

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -153,7 +153,7 @@ class RequestHandlerImplTest : public ::testing::Test {
     // set LRU cache size is 3
     client_context_ = std::make_shared<ClientContext>(
         std::unique_ptr<MixerClient>(mock_client_), client_config_, 3,
-        ::istio::utils::LocalAttributes(inbound, outbound, forward));
+        ::istio::utils::LocalAttributes(inbound, outbound, forward), false);
     controller_ =
         std::unique_ptr<Controller>(new ControllerImpl(client_context_));
   }

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -34,6 +34,7 @@ using ::istio::mixerclient::DoneFunc;
 using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
 using ::istio::quota_config::Requirement;
+using ::istio::utils::LocalAttributes;
 
 using ::testing::_;
 using ::testing::Invoke;
@@ -151,9 +152,11 @@ class RequestHandlerImplTest : public ::testing::Test {
 
     mock_client_ = new ::testing::NiceMock<MockMixerClient>;
     // set LRU cache size is 3
+    const LocalAttributes* local_attributes =
+        new LocalAttributes(inbound, outbound, forward);
     client_context_ = std::make_shared<ClientContext>(
         std::unique_ptr<MixerClient>(mock_client_), client_config_, 3,
-        ::istio::utils::LocalAttributes(inbound, outbound, forward), false);
+        local_attributes, false);
     controller_ =
         std::unique_ptr<Controller>(new ControllerImpl(client_context_));
   }

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -129,24 +129,31 @@ class RequestHandlerImplTest : public ::testing::Test {
   void SetUp() { SetUpMockController(kDefaultClientConfig); }
 
   void SetUpMockController(const std::string& config_text) {
-     SetUpMockController(config_text, kLocalInbound, kLocalOutbound, kLocalForward); 
+    SetUpMockController(config_text, kLocalInbound, kLocalOutbound,
+                        kLocalForward);
   }
 
-  void SetUpMockController(const std::string& config_text, const std::string& local_inbound_attributes,
-      const std::string& local_outbound_attributes, const std::string& local_forward_attributes) {
+  void SetUpMockController(const std::string& config_text,
+                           const std::string& local_inbound_attributes,
+                           const std::string& local_outbound_attributes,
+                           const std::string& local_forward_attributes) {
     ASSERT_TRUE(TextFormat::ParseFromString(config_text, &client_config_));
-    
+
     Attributes inbound;
-    ASSERT_TRUE(TextFormat::ParseFromString(local_inbound_attributes, &inbound));
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(local_inbound_attributes, &inbound));
     Attributes outbound;
-    ASSERT_TRUE(TextFormat::ParseFromString(local_outbound_attributes, &outbound));
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(local_outbound_attributes, &outbound));
     Attributes forward;
-    ASSERT_TRUE(TextFormat::ParseFromString(local_forward_attributes, &forward));
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(local_forward_attributes, &forward));
 
     mock_client_ = new ::testing::NiceMock<MockMixerClient>;
     // set LRU cache size is 3
     client_context_ = std::make_shared<ClientContext>(
-        std::unique_ptr<MixerClient>(mock_client_), client_config_, 3, inbound, outbound, forward);
+        std::unique_ptr<MixerClient>(mock_client_), client_config_, 3,
+        ::istio::utils::LocalAttributes(inbound, outbound, forward));
     controller_ =
         std::unique_ptr<Controller>(new ControllerImpl(client_context_));
   }

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -18,6 +18,7 @@
 #include "src/istio/control/http/attributes_builder.h"
 
 using ::istio::mixer::v1::Attributes;
+using ::istio::mixer::v1::Attributes_AttributeValue;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 
 namespace istio {
@@ -57,6 +58,21 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
   }
   if (service_config_ && service_config_->has_mixer_attributes()) {
     request->attributes.MergeFrom(service_config_->mixer_attributes());
+  }
+
+  // Add locally known attributes
+  bool inbound = true;
+  const auto &attributes_map = client_context_->config().mixer_attributes().attributes();
+  const auto it = attributes_map.find("context.reporter.kind");
+  if (it != attributes_map.end()) {
+    const Attributes_AttributeValue &value = it->second;
+    if ("outbound" == value.string_value()) {
+      inbound = false;
+    }
+  }
+
+  if (inbound) {
+  } else {
   }
 }
 

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -74,7 +74,7 @@ void ServiceContext::InjectForwardedAttributes(
     attributes.MergeFrom(service_config_->forward_attributes());
   }
 
-  client_context_->AddForwardAttributes(&attributes);
+  // client_context_->AddForwardAttributes(&attributes);
 
   if (!attributes.attributes().empty()) {
     AttributesBuilder::ForwardAttributes(attributes, header_update);

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -18,7 +18,6 @@
 #include "src/istio/control/http/attributes_builder.h"
 
 using ::istio::mixer::v1::Attributes;
-using ::istio::mixer::v1::Attributes_AttributeValue;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 
 namespace istio {
@@ -60,24 +59,12 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
     request->attributes.MergeFrom(service_config_->mixer_attributes());
   }
 
-  // Add locally known attributes
-  bool inbound = true;
-  const auto &attributes_map =
-      client_context_->config().mixer_attributes().attributes();
-  const auto it = attributes_map.find("context.reporter.kind");
-  if (it != attributes_map.end()) {
-    const Attributes_AttributeValue &value = it->second;
-    if ("outbound" == value.string_value()) {
-      inbound = false;
-    }
-  }
-
-  if (inbound) {
+  if (client_context_->outbound()) {
     request->attributes.MergeFrom(
-        client_context_->local_attributes().inbound());
+      client_context_->local_attributes().outbound());
   } else {
     request->attributes.MergeFrom(
-        client_context_->local_attributes().outbound());
+        client_context_->local_attributes().inbound());
   }
 }
 

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -62,7 +62,8 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
 
   // Add locally known attributes
   bool inbound = true;
-  const auto &attributes_map = client_context_->config().mixer_attributes().attributes();
+  const auto &attributes_map =
+      client_context_->config().mixer_attributes().attributes();
   const auto it = attributes_map.find("context.reporter.kind");
   if (it != attributes_map.end()) {
     const Attributes_AttributeValue &value = it->second;
@@ -72,9 +73,11 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
   }
 
   if (inbound) {
-    request->attributes.MergeFrom(client_context_->local_inbound_attributes());
+    request->attributes.MergeFrom(
+        client_context_->local_attributes().inbound());
   } else {
-    request->attributes.MergeFrom(client_context_->local_outbound_attributes());
+    request->attributes.MergeFrom(
+        client_context_->local_attributes().outbound());
   }
 }
 

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -59,14 +59,7 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
     request->attributes.MergeFrom(service_config_->mixer_attributes());
   }
 
-  auto local_attributes = client_context_->local_attributes();
-  if (local_attributes != nullptr) {
-    if (client_context_->outbound()) {
-      request->attributes.MergeFrom(local_attributes->outbound);
-    } else {
-      request->attributes.MergeFrom(local_attributes->inbound);
-    }
-  }
+  client_context_->AddRequestAttributes(&request->attributes);
 }
 
 // Inject a header that contains the static forwarded attributes.
@@ -81,11 +74,7 @@ void ServiceContext::InjectForwardedAttributes(
     attributes.MergeFrom(service_config_->forward_attributes());
   }
 
-  auto local_attributes = client_context_->local_attributes();
-  if (local_attributes != nullptr && client_context_->outbound()) {
-    // attributes are only forwarded on outbound.
-    attributes.MergeFrom(local_attributes->forward);
-  }
+  client_context_->AddForwardAttributes(&attributes);
 
   if (!attributes.attributes().empty()) {
     AttributesBuilder::ForwardAttributes(attributes, header_update);

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -72,7 +72,9 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
   }
 
   if (inbound) {
+    request->attributes.MergeFrom(client_context_->local_inbound_attributes());
   } else {
+    request->attributes.MergeFrom(client_context_->local_outbound_attributes());
   }
 }
 

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -59,12 +59,13 @@ void ServiceContext::AddStaticAttributes(RequestContext *request) const {
     request->attributes.MergeFrom(service_config_->mixer_attributes());
   }
 
-  if (client_context_->outbound()) {
-    request->attributes.MergeFrom(
-      client_context_->local_attributes().outbound());
-  } else {
-    request->attributes.MergeFrom(
-        client_context_->local_attributes().inbound());
+  auto local_attributes = client_context_->local_attributes();
+  if (local_attributes != nullptr) {
+    if (client_context_->outbound()) {
+      request->attributes.MergeFrom(local_attributes->outbound);
+    } else {
+      request->attributes.MergeFrom(local_attributes->inbound);
+    }
   }
 }
 

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -81,6 +81,12 @@ void ServiceContext::InjectForwardedAttributes(
     attributes.MergeFrom(service_config_->forward_attributes());
   }
 
+  auto local_attributes = client_context_->local_attributes();
+  if (local_attributes != nullptr && client_context_->outbound()) {
+    // attributes are only forwarded on outbound.
+    attributes.MergeFrom(local_attributes->forward);
+  }
+
   if (!attributes.attributes().empty()) {
     AttributesBuilder::ForwardAttributes(attributes, header_update);
   }

--- a/src/istio/utils/BUILD
+++ b/src/istio/utils/BUILD
@@ -17,6 +17,7 @@ licenses(["notice"])
 cc_library(
     name = "utils_lib",
     srcs = [
+        "local_attributes.cc",
         "protobuf.cc",
         "status.cc",
         "utils.cc"
@@ -28,6 +29,9 @@ cc_library(
     deps = [
         "//external:protobuf",
         "//include/istio/utils:headers_lib",
+        "//include/istio/utils:attribute_names_header",
+        "//external:mixer_client_config_cc_proto",
+        #"//src/istio/mixerclient:mixerclient_lib",
     ],
 )
 

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -74,6 +74,7 @@ const char AttributeName::kConnectionEvent[] = "connection.event";
 
 // Context attributes
 const char AttributeName::kContextProtocol[] = "context.protocol";
+const char AttributeName::kContextReporterKind[] = "context.reporter.kind";
 const char AttributeName::kContextTime[] = "context.time";
 const char AttributeName::kContextProxyErrorCode[] = "context.proxy_error_code";
 const char AttributeName::kContextReporterUID[] = "context.reporter.uid";

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -22,6 +22,7 @@ namespace utils {
 const char AttributeName::kSourceUser[] = "source.user";
 const char AttributeName::kSourcePrincipal[] = "source.principal";
 const char AttributeName::kSourceNamespace[] = "source.namespace";
+const char AttributeName::kSourceUID[] = "destination.uid";
 const char AttributeName::kDestinationPrincipal[] = "destination.principal";
 
 const char AttributeName::kRequestHeaders[] = "request.headers";
@@ -53,6 +54,7 @@ const char AttributeName::kSourcePort[] = "source.port";
 const char AttributeName::kDestinationIp[] = "destination.ip";
 const char AttributeName::kDestinationPort[] = "destination.port";
 const char AttributeName::kDestinationUID[] = "destination.uid";
+const char AttributeName::kDestinationNamespace[] = "destination.namespace";
 const char AttributeName::kOriginIp[] = "origin.ip";
 const char AttributeName::kConnectionReceviedBytes[] =
     "connection.received.bytes";
@@ -74,6 +76,7 @@ const char AttributeName::kConnectionEvent[] = "connection.event";
 const char AttributeName::kContextProtocol[] = "context.protocol";
 const char AttributeName::kContextTime[] = "context.time";
 const char AttributeName::kContextProxyErrorCode[] = "context.proxy_error_code";
+const char AttributeName::kContextReporterUID[] = "context.reporter.uid";
 
 // Check error code and message.
 const char AttributeName::kCheckErrorCode[] = "check.error_code";

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -22,7 +22,7 @@ namespace utils {
 const char AttributeName::kSourceUser[] = "source.user";
 const char AttributeName::kSourcePrincipal[] = "source.principal";
 const char AttributeName::kSourceNamespace[] = "source.namespace";
-const char AttributeName::kSourceUID[] = "destination.uid";
+const char AttributeName::kSourceUID[] = "source.uid";
 const char AttributeName::kDestinationPrincipal[] = "destination.principal";
 
 const char AttributeName::kRequestHeaders[] = "request.headers";

--- a/src/istio/utils/local_attributes.cc
+++ b/src/istio/utils/local_attributes.cc
@@ -43,7 +43,8 @@ std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
   ::istio::mixer::v1::Attributes forward;
   AttributesBuilder(&forward).AddString(AttributeName::kSourceUID, local.uid);
 
-  return std::make_unique<LocalAttributes>(inbound, outbound, forward);
+  return std::unique_ptr<LocalAttributes>(
+      new LocalAttributes(inbound, outbound, forward));
 }
 
 }  // namespace utils

--- a/src/istio/utils/local_attributes.cc
+++ b/src/istio/utils/local_attributes.cc
@@ -1,0 +1,50 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "include/istio/utils/local_attributes.h"
+#include "include/istio/utils/attribute_names.h"
+#include "include/istio/utils/attributes_builder.h"
+
+namespace istio {
+namespace utils {
+
+// create Local attributes object and return a pointer to it.
+// Should be freed by the caller.
+std::unique_ptr<const LocalAttributes> CreateLocalAttributes(
+    const LocalNode &local) {
+  ::istio::mixer::v1::Attributes inbound;
+  AttributesBuilder ib(&inbound);
+  ib.AddString(AttributeName::kDestinationUID, local.uid);
+  ib.AddString(AttributeName::kContextReporterUID, local.uid);
+  ib.AddString(AttributeName::kDestinationNamespace, local.ns);
+
+  if (!local.ip.empty()) {
+    // TODO: mjog check if destination.ip should be setup for inbound.
+  }
+
+  ::istio::mixer::v1::Attributes outbound;
+  AttributesBuilder ob(&outbound);
+  ob.AddString(AttributeName::kSourceUID, local.uid);
+  ob.AddString(AttributeName::kContextReporterUID, local.uid);
+  ob.AddString(AttributeName::kSourceNamespace, local.ns);
+
+  ::istio::mixer::v1::Attributes forward;
+  AttributesBuilder(&forward).AddString(AttributeName::kSourceUID, local.uid);
+
+  return std::make_unique<LocalAttributes>(inbound, outbound, forward);
+}
+
+}  // namespace utils
+}  // namespace istio


### PR DESCRIPTION
At present Pilot programs all attributes including proxy identity attributes like destination.uid / destination.namespace. This bloats the configuration and makes it difficult to cache.

1. This PR uses node metadata that is populated by proxy agent in boostrap to determine identity attributes.
2. It uses the old name parsing as a backup. 
