### PR TITLE
Fix mac test fail: remove tests to compare signature values

### DIFF
--- a/src/istio/mixerclient/referenced_test.cc
+++ b/src/istio/mixerclient/referenced_test.cc
@@ -176,8 +176,6 @@ TEST(ReferencedTest, FillSuccessTest) {
             "target.service, Exact-keys: bool-key, bytes-key, double-key, "
             "duration-key, int-key, string-key, string-map-key[If-Match], "
             "time-key, ");
-
-  EXPECT_EQ(referenced.Hash(), 15726019709841724427U);
 }
 
 TEST(ReferencedTest, FillFail1Test) {
@@ -247,8 +245,6 @@ TEST(ReferencedTest, OKSignature1Test) {
 
   utils::HashType signature;
   EXPECT_TRUE(referenced.Signature(attributes, "extra", &signature));
-
-  EXPECT_EQ(signature, 7485122822970549717U);
 }
 
 TEST(ReferencedTest, StringMapReferencedTest) {
@@ -269,7 +265,6 @@ TEST(ReferencedTest, StringMapReferencedTest) {
 
   utils::HashType signature;
   EXPECT_TRUE(referenced.Signature(attrs, "extra", &signature));
-  EXPECT_EQ(signature, 5578853713114714386U);
 
   // negative test: map-key3 must absence
   ::istio::mixer::v1::Attributes attr1(attrs);


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

**What this PR does / why we need it**:

Signature value is different between different platform.  It should NOT be compared in the test.

**Release note**:
```release-note
None
```
