### PR TITLE
Update Envoy SHA to latest with TCP proxy fixes.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "cb892b4855bc9e8516ca5eece8098f56f77fe522"
+ENVOY_SHA = "f936fc60f488cfae07f5e5d20d7381f0f23482fe"
 
 http_archive(
     name = "envoy",

--- a/include/istio/control/http/BUILD
+++ b/include/istio/control/http/BUILD
@@ -23,5 +23,5 @@ cc_library(
         "request_handler.h",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//src/istio/authn:context_proto"],
+    deps = ["//src/istio/authn:context_proto_cc"],
 )

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "cb892b4855bc9e8516ca5eece8098f56f77fe522"
+		"lastStableSHA": "f936fc60f488cfae07f5e5d20d7381f0f23482fe"
 	}
 ]

--- a/src/envoy/http/authn/BUILD
+++ b/src/envoy/http/authn/BUILD
@@ -45,7 +45,7 @@ envoy_cc_library(
         "//external:authentication_policy_config_cc_proto",
         "//src/envoy/http/jwt_auth:jwt_lib",
         "//src/envoy/utils:utils_lib",
-        "//src/istio/authn:context_proto",
+        "//src/istio/authn:context_proto_cc",
         "//src/envoy/utils:filter_names_lib",
     ],
 )
@@ -65,7 +65,7 @@ envoy_cc_library(
         "//external:authentication_policy_config_cc_proto",
         "//src/envoy/utils:authn_lib",
         "//src/envoy/utils:utils_lib",
-        "//src/istio/authn:context_proto",
+        "//src/istio/authn:context_proto_cc",
         "@envoy//source/exe:envoy_common_lib",
         "//src/envoy/utils:filter_names_lib",
     ],
@@ -76,7 +76,7 @@ envoy_cc_test_library(
     hdrs = ["test_utils.h"],
     repository = "@envoy",
     deps = [
-        "//src/istio/authn:context_proto",
+        "//src/istio/authn:context_proto_cc",
     ],
 )
 

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -30,9 +30,9 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
                  const LocalInfo::LocalInfo& local_info)
     : config_(config),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.check_cluster(), cm, scope)),
