### PR TITLE
update envoy SHA to point to json access log format functionality

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "8607e912a1df840da1080b7b0d4a9ed6bc247c39"
+ENVOY_SHA = "de039269f54aa21aa0da21da89a5075aa3db3bb9"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "8607e912a1df840da1080b7b0d4a9ed6bc247c39"
+		"lastStableSHA": "de039269f54aa21aa0da21da89a5075aa3db3bb9"
 	}
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Corresponds to https://github.com/envoyproxy/envoy/pull/4693

Picks up functionality for configuring access logs to be formatted as json