### PR TITLE
Update Envoy SHA to 4ef8562b (#2023)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "45a460fabf34698a875060482de96f7f618bdc9f"
+ENVOY_SHA = "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "45a460fabf34698a875060482de96f7f618bdc9f"
+		"lastStableSHA": "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
 	}
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry-picks the Envoy update PR #2023 to fix an issue with the `/server_info` API.

**Release note**:
```release-note
NONE
```