### PR TITLE
Revert "To share mixer client across listeners (#1972)"

### DIFF
--- a/src/envoy/http/mixer/config.h
+++ b/src/envoy/http/mixer/config.h
@@ -45,7 +45,6 @@ class Config {
   // The Http client config.
   ::istio::mixer::v1::config::client::HttpClientConfig config_pb_;
 };
-typedef std::unique_ptr<Config> ConfigPtr;
 
 }  // namespace Mixer
 }  // namespace Http

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -63,7 +63,6 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
   // This stats object.
   Utils::MixerFilterStats stats_;
 };
-typedef std::shared_ptr<ControlFactory> ControlFactorySharedPtr;
 
 }  // namespace Mixer
 }  // namespace Http

--- a/src/envoy/tcp/mixer/config.h
+++ b/src/envoy/tcp/mixer/config.h
@@ -78,7 +78,6 @@ class Config {
   // Time interval in milliseconds for sending periodical delta reports.
   std::chrono::milliseconds report_interval_ms_;
 };
-typedef std::unique_ptr<Config> ConfigPtr;
 
 }  // namespace Mixer
 }  // namespace Tcp

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -70,7 +70,6 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
   // UUID of the Envoy TCP mixer filter.
   const std::string uuid_;
 };
-typedef std::shared_ptr<ControlFactory> ControlFactorySharedPtr;
 
 }  // namespace Mixer
 }  // namespace Tcp

--- a/src/envoy/tcp/mixer/filter_factory.cc
+++ b/src/envoy/tcp/mixer/filter_factory.cc
@@ -52,8 +52,11 @@ class FilterFactory : public NamedNetworkFilterConfigFactory {
  private:
   Network::FilterFactoryCb createFilterFactory(const TcpClientConfig& config_pb,
                                                FactoryContext& context) {
-    auto config_obj = std::make_unique<Tcp::Mixer::Config>(config_pb);
-    auto control_factory = getControlFactory(std::move(config_obj), context);
+    std::unique_ptr<Tcp::Mixer::Config> config_obj(
+        new Tcp::Mixer::Config(config_pb));
+
+    auto control_factory = std::make_shared<Tcp::Mixer::ControlFactory>(
+        std::move(config_obj), context);
     return [control_factory](Network::FilterManager& filter_manager) -> void {
       std::shared_ptr<Tcp::Mixer::Filter> instance =
           std::make_shared<Tcp::Mixer::Filter>(control_factory->control());
@@ -61,23 +64,6 @@ class FilterFactory : public NamedNetworkFilterConfigFactory {
       filter_manager.addWriteFilter(Network::WriteFilterSharedPtr(instance));
     };
   }
-
-  Tcp::Mixer::ControlFactorySharedPtr getControlFactory(
-      Tcp::Mixer::ConfigPtr config_obj, FactoryContext& context) {
-    const std::string hash = config_obj->config_pb().SerializeAsString();
-    Tcp::Mixer::ControlFactorySharedPtr control_factory =
-        control_factory_maps_[hash].lock();
-    if (!control_factory) {
-      control_factory = std::make_shared<Tcp::Mixer::ControlFactory>(
-          std::move(config_obj), context);
-      control_factory_maps_[hash] = control_factory;
-    }
-    return control_factory;
-  }
-
-  // A weak pointer map to share control factory across different listeners.
-  std::unordered_map<std::string, std::weak_ptr<Tcp::Mixer::ControlFactory>>
-      control_factory_maps_;
 };
 
 static Registry::RegisterFactory<FilterFactory, NamedNetworkFilterConfigFactory>


### PR DESCRIPTION
This reverts commit b33ceb25059d9f83589df5607c09bbacca51f912.

FactoryContext maybe is per listener, and should not be shared across listeners.

```release-note
NONE
```
