### PR TITLE
bump Envoy SHA to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "de039269f54aa21aa0da21da89a5075aa3db3bb9"
+ENVOY_SHA = "00c909c8640eab732c2c49c32896702978ff638e"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "de039269f54aa21aa0da21da89a5075aa3db3bb9"
+		"lastStableSHA": "00c909c8640eab732c2c49c32896702978ff638e"
 	}
 ]


### PR DESCRIPTION
Last SHA update was Oct 11. Lots of fixes went in, in addition
to the ability to get handle on StreamInfo via Connection object,
mutable filter state, retry policies, updated WebSocket stuff, etc.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>