### PR TITLE
Optimize report sending by re-use protobuf

### DIFF
--- a/src/istio/mixerclient/attribute_compressor.h
+++ b/src/istio/mixerclient/attribute_compressor.h
@@ -56,7 +56,10 @@ class BatchCompressor {
   virtual int size() const = 0;
 
   // Finish the batch and create the batched report request.
-  virtual std::unique_ptr<::istio::mixer::v1::ReportRequest> Finish() = 0;
+  virtual const ::istio::mixer::v1::ReportRequest& Finish() = 0;
+
+  // Reset the object data.
+  virtual void Clear() = 0;
 };
 
 // Compress attributes.

--- a/src/istio/mixerclient/attribute_compressor_test.cc
+++ b/src/istio/mixerclient/attribute_compressor_test.cc
@@ -337,14 +337,14 @@ TEST_F(AttributeCompressorTest, BatchCompressTest) {
   auto report_pb = batch_compressor->Finish();
 
   std::string out_str;
-  TextFormat::PrintToString(*report_pb, &out_str);
+  TextFormat::PrintToString(report_pb, &out_str);
   GOOGLE_LOG(INFO) << "===" << out_str << "===";
 
   ::istio::mixer::v1::ReportRequest expected_report_pb;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kReportAttributes, &expected_report_pb));
-  report_pb->set_global_word_count(221);
-  EXPECT_TRUE(MessageDifferencer::Equals(*report_pb, expected_report_pb));
+  report_pb.set_global_word_count(221);
+  EXPECT_TRUE(MessageDifferencer::Equals(report_pb, expected_report_pb));
 }
 
 }  // namespace

--- a/src/istio/mixerclient/report_batch_test.cc
+++ b/src/istio/mixerclient/report_batch_test.cc
@@ -65,7 +65,7 @@ class ReportBatchTest : public ::testing::Test {
     };
   }
 
-  MockReportTransport mock_report_transport_;
+  ::testing::NiceMock<MockReportTransport> mock_report_transport_;
   MockTimer* mock_timer_;
   AttributeCompressor compressor_;
   std::unique_ptr<ReportBatch> batch_;


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

**What this PR does / why we need it**:

Experience shows that protobuf message building is slow, especially in this small memory allocation.
There are two ways to improve it.  1) use arena allocator or 2) re-use the protobuf 

This PR will try to re-use report protobuf.  By using the same BatchCompressor object.  

**Release note**:
```release-note
None
```
