### PR TITLE
[typo-fix] typo of the variable use_count -> wrote use_cound instead

### DIFF
--- a/src/istio/mixerclient/check_cache.h
+++ b/src/istio/mixerclient/check_cache.h
@@ -148,7 +148,7 @@ class CheckCache {
     std::chrono::time_point<std::chrono::system_clock> expire_time_;
     // if -1, not to check use_count.
     // if 0, cache item should not be used.
-    // use_cound is decreased by 1 for each request,
+    // use_count is decreased by 1 for each request,
     int use_count_;
   };
 


### PR DESCRIPTION
Just found this typo as I went through the code trying to learn Istio's internals.
