### PR TITLE
Add more information to the authn rejection message

### DIFF
--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -56,7 +56,8 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
 
   if (!createPeerAuthenticator(filter_context_.get())->run(&payload) &&
       !filter_config_.policy().peer_is_optional()) {
-    rejectRequest("Peer authentication failed.");
+    rejectRequest("Peer authentication failed: none of the peer authn policies "
+                  "are satisfied.");
     return FilterHeadersStatus::StopIteration;
   }
 
@@ -65,7 +66,8 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
       filter_config_.policy().origin_is_optional();
 
   if (!success) {
-    rejectRequest("Origin authentication failed.");
+    rejectRequest("Origin authentication failed: none of the origin authn "
+                  "policies are satisfied.");
     return FilterHeadersStatus::StopIteration;
   }
 

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -56,8 +56,9 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
 
   if (!createPeerAuthenticator(filter_context_.get())->run(&payload) &&
       !filter_config_.policy().peer_is_optional()) {
-    rejectRequest("Peer authentication failed: none of the peer authn policies "
-                  "are satisfied.");
+    rejectRequest(
+        "Peer authentication failed: none of the peer authn policies "
+        "are satisfied.");
     return FilterHeadersStatus::StopIteration;
   }
 
@@ -66,8 +67,9 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(HeaderMap& headers,
       filter_config_.policy().origin_is_optional();
 
   if (!success) {
-    rejectRequest("Origin authentication failed: none of the origin authn "
-                  "policies are satisfied.");
+    rejectRequest(
+        "Origin authentication failed: none of the origin authn "
+        "policies are satisfied.");
     return FilterHeadersStatus::StopIteration;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Add more information in the authn rejection message

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1366

**Special notes for your reviewer**: An authn policy may contain multiple origin authentication policies and/or multiple peer authentication policies. The rejection message does not have a mTLS/JWT failure code since the authentication fails when none of the mTLS/JWT policies are satisfied (not due to a single mTLS/JWT policy failure).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
