### PR TITLE
Back port the fix for peerIsOptional/originIsOptional to 1.0 branch 

### DIFF
--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -52,16 +52,16 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
 
   Payload payload;
 
-  if (!filter_config_.policy().peer_is_optional() &&
-      !createPeerAuthenticator(filter_context_.get())->run(&payload)) {
+  if (!createPeerAuthenticator(filter_context_.get())->run(&payload) &&
+      !filter_config_.policy().peer_is_optional()) {
     rejectRequest("Peer authentication failed.");
     removeJwtPayloadFromHeaders();
     return FilterHeadersStatus::StopIteration;
   }
 
   bool success =
-      filter_config_.policy().origin_is_optional() ||
-      createOriginAuthenticator(filter_context_.get())->run(&payload);
+      createOriginAuthenticator(filter_context_.get())->run(&payload) ||
+      filter_config_.policy().origin_is_optional();
 
   // After Istio authn, the JWT headers consumed by Istio authn should be
   // removed.

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -126,7 +126,7 @@ TEST_F(AuthenticationFilterTest, PeerFail) {
   EXPECT_FALSE(Utils::Authentication::HasResultInHeader(request_headers_));
 }
 
-TEST_F(AuthenticationFilterTest, PeerPassOrginFail) {
+TEST_F(AuthenticationFilterTest, PeerPassOriginFail) {
   // Peer pass thus origin authentication must be called. Final result should
   // fail as origin authn fails.
   EXPECT_CALL(filter_, createPeerAuthenticator(_))
@@ -168,8 +168,66 @@ TEST_F(AuthenticationFilterTest, IgnoreBothFail) {
   *filter_config_.mutable_policy() = policy_;
   StrictMock<MockAuthenticationFilter> filter(filter_config_);
   filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  EXPECT_CALL(filter, createPeerAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysFailAuthenticator));
+  EXPECT_CALL(filter, createOriginAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysFailAuthenticator));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
             filter.decodeHeaders(request_headers_, true));
+}
+
+TEST_F(AuthenticationFilterTest, IgnoreBothPass) {
+  iaapi::Policy policy_;
+  ASSERT_TRUE(
+      Protobuf::TextFormat::ParseFromString(ingoreBothPolicy, &policy_));
+  *filter_config_.mutable_policy() = policy_;
+  StrictMock<MockAuthenticationFilter> filter(filter_config_);
+  filter.setDecoderFilterCallbacks(decoder_callbacks_);
+
+  EXPECT_CALL(filter, createPeerAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysPassAuthenticator));
+  EXPECT_CALL(filter, createOriginAuthenticator(_))
+      .Times(1)
+      .WillOnce(Invoke(createAlwaysPassAuthenticator));
+  RequestInfo::RequestInfoImpl request_info(Http::Protocol::Http2);
+  EXPECT_CALL(decoder_callbacks_, requestInfo())
+      .Times(AtLeast(1))
+      .WillRepeatedly(ReturnRef(request_info));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue,
+            filter.decodeHeaders(request_headers_, true));
+
+  EXPECT_EQ(1, request_info.dynamicMetadata().filter_metadata_size());
+  const auto *data = Utils::Authentication::GetResultFromMetadata(
+      request_info.dynamicMetadata());
+  ASSERT_TRUE(data);
+
+  ProtobufWkt::Struct expected_data;
+  ASSERT_TRUE(Protobuf::TextFormat::ParseFromString(R"(
+       fields {
+         key: "source.namespace"
+         value {
+           string_value: "test_ns"
+         }
+       }
+       fields {
+         key: "source.principal"
+         value {
+           string_value: "cluster.local/sa/test_user/ns/test_ns/"
+         }
+       }
+       fields {
+         key: "source.user"
+         value {
+           string_value: "cluster.local/sa/test_user/ns/test_ns/"
+         }
+       })",
+                                                    &expected_data));
+  EXPECT_TRUE(TestUtility::protoEqual(expected_data, *data));
 }
 
 }  // namespace

--- a/src/envoy/http/authn/origin_authenticator_test.cc
+++ b/src/envoy/http/authn/origin_authenticator_test.cc
@@ -27,13 +27,13 @@ namespace iaapi = istio::authentication::v1alpha1;
 
 using istio::authn::Payload;
 using istio::authn::Result;
