### PR TITLE
Update bazel for circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gcr.io/istio/ci:go1.10-bazel0.15-clang6.0
+      - image: gcr.io/istio/ci:go1.10-bazel0.18-clang6.0
     environment:
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all"
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: istio/ci:go1.10-bazel0.15-clang6.0
+      - image: gcr.io/istio/ci:go1.10-bazel0.15-clang6.0
     environment:
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all"
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: gcr.io/istio/ci:go1.10-bazel0.18-clang6.0
+      - image: istio/ci:go1.10-bazel0.18-clang6.0
     environment:
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all"
     resource_class: xlarge


### PR DESCRIPTION
**What this PR does / why we need it**:
Update bazel to 0.18 for circleCI. This is to fix compile issue found in https://github.com/istio/proxy/pull/1993

```release-note
NONE
```
