### PR TITLE
Fix a bug of not setting global_word_count

### DIFF
--- a/src/istio/mixerclient/attribute_compressor.cc
+++ b/src/istio/mixerclient/attribute_compressor.cc
@@ -126,9 +126,7 @@ void CompressByDict(const Attributes& attributes, MessageDictionary& dict,
 class BatchCompressorImpl : public BatchCompressor {
  public:
   BatchCompressorImpl(const GlobalDictionary& global_dict)
-      : dict_(global_dict) {
-    report_.set_global_word_count(global_dict.size());
-  }
+      : dict_(global_dict), global_dict_size_(global_dict.size()) {}
 
   void Add(const Attributes& attributes) override {
     CompressByDict(attributes, dict_, report_.add_attributes());
@@ -140,6 +138,7 @@ class BatchCompressorImpl : public BatchCompressor {
     for (const std::string& word : dict_.GetWords()) {
       report_.add_default_words(word);
     }
+    report_.set_global_word_count(global_dict_size_);
     return report_;
   }
 
@@ -150,6 +149,7 @@ class BatchCompressorImpl : public BatchCompressor {
 
  private:
   MessageDictionary dict_;
+  int global_dict_size_;
   ::istio::mixer::v1::ReportRequest report_;
 };
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

**What this PR does / why we need it**:

https://github.com/istio/proxy/pull/1973 introduced a bug:
Report protobuf is re-used.  Its word_count only set at the first time. then each time it is Clear() ed
but word_count was not set

This PR fixes it.


**Release note**:
```release-note
None
```
