### PR TITLE
To share mixer client across listeners

### DIFF
--- a/src/envoy/http/mixer/config.h
+++ b/src/envoy/http/mixer/config.h
@@ -45,6 +45,7 @@ class Config {
   // The Http client config.
   ::istio::mixer::v1::config::client::HttpClientConfig config_pb_;
 };
+typedef std::unique_ptr<Config> ConfigPtr;
 
 }  // namespace Mixer
 }  // namespace Http

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -63,6 +63,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
   // This stats object.
   Utils::MixerFilterStats stats_;
 };
+typedef std::shared_ptr<ControlFactory> ControlFactorySharedPtr;
 
 }  // namespace Mixer
 }  // namespace Http

--- a/src/envoy/http/mixer/filter_factory.cc
+++ b/src/envoy/http/mixer/filter_factory.cc
@@ -75,10 +75,8 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
   Http::FilterFactoryCb createFilterFactory(const HttpClientConfig& config_pb,
                                             const std::string&,
                                             FactoryContext& context) {
-    std::unique_ptr<Http::Mixer::Config> config_obj(
-        new Http::Mixer::Config(config_pb));
-    auto control_factory = std::make_shared<Http::Mixer::ControlFactory>(
-        std::move(config_obj), context);
+    auto config_obj = std::make_unique<Http::Mixer::Config>(config_pb);
+    auto control_factory = getControlFactory(std::move(config_obj), context);
     return [control_factory](
                Http::FilterChainFactoryCallbacks& callbacks) -> void {
       std::shared_ptr<Http::Mixer::Filter> instance =
@@ -87,6 +85,23 @@ class MixerConfigFactory : public NamedHttpFilterConfigFactory {
       callbacks.addAccessLogHandler(AccessLog::InstanceSharedPtr(instance));
     };
   }
+
+  Http::Mixer::ControlFactorySharedPtr getControlFactory(
+      Http::Mixer::ConfigPtr config_obj, FactoryContext& context) {
+    const std::string hash = config_obj->config_pb().SerializeAsString();
+    Http::Mixer::ControlFactorySharedPtr control_factory =
+        control_factory_maps_[hash].lock();
+    if (!control_factory) {
+      control_factory = std::make_shared<Http::Mixer::ControlFactory>(
+          std::move(config_obj), context);
+      control_factory_maps_[hash] = control_factory;
+    }
+    return control_factory;
+  }
+
+  // A weak pointer map to share control factory across different listeners.
+  std::unordered_map<std::string, std::weak_ptr<Http::Mixer::ControlFactory>>
+      control_factory_maps_;
 };
 
 static Registry::RegisterFactory<MixerConfigFactory,

--- a/src/envoy/tcp/mixer/config.h
+++ b/src/envoy/tcp/mixer/config.h
@@ -78,6 +78,7 @@ class Config {
   // Time interval in milliseconds for sending periodical delta reports.
   std::chrono::milliseconds report_interval_ms_;
 };
+typedef std::unique_ptr<Config> ConfigPtr;
 
 }  // namespace Mixer
 }  // namespace Tcp

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -70,6 +70,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
   // UUID of the Envoy TCP mixer filter.
   const std::string uuid_;
 };
+typedef std::shared_ptr<ControlFactory> ControlFactorySharedPtr;
 
 }  // namespace Mixer
 }  // namespace Tcp


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

**What this PR does / why we need it**:

Now one mixer client is created for each listeners.  But many listeners share same mixer filter config, they can be shared.   
With this change,  mixer_client is still created per-thread.

**Release note**:
```release-note
None
```
