### PR TITLE
Fix attribute constant

### DIFF
--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -66,8 +66,8 @@ struct AttributeName {
   static const char kDestinationUID[];
   static const char kDestinationNamespace[];
   static const char kOriginIp[];
-  static const char kConnectionReceviedBytes[];
-  static const char kConnectionReceviedTotalBytes[];
+  static const char kConnectionReceivedBytes[];
+  static const char kConnectionReceivedTotalBytes[];
   static const char kConnectionSendBytes[];
   static const char kConnectionSendTotalBytes[];
   static const char kConnectionDuration[];

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -87,9 +87,9 @@ void AttributesBuilder::ExtractReportAttributes(
 
   ReportData::ReportInfo info;
   report_data->GetReportInfo(&info);
-  builder.AddInt64(utils::AttributeName::kConnectionReceviedBytes,
+  builder.AddInt64(utils::AttributeName::kConnectionReceivedBytes,
                    info.received_bytes - last_report_info->received_bytes);
-  builder.AddInt64(utils::AttributeName::kConnectionReceviedTotalBytes,
+  builder.AddInt64(utils::AttributeName::kConnectionReceivedTotalBytes,
                    info.received_bytes);
   builder.AddInt64(utils::AttributeName::kConnectionSendBytes,
                    info.send_bytes - last_report_info->send_bytes);

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -56,9 +56,9 @@ const char AttributeName::kDestinationPort[] = "destination.port";
 const char AttributeName::kDestinationUID[] = "destination.uid";
 const char AttributeName::kDestinationNamespace[] = "destination.namespace";
 const char AttributeName::kOriginIp[] = "origin.ip";
-const char AttributeName::kConnectionReceviedBytes[] =
+const char AttributeName::kConnectionReceivedBytes[] =
     "connection.received.bytes";
-const char AttributeName::kConnectionReceviedTotalBytes[] =
+const char AttributeName::kConnectionReceivedTotalBytes[] =
     "connection.received.bytes_total";
 const char AttributeName::kConnectionSendBytes[] = "connection.sent.bytes";
 const char AttributeName::kConnectionSendTotalBytes[] =


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a misspelling in the attribute constants.

```release-note
NONE
```