+          config_.check_cluster(), cm, scope, dispatcher.timeSource())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.report_cluster(), cm, scope)),
+          config_.report_cluster(), cm, scope, dispatcher.timeSource())),
       stats_obj_(dispatcher, stats,
                  config_.config_pb().transport().stats_update_interval(),
                  [this](::istio::mixerclient::Statistics* stat) -> bool {

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -29,9 +29,9 @@ Control::Control(const Config& config, Upstream::ClusterManager& cm,
     : config_(config),
       dispatcher_(dispatcher),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.check_cluster(), cm, scope)),
+          config_.check_cluster(), cm, scope, dispatcher.timeSource())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.report_cluster(), cm, scope)),
+          config_.report_cluster(), cm, scope, dispatcher.timeSource())),
       stats_obj_(dispatcher, stats,
                  config_.config_pb().transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool { return GetStats(stat); }),

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -34,7 +34,7 @@ envoy_cc_library(
     deps = [
         ":utils_lib",
         "//include/istio/utils:attribute_names_header",
-        "//src/istio/authn:context_proto",
+        "//src/istio/authn:context_proto_cc",
         "//src/istio/utils:attribute_names_lib",
         "//src/istio/utils:utils_lib",
         ":filter_names_lib",

--- a/src/envoy/utils/mixer_control.h
+++ b/src/envoy/utils/mixer_control.h
@@ -41,7 +41,7 @@ void SerializeForwardedAttributes(
 
 Grpc::AsyncClientFactoryPtr GrpcClientFactoryForCluster(
     const std::string &cluster_name, Upstream::ClusterManager &cm,
-    Stats::Scope &scope);
+    Stats::Scope &scope, TimeSource &time_source);
 
 bool ExtractNodeInfo(const envoy::api::v2::core::Node &node,
                      ::istio::utils::LocalNode *args);

--- a/src/istio/control/http/BUILD
+++ b/src/istio/control/http/BUILD
@@ -33,7 +33,7 @@ cc_library(
         "//include/istio/control/http:headers_lib",
         "//include/istio/utils:attribute_names_header",
         "//src/istio/api_spec:api_spec_lib",
-        "//src/istio/authn:context_proto",
+        "//src/istio/authn:context_proto_cc",
         "//src/istio/control:common_lib",
         "//src/istio/utils:attribute_names_lib",
         "//src/istio/utils:utils_lib",


### PR DESCRIPTION
Pulling the following changes from github.com/envoyproxy/envoy:

f936fc60f ssl: serialize accesses to SSL socket factory contexts (#4345)
e34dcd62a Fix crash in tcp_proxy (#4323)
ae6a25222 router: fix matching when all domains have wildcards (#4326)
aa06142ff test: Stop fake_upstream methods from accidentally succeeding (#4232)
5d731878f rbac: update the authenticated.user to a StringMatcher. (#4250)
c6bfc7d9a time: Event::TimeSystem abstraction to make it feasible to inject time with simulated timers (#4257)
752483ea9 Fixing the fix (#4333)
83487f6f3 tls: update BoringSSL to ab36a84b (3497). (#4338)
7bc210e02 test: fixing interactions between waitFor and ignore_spurious_events (#4309)
69474b398 admin: order stats in clusters json admin (#4306)
2d155f901 ppc64le build (#4183)
07efc6dc6 fix static initialization fiasco problem (#4314)
0b7e3b5e0 test: Remove declared but undefined class methods (#4297)
1485a1304 lua: make sure resetting dynamic metadata wrapper when request info is marked dead
d243cd62e test: set to zero when start_time exceeds limit (#4328)
0a1e92acc test: fix heap use-after-free in ~IntegrationTestServer. (#4319)
cddc732c7 CONTRIBUTING: Document 'kick-ci' trick. (#4335)
f13ef2464 docs: remove reference to deprecated value field (#4322)
e947a2766 router: minor doc fixes in stream idle timeout (#4329)
0c2e998af tcp-proxy: fixing a TCP proxy bug where we attempted to readDisable a closed connection (#4296)
00ffe44a2 utility: fix strftime overflow handling. (#4321)
af1183c28 Re-enable TcpProxySslIntegrationTest and make the tests pass again. (#4318)
35534617b fuzz: fix H2 codec fuzzer post #4262. (#4311)
42f604853 Proto string issue fix (#4320)
9c492a01d Support Envoy to fetch secrets using SDS service. (#4256)
a8572192f ratelimit: revert `revert rate limit failure mode config` and add tests (#4303)
1d34172bd dns: fix exception unsafe behavior in c-ares callbacks. (#4307)
121242340 alts: add gRPC TSI socket (#4153)
f0363ae63 fuzz: detect client-side resets in H2 codec fuzzer. (#4300)
01aa3f820 test: hopefully deflaking echo integration test (#4304)
1fc0f4ba2 ratelimit: link legacy proto when message is being used (#4308)
aa4481e6b fix rare List::remove(&target) segfault (#4244)
89e0f23ba headers: fixing fast fail of size-validation (#4269)
97eba5918 build: bump googletest version. (#4293)
0057e22d9 fuzz: avoid false positives in HCM fuzzer. (#4262)
9d094e590 Revert ac0bd74f6f9716e3a44d1412f795317c30ca770a (#4295)
ddb28a4a1 Add validation context provider (#4264)
3b47cbabb added histogram latency information to Hystrix dashboard stream (#3986)
cf87d50cd docs: update SNI FAQ. (#4285)
f952033a4 config: fix update empty stat for eds (#4276)
329e591d3 router: Add ability of custom headers to rely on per-request data (#4219)
68d20b46c  thrift: refactor build files and imports (#4271)
5fa8192a3 access_log: log requested_server_name in tcp proxy (#4144)
fa45bb48f fuzz: libc++ clocks don't like nanos. (#4282)
53f8944f7 stats: add symbol table for future stat name encoding (#3927)
c987b425b test infra: Remove timeSource() from the ClusterManager api (#4247)
cd171d9a9 websocket: tunneling websockets (and upgrades in general) over H2 (#4188)
b9dc5d9a0 router: disallow :path/host rewriting in request_headers_to_add. (#4220)
0c9101127 network: skip socket options and source address for UDS client connections (#4252)
da1857d59 build: fixing a downstream compile error by noting explicit fallthrough (#4265)
9857cfe2a fuzz: cleanup per-test environment after each fuzz case. (#4253)
52beb067d test: Wrap proto string in std::string before comparison (#4238)
f5e219edc extensions/thrift_proxy: Add header matching to thrift router (#4239)
c9ce5d2b1 fuzz: track read_disable_count bidirectionally in codec_impl_fuzz_test. (#4260)
35103b353 fuzz: use nanoseconds for SystemTime in RequestInfo. (#4255)
ba6ba9883 fuzz: make runtime root hermetic in server_fuzz_test. (#4258)
b0a901480 time: Add 'format' test to ensure no one directly instantiates Prod*Time from source. (#4248)
85674603b access_log: support beginning of epoch in START_TIME. (#4254)
28d5f4118 proto: unify envoy_proto_library/api_proto_library. (#4233)
f7d3cb638 http: fix allocation bug introduced in #4211. (#4245)

Fixes istio/istio#8310 (once pulled into istio/istio).

Signed-off-by: Piotr Sikora <piotrsikora@google.com>