+using testing::_;
 using testing::DoAll;
 using testing::MockFunction;
 using testing::NiceMock;
 using testing::Return;
 using testing::SetArgPointee;
 using testing::StrictMock;
-using testing::_;
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/authn/peer_authenticator_test.cc
+++ b/src/envoy/http/authn/peer_authenticator_test.cc
@@ -26,13 +26,13 @@
 namespace iaapi = istio::authentication::v1alpha1;
 
 using istio::authn::Payload;
+using testing::_;
 using testing::DoAll;
 using testing::MockFunction;
 using testing::NiceMock;
 using testing::Return;
 using testing::SetArgPointee;
 using testing::StrictMock;
-using testing::_;
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -22,9 +22,9 @@
 
 using ::istio::envoy::config::filter::http::jwt_auth::v2alpha1::
     JwtAuthentication;
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::NiceMock;
-using ::testing::_;
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/token_extractor_test.cc
+++ b/src/envoy/http/jwt_auth/token_extractor_test.cc
@@ -19,9 +19,9 @@
 
 using ::istio::envoy::config::filter::http::jwt_auth::v2alpha1::
     JwtAuthentication;
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::NiceMock;
-using ::testing::_;
 
 namespace Envoy {
 namespace Http {

--- a/src/istio/api_spec/http_api_spec_parser_test.cc
+++ b/src/istio/api_spec/http_api_spec_parser_test.cc
@@ -27,8 +27,8 @@ using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::config::client::HTTPAPISpec;
 using ::istio::utils::AttributesBuilder;
 
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace api_spec {

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -28,8 +28,8 @@ using ::google::protobuf::util::MessageDifferencer;
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::Attributes_StringMap;
 
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace control {

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -35,8 +35,8 @@ using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
 using ::istio::quota_config::Requirement;
 
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace control {

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -26,9 +26,9 @@
 using ::google::protobuf::TextFormat;
 using ::google::protobuf::util::MessageDifferencer;
 
+using ::testing::_;
 using ::testing::Invoke;
 using ::testing::Return;
-using ::testing::_;
 
 namespace istio {
 namespace control {

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -31,8 +31,8 @@ using ::istio::mixerclient::MixerClient;
 using ::istio::mixerclient::TransportCheckFunc;
 using ::istio::quota_config::Requirement;
 
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace control {

--- a/src/istio/mixerclient/client_impl_test.cc
+++ b/src/istio/mixerclient/client_impl_test.cc
@@ -27,8 +27,8 @@ using ::istio::mixer::v1::CheckRequest;
 using ::istio::mixer::v1::CheckResponse;
 using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::quota_config::Requirement;
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace mixerclient {

--- a/src/istio/mixerclient/quota_cache_test.cc
+++ b/src/istio/mixerclient/quota_cache_test.cc
@@ -27,8 +27,8 @@ using ::istio::mixer::v1::CheckRequest;
 using ::istio::mixer::v1::CheckResponse;
 using ::istio::mixer::v1::ReferencedAttributes;
 using ::istio::quota_config::Requirement;
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace mixerclient {

--- a/src/istio/mixerclient/report_batch_test.cc
+++ b/src/istio/mixerclient/report_batch_test.cc
@@ -23,8 +23,8 @@ using ::google::protobuf::util::error::Code;
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::ReportRequest;
 using ::istio::mixer::v1::ReportResponse;
-using ::testing::Invoke;
 using ::testing::_;
+using ::testing::Invoke;
 
 namespace istio {
 namespace mixerclient {


### PR DESCRIPTION
**What this PR does / why we need it**: In order to cherrypick this fix into Istio 1.0.3, we need back port the fix to 1.0 branch first.

**Which issue this PR fixes**: The same as #1959 

**Special notes for your reviewer**: I manually excluded the test case `IgnoreBothPass` added in #1959 as it has dependencies on some other PRs in master branch which I think is too big  to cherrypick to 1.0 branch.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed a bug for the peerIsOptional/originIsOptional flag in authentication policy that didn't pass generated attributes when set to true. (#1892 #1958)
```
