### PR TITLE
Update Envoy SHA to 811ee0dc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "a637506da5f55f0bec37701d9e0a04f1179a6bfb"
+ENVOY_SHA = "811ee0dc52951acf2f66190587f92394473c245c"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "a637506da5f55f0bec37701d9e0a04f1179a6bfb"
+		"lastStableSHA": "811ee0dc52951acf2f66190587f92394473c245c"
 	}
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Envoy SHA to [811ee0dc](https://github.com/envoyproxy/envoy/commit/811ee0dc52951acf2f66190587f92394473c245c) in order to make the RBAC permissions change available in the Istio Proxy.

**Release note**:
NONE