### PR TITLE
Update TCP Cluster Rewrite filter name

### DIFF
--- a/src/envoy/tcp/tcp_cluster_rewrite/config.h
+++ b/src/envoy/tcp/tcp_cluster_rewrite/config.h
@@ -44,7 +44,9 @@ class TcpClusterRewriteFilterConfigFactory
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 
-  std::string name() override { return "tcp_cluster_rewrite"; }
+  std::string name() override {
+    return "envoy.filters.network.tcp_cluster_rewrite";
+  }
 
  private:
   Network::FilterFactoryCb createFilterFactory(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the TCP Cluster Rewrite filter name to `envoy.filters.network.tcp_cluster_rewrite`.

**Release note**:
```release-note
NONE
```
