### PR TITLE
Enable TCP Cluster Rewrite filter registration

### DIFF
--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -29,7 +29,7 @@ envoy_cc_binary(
         "//src/envoy/http/jwt_auth:http_filter_factory",
         "//src/envoy/http/mixer:filter_lib",
         "//src/envoy/tcp/mixer:filter_lib",
-        "//src/envoy/tcp/tcp_cluster_rewrite:tcp_cluster_rewrite_lib",
+        "//src/envoy/tcp/tcp_cluster_rewrite:config_lib",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the static registration of the TCP Cluster Rewrite filter by updating the build configuration.

**Release note**:
```release-note
NONE
```

/cc @lizan @rshriram