### PR TITLE
Fix a bug in origin authenticator that wrongly treats empty origin methods as pass

### DIFF
--- a/src/envoy/http/authn/origin_authenticator.cc
+++ b/src/envoy/http/authn/origin_authenticator.cc
@@ -92,7 +92,7 @@ bool OriginAuthenticator::run(Payload* payload) {
 
   // If none of the JWT triggered, origin authentication will be ignored, as if
   // it is not defined.
-  return !triggered || success;
+  return (policy_.origins_size() > 0 && !triggered) || success;
 }
 
 }  // namespace AuthN

--- a/src/envoy/http/authn/origin_authenticator_test.cc
+++ b/src/envoy/http/authn/origin_authenticator_test.cc
@@ -41,6 +41,14 @@ namespace Istio {
 namespace AuthN {
 namespace {
 
+const char kZeroOriginMethodPolicyBindPeer[] = R"(
+  principal_binding: USE_PEER
+)";
+
+const char kZeroOriginMethodPolicyBindOrigin[] = R"(
+  principal_binding: USE_ORIGIN
+)";
+
 const char kSingleOriginMethodPolicy[] = R"(
   principal_binding: USE_ORIGIN
   origins {
@@ -206,6 +214,34 @@ TEST_P(OriginAuthenticatorTest, Empty) {
     initial_result_.set_principal("bar");
   }
   EXPECT_TRUE(TestUtility::protoEqual(initial_result_,
+                                      filter_context_.authenticationResult()));
+}
+
+TEST_P(OriginAuthenticatorTest, ZeroMethodFail) {
+  ASSERT_TRUE(Protobuf::TextFormat::ParseFromString(
+      kZeroOriginMethodPolicyBindOrigin, &policy_));
+  createAuthenticator();
+  EXPECT_FALSE(authenticator_->run(payload_));
+}
+
+TEST_P(OriginAuthenticatorTest, ZeroMethodPass) {
+  ASSERT_TRUE(Protobuf::TextFormat::ParseFromString(
+      kZeroOriginMethodPolicyBindPeer, &policy_));
+  createAuthenticator();
+
+  Result expected_result = TestUtilities::AuthNResultFromString(R"(
+      origin {
+        user: "bar"
+        presenter: "istio.io"
+      }
+    )");
+  if (set_peer_) {
+    expected_result.set_principal("bar");
+    expected_result.set_peer_user("bar");
+  }
+
+  EXPECT_TRUE(authenticator_->run(&jwt_extra_payload_));
+  EXPECT_TRUE(TestUtility::protoEqual(expected_result,
                                       filter_context_.authenticationResult()));
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug in origin authenticator that wrongly treats empty origin methods as pass

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a

**Special notes for your reviewer**: n/a
