### PR TITLE
Update Envoy SHA to 74de08a0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
+ENVOY_SHA = "74de08a0d4d31bd466639d25d681df5d290bb770"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "4ef8562b2194f222ce8a3d733fb04c629eaf0667"
+		"lastStableSHA": "74de08a0d4d31bd466639d25d681df5d290bb770"
 	}
 ]

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -108,8 +108,8 @@ void AuthenticationFilter::rejectRequest(const std::string& message) {
     return;
   }
   state_ = State::REJECTED;
-  decoder_callbacks_->sendLocalReply(Http::Code::Unauthorized, message,
-                                     nullptr);
+  decoder_callbacks_->sendLocalReply(Http::Code::Unauthorized, message, nullptr,
+                                     absl::nullopt);
 }
 
 std::unique_ptr<Istio::AuthN::AuthenticatorBase>

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -63,7 +63,7 @@ void JwtVerificationFilter::onDone(const JwtAuth::Status& status) {
     Code code = Code(401);  // Unauthorized
     // return failure reason as message body
     decoder_callbacks_->sendLocalReply(code, JwtAuth::StatusToString(status),
-                                       nullptr);
+                                       nullptr, absl::nullopt);
     return;
   }
 

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -159,7 +159,7 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
     state_ = Responded;
     int status_code = ::istio::utils::StatusHttpCode(status.error_code());
     decoder_callbacks_->sendLocalReply(Code(status_code), status.ToString(),
-                                       nullptr);
+                                       nullptr, absl::nullopt);
     decoder_callbacks_->streamInfo().setResponseFlag(
         StreamInfo::ResponseFlag::UnauthorizedExternalService);
     return;
@@ -174,9 +174,11 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
     state_ = Responded;
     decoder_callbacks_->sendLocalReply(
         Code(route_directive_.direct_response_code()),
-        route_directive_.direct_response_body(), [this](HeaderMap& headers) {
+        route_directive_.direct_response_body(),
+        [this](HeaderMap& headers) {
           UpdateHeaders(headers, route_directive_.response_header_operations());
-        });
+        },
+        absl::nullopt);
     return;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the Envoy SHA to [74de08a0](https://github.com/envoyproxy/envoy/commit/74de08a0d4d31bd466639d25d681df5d290bb770) to bring in the new TCP RBAC filter to Istio.

**Release note**:
```release-note
NONE
```
