### PR TITLE
Update Envoy SHA to 4ef8562b

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "45a460fabf34698a875060482de96f7f618bdc9f"
+ENVOY_SHA = "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "45a460fabf34698a875060482de96f7f618bdc9f"
+		"lastStableSHA": "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
 	}
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Envoy `/server_info` API was inconsistent intermittently causing errors on a Proxy update on Istio. This update will bring in the API fix to Istio.

**Release note**:
```release-note
NONE
```
