### PR TITLE
[WIP] add sni_verifier filter

### DIFF
--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -25,7 +25,6 @@ envoy_cc_binary(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
-        "//src/envoy/alts:alts_socket_factory",
         "//src/envoy/http/authn:filter_lib",
         "//src/envoy/http/jwt_auth:http_filter_factory",
         "//src/envoy/http/mixer:filter_lib",

--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -31,7 +31,7 @@ envoy_cc_binary(
         "//src/envoy/tcp/forward_downstream_sni:config_lib",
         "//src/envoy/tcp/mixer:filter_lib",
         "//src/envoy/tcp/tcp_cluster_rewrite:config_lib",
-        "//src/envoy/tcp/sni_verifier:filter_lib",
+        "//src/envoy/tcp/sni_verifier:config_lib",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -18,7 +18,6 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_test",
 )
 
 envoy_cc_library(

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -18,6 +18,7 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_cc_test",
 )
 
 envoy_cc_library(
@@ -40,5 +41,17 @@ envoy_cc_library(
     external_deps = ["ssl"],
     deps = [
         "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "sni_verifier_test",
+    srcs = ["sni_verifier_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":sni_verifier_lib",
+        ":config_lib",
+        "@envoy//test/mocks/network:network_mocks",
+        "@envoy//test/mocks/server:server_mocks",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -21,14 +21,21 @@ load(
 )
 
 envoy_cc_library(
-    name = "filter_lib",
-    srcs = [
-        "config.cc",
-        "sni_verifier.h",
-        "sni_verifier.cc",
-    ],
+    name = "config_lib",
+    srcs = ["config.cc"],
     repository = "@envoy",
     visibility = ["//visibility:public"],
+    deps = [
+        ":sni_verifier_lib",
+        "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "sni_verifier_lib",
+    srcs = [ "sni_verifier.cc"],
+    hdrs = [ "sni_verifier.h"],
+    repository = "@envoy",
     external_deps = ["ssl"],
     deps = [
         "@envoy//source/exe:envoy_common_lib",

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -18,11 +18,13 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_test",
 )
 
 envoy_cc_library(
     name = "config_lib",
     srcs = ["config.cc"],
+    hdrs = ["config.h"],
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -52,6 +52,6 @@ envoy_cc_test(
         ":sni_verifier_lib",
         ":config_lib",
         "@envoy//test/mocks/network:network_mocks",
-        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/test_common:tls_utility_lib",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -52,6 +52,7 @@ envoy_cc_test(
         ":sni_verifier_lib",
         ":config_lib",
         "@envoy//test/mocks/network:network_mocks",
+        "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/test_common:tls_utility_lib",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -13,51 +13,39 @@
  * limitations under the License.
  */
 
+#include "src/envoy/tcp/sni_verifier/config.h"
 #include "envoy/registry/registry.h"
-#include "envoy/server/filter_config.h"
-
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 
 namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {
 
-/**
- * Config registration for the  SNI verifier filter. @see
- * NamedNetworkFilterConfigFactory.
- */
-class SniVerifierConfigFactory
-    : public Server::Configuration::NamedNetworkFilterConfigFactory {
- public:
-  // NamedNetworkFilterConfigFactory
-  Network::FilterFactoryCb createFilterFactory(
-      const Json::Object&,
-      Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromContext(context);
-  }
+Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactory(
+    const Json::Object&,
+    Server::Configuration::FactoryContext& context) override {
+  return createFilterFactoryFromContext(context);
+}
 
-  Network::FilterFactoryCb createFilterFactoryFromProto(
-      const Protobuf::Message&,
-      Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromContext(context);
-  }
+Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message&,
+    Server::Configuration::FactoryContext& context) override {
+  return createFilterFactoryFromContext(context);
+}
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
-  }
+ProtobufTypes::MessagePtr SniVerifierConfigFactory::createEmptyConfigProto() {
+  return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
+}
 
-  std::string name() override { return "sni_verifier"; }
-
- private:
-  Network::FilterFactoryCb createFilterFactoryFromContext(
-      Server::Configuration::FactoryContext& context) {
-    ConfigSharedPtr filter_config(new Config(context.scope()));
-    return [filter_config](Network::FilterManager& filter_manager) -> void {
-      filter_manager.addReadFilter(
-          std::make_shared<SniVerifierFilter>(filter_config));
-    };
-  }
-};
+Network::FilterFactoryCb
+SniVerifierConfigFactory::createFilterFactoryFromContext(
+    Server::Configuration::FactoryContext& context) {
+  ConfigSharedPtr filter_config(new Config(context.scope()));
+  return [filter_config](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(
+        std::make_shared<SniVerifierFilter>(filter_config));
+  };
+}
 
 /**
  * Static registration for the echo filter. @see RegisterFactory.

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -40,8 +40,7 @@ SniVerifierConfigFactory::createFilterFactoryFromContext(
     Server::Configuration::FactoryContext& context) {
   ConfigSharedPtr filter_config(new Config(context.scope()));
   return [filter_config](Network::FilterManager& filter_manager) -> void {
-    filter_manager.addReadFilter(
-        std::make_shared<SniVerifierFilter>(filter_config));
+    filter_manager.addReadFilter(std::make_shared<Filter>(filter_config));
   };
 }
 

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -22,14 +22,12 @@ namespace Tcp {
 namespace SniVerifier {
 
 Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactory(
-    const Json::Object&,
-    Server::Configuration::FactoryContext& context) override {
+    const Json::Object&, Server::Configuration::FactoryContext& context) {
   return createFilterFactoryFromContext(context);
 }
 
 Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactoryFromProto(
-    const Protobuf::Message&,
-    Server::Configuration::FactoryContext& context) override {
+    const Protobuf::Message&, Server::Configuration::FactoryContext& context) {
   return createFilterFactoryFromContext(context);
 }
 

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -28,17 +28,17 @@ namespace SniVerifier {
  */
 class SniVerifierConfigFactory
     : public Server::Configuration::NamedNetworkFilterConfigFactory {
-public:
+ public:
   // NamedNetworkFilterConfigFactory
-  Network::FilterFactoryCb
-  createFilterFactory(const Json::Object&,
-                      Server::Configuration::FactoryContext& context) override {
+  Network::FilterFactoryCb createFilterFactory(
+      const Json::Object&,
+      Server::Configuration::FactoryContext& context) override {
     return createFilterFactoryFromContext(context);
   }
 
-  Network::FilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message&,
-                               Server::Configuration::FactoryContext& context) override {
+  Network::FilterFactoryCb createFilterFactoryFromProto(
+      const Protobuf::Message&,
+      Server::Configuration::FactoryContext& context) override {
     return createFilterFactoryFromContext(context);
   }
 
@@ -48,12 +48,13 @@ public:
 
   std::string name() override { return "sni_verifier"; }
 
-private:
-  Network::FilterFactoryCb
-  createFilterFactoryFromContext(Server::Configuration::FactoryContext& context) {
+ private:
+  Network::FilterFactoryCb createFilterFactoryFromContext(
+      Server::Configuration::FactoryContext& context) {
     ConfigSharedPtr filter_config(new Config(context.scope()));
     return [filter_config](Network::FilterManager& filter_manager) -> void {
-      filter_manager.addReadFilter(std::make_shared<SniVerifierFilter>(filter_config));
+      filter_manager.addReadFilter(
+          std::make_shared<SniVerifierFilter>(filter_config));
     };
   }
 };
@@ -61,10 +62,11 @@ private:
 /**
  * Static registration for the echo filter. @see RegisterFactory.
  */
-static Registry::RegisterFactory<SniVerifierConfigFactory,
-                                 Server::Configuration::NamedNetworkFilterConfigFactory>
+static Registry::RegisterFactory<
+    SniVerifierConfigFactory,
+    Server::Configuration::NamedNetworkFilterConfigFactory>
     registered_;
 
-} // namespace SniVerifier
-} // namespace Tcp
-} // namespace Envoy
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/config.h
+++ b/src/envoy/tcp/sni_verifier/config.h
@@ -1,0 +1,49 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "envoy/server/filter_config.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+/**
+ * Config registration for the  SNI verifier filter. @see
+ * NamedNetworkFilterConfigFactory.
+ */
+class SniVerifierConfigFactory
+    : public Server::Configuration::NamedNetworkFilterConfigFactory {
+ public:
+  // NamedNetworkFilterConfigFactory
+  Network::FilterFactoryCb createFilterFactory(
+      const Json::Object&,
+      Server::Configuration::FactoryContext& context) override;
+
+  Network::FilterFactoryCb createFilterFactoryFromProto(
+      const Protobuf::Message&,
+      Server::Configuration::FactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+  std::string name() override { return "sni_verifier"; }
+
+ private:
+  Network::FilterFactoryCb createFilterFactoryFromContext(
+      Server::Configuration::FactoryContext& context);
+};
+
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -81,7 +81,7 @@ Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
   size_t lenToRead =
       (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
   read_ += lenToRead;
-  parseClientHello(buf_, read_);
+  parseClientHello(*buf_, read_);
 
   return is_match_ ? Network::FilterStatus::Continue
                    : Network::FilterStatus::StopIteration;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -80,9 +80,10 @@ Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
   size_t freeSpaceInBuf = config_->maxClientHelloSize() - read_;
   size_t lenToRead =
       (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
+  data.copyOut(0, lenToRead, buf_.get() + read_);
   read_ += lenToRead;
-  parseClientHello(buf_.get(), read_);
 
+  parseClientHello(buf_.get(), read_);
   return is_match_ ? Network::FilterStatus::Continue
                    : Network::FilterStatus::StopIteration;
 }

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -83,7 +83,8 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool) {
 
   auto start_handshake_data =
       restart_handshake_ ? buf_.get() : buf_.get() + read_;
-  auto handshake_size = restart_handshake_ ? read_ : data_to_read;
+  auto handshake_size =
+      restart_handshake_ ? read_ + data_to_read : data_to_read;
 
   parseClientHello(start_handshake_data, handshake_size);
   read_ += data_to_read;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -151,9 +151,9 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
         done(true);
       } else if (read_ >
                  Config::TLS_MIN_CLIENT_HELLO) {  // we give up at this point
+        config_->stats().tls_not_found_.inc();
         done(false);
       }
-      config_->stats().tls_not_found_.inc();
       break;
     default:
       done(false);

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -149,10 +149,14 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
       if (clienthello_success_) {
         config_->stats().tls_found_.inc();
         done(true);
-      } else if (read_ >
-                 Config::TLS_MIN_CLIENT_HELLO) {  // we give up at this point
-        config_->stats().tls_not_found_.inc();
-        done(false);
+      } else {
+        if (read_ > Config::TLS_MIN_CLIENT_HELLO) {  // we give up at this point
+          config_->stats().tls_not_found_.inc();
+          done(false);
+        } else {  // clean the SSL object to allow another handshake
+          SSL_shutdown(ssl_.get());
+          SSL_clear(ssl_.get());
+        }
       }
       break;
     default:

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -91,18 +91,20 @@ Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
 
 void SniVerifierFilter::onServername(absl::string_view servername) {
   if (!servername.empty()) {
-    config_->stats().sni_found_.inc();
+    config_->stats().inner_sni_found_.inc();
     absl::string_view outerSni =
         read_callbacks_->connection().requestedServerName();
-    if (servername == outerSni) {
-      is_match_ = true;
+
+    is_match_ = (servername == outerSni);
+    if (!is_match_) {
+      config_->stats().snis_do_not_match.inc();
     }
     ENVOY_LOG(
         debug,
         "sni_verifier:onServerName(), inner SNI: {}, outer SNI: {}, match: {}",
         servername, outerSni, is_match_);
   } else {
-    config_->stats().sni_not_found_.inc();
+    config_->stats().inner_sni_not_found_.inc();
   }
   clienthello_success_ = true;
 }

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -151,9 +151,9 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
         done(true);
       } else if (read_ >
                  Config::TLS_MIN_CLIENT_HELLO) {  // we give up at this point
-        config_->stats().tls_not_found_.inc();
         done(false);
       }
+      config_->stats().tls_not_found_.inc();
       break;
     default:
       done(false);

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -85,7 +85,7 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool) {
       restart_handshake_ ? buf_.get() : buf_.get() + read_;
   auto handshake_size = restart_handshake_ ? read_ : data_to_read;
 
-  parseClientHello(start_handshake_data, end_handshake_data);
+  parseClientHello(start_handshake_data, handshake_size);
   read_ += data_to_read;
 
   return is_match_ ? Network::FilterStatus::Continue

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -97,7 +97,7 @@ void SniVerifierFilter::onServername(absl::string_view servername) {
 
     is_match_ = (servername == outerSni);
     if (!is_match_) {
-      config_->stats().snis_do_not_match.inc();
+      config_->stats().snis_do_not_match_.inc();
     }
     ENVOY_LOG(
         debug,

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -63,7 +63,7 @@ bssl::UniquePtr<SSL> Config::newSsl() {
 }
 
 SniVerifierFilter::SniVerifierFilter(const ConfigSharedPtr config)
-  : config_(config), ssl_(config_->newSsl(),
+  : config_(config), ssl_(config_->newSsl()),
                           buf_(std::make_unique<unit8_t[]>(config_->macClientHelloSize())) {
   SSL_set_accept_state(ssl_.get());
 }

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -150,7 +150,8 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
         config_->stats().tls_found_.inc();
         done(true);
       } else {
-        if (read_ > Config::TLS_MIN_CLIENT_HELLO) {  // we give up at this point
+        if (read_ >=
+            config_->maxClientHelloSize()) {  // we give up at this point
           config_->stats().tls_not_found_.inc();
           done(false);
         } else {  // clean the SSL object to allow another handshake

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -65,7 +65,7 @@ bssl::UniquePtr<SSL> Config::newSsl() {
 SniVerifierFilter::SniVerifierFilter(const ConfigSharedPtr config)
     : config_(config),
       ssl_(config_->newSsl()),
-      buf_(std::make_unique<uint8_t[]>(config_->macClientHelloSize())) {
+      buf_(std::make_unique<uint8_t[]>(config_->maxClientHelloSize())) {
   SSL_set_accept_state(ssl_.get());
 }
 
@@ -77,7 +77,7 @@ Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
                      : Network::FilterStatus::StopIteration;
   }
 
-  size_t freeSpaceInBuf = config_->macClientHelloSize() - read_;
+  size_t freeSpaceInBuf = config_->maxClientHelloSize() - read_;
   size_t lenToRead =
       (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
   uint8_t* bufToParse = buf_ + read_;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -64,7 +64,7 @@ bssl::UniquePtr<SSL> Config::newSsl() {
 
 SniVerifierFilter::SniVerifierFilter(const ConfigSharedPtr config)
   : config_(config), ssl_(config_->newSsl()),
-                          buf_(std::make_unique<unit8_t[]>(config_->macClientHelloSize())) {
+                          buf_(std::make_unique<uint8_t[]>(config_->macClientHelloSize())) {
   SSL_set_accept_state(ssl_.get());
 }
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -63,8 +63,9 @@ bssl::UniquePtr<SSL> Config::newSsl() {
 }
 
 SniVerifierFilter::SniVerifierFilter(const ConfigSharedPtr config)
-  : config_(config), ssl_(config_->newSsl()),
-                          buf_(std::make_unique<uint8_t[]>(config_->macClientHelloSize())) {
+    : config_(config),
+      ssl_(config_->newSsl()),
+      buf_(std::make_unique<uint8_t[]>(config_->macClientHelloSize())) {
   SSL_set_accept_state(ssl_.get());
 }
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -148,10 +148,11 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
     case SSL_ERROR_SSL:
       if (clienthello_success_) {
         config_->stats().tls_found_.inc();
-      } else {
+        done(true);
+      } else if (read_ > TLS_MIN_CLIENT_HELLO) {  // we give up at this point
         config_->stats().tls_not_found_.inc();
+        done(false);
       }
-      done(true);
       break;
     default:
       done(false);

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -81,7 +81,7 @@ Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
   size_t lenToRead =
       (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
   read_ += lenToRead;
-  parseClientHello(*buf_, read_);
+  parseClientHello(buf_.get(), read_);
 
   return is_match_ ? Network::FilterStatus::Continue
                    : Network::FilterStatus::StopIteration;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -65,7 +65,6 @@ SniVerifierFilter::SniVerifierFilter(const ConfigSharedPtr config)
     : config_(config), ssl_(config_->newSsl()) {
   RELEASE_ASSERT(sizeof(buf_) >= config_->maxClientHelloSize(), "");
 
-  SSL_set_app_data(ssl_.get(), this);
   SSL_set_accept_state(ssl_.get());
 }
 
@@ -128,7 +127,11 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
   SSL_set_bio(ssl_.get(), bio.get(), bio.get());
   bio.release();
 
+  SSL_set_app_data(ssl_.get(), this);
   int ret = SSL_do_handshake(ssl_.get());
+
+  // reset the app data
+  SSL_set_app_data(ssl_.get(), nullptr);
 
   // This should never succeed because an error is always returned from the SNI
   // callback.

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -80,10 +80,8 @@ Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
   size_t freeSpaceInBuf = config_->maxClientHelloSize() - read_;
   size_t lenToRead =
       (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
-  uint8_t* bufToParse = buf_ + read_;
-  data.copyOut(0, lenToRead, bufToParse);
   read_ += lenToRead;
-  parseClientHello(bufToParse, lenToRead);
+  parseClientHello(buf_, read_);
 
   return is_match_ ? Network::FilterStatus::Continue
                    : Network::FilterStatus::StopIteration;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -29,7 +29,7 @@ namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {
 
-Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
+Config::Config(Stats::Scope& scope, size_t max_client_hello_size)
     : stats_{SNI_VERIFIER_STATS(POOL_COUNTER_PREFIX(scope, "sni_verifier."))},
       ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())),
       max_client_hello_size_(max_client_hello_size) {

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -86,8 +86,8 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool) {
   auto handshake_size =
       restart_handshake_ ? read_ + data_to_read : data_to_read;
 
-  parseClientHello(start_handshake_data, handshake_size);
   read_ += data_to_read;
+  parseClientHello(start_handshake_data, handshake_size);
 
   return is_match_ ? Network::FilterStatus::Continue
                    : Network::FilterStatus::StopIteration;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -82,7 +82,7 @@ Network::FilterStatus Filter::onData(Buffer::Instance& data, bool) {
   data.copyOut(0, data_to_read, buf_.get() + read_);
 
   auto start_handshake_data =
-      restart_handshake_ ? buf_.get() : buf.get() + read_;
+      restart_handshake_ ? buf_.get() : buf_.get() + read_;
   auto handshake_size = restart_handshake_ ? read_ : data_to_read;
 
   parseClientHello(start_handshake_data, end_handshake_data);

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -149,7 +149,8 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
       if (clienthello_success_) {
         config_->stats().tls_found_.inc();
         done(true);
-      } else if (read_ > TLS_MIN_CLIENT_HELLO) {  // we give up at this point
+      } else if (read_ >
+                 Config::TLS_MIN_CLIENT_HELLO) {  // we give up at this point
         config_->stats().tls_not_found_.inc();
         done(false);
       }

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -45,8 +45,11 @@ Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
       ssl_ctx_.get(), [](SSL* ssl, int* out_alert, void*) -> int {
         SniVerifierFilter* filter =
             static_cast<SniVerifierFilter*>(SSL_get_app_data(ssl));
-        filter->onServername(
-            SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
+
+        if (filter != nullptr) {
+          filter->onServername(
+              SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
+        }
 
         // Return an error to stop the handshake; we have what we wanted
         // already.

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -67,10 +67,10 @@ class Config {
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;
 
-class SniVerifierFilter : public Network::ReadFilter,
-                          Logger::Loggable<Logger::Id::filter> {
+class Filter : public Network::ReadFilter,
+               Logger::Loggable<Logger::Id::filter> {
  public:
-  SniVerifierFilter(const ConfigSharedPtr config);
+  Filter(const ConfigSharedPtr config);
 
   // Network::ReadFilter
   Network::FilterStatus onData(Buffer::Instance& data,

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -96,6 +96,7 @@ class Filter : public Network::ReadFilter,
   bool clienthello_success_{false};
   bool done_{false};
   bool is_match_{false};
+  bool restart_handshake_{false};
 
   std::unique_ptr<uint8_t[]> buf_;
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -30,16 +30,16 @@ namespace SniVerifier {
 /**
  * All stats for the SNI verifier. @see stats_macros.h
  */
-#define SNI_VERIFIER_STATS(COUNTER)                                                                \
-  COUNTER(connection_closed)                                                                       \
-  COUNTER(client_hello_too_large)                                                                  \
-  COUNTER(read_error)                                                                              \
-  COUNTER(read_timeout)                                                                            \
-  COUNTER(tls_found)                                                                               \
-  COUNTER(tls_not_found)                                                                           \
-  COUNTER(alpn_found)                                                                              \
-  COUNTER(alpn_not_found)                                                                          \
-  COUNTER(sni_found)                                                                               \
+#define SNI_VERIFIER_STATS(COUNTER) \
+  COUNTER(connection_closed)        \
+  COUNTER(client_hello_too_large)   \
+  COUNTER(read_error)               \
+  COUNTER(read_timeout)             \
+  COUNTER(tls_found)                \
+  COUNTER(tls_not_found)            \
+  COUNTER(alpn_found)               \
+  COUNTER(alpn_not_found)           \
+  COUNTER(sni_found)                \
   COUNTER(sni_not_found)
 
 /**
@@ -53,8 +53,9 @@ struct SniVerifierStats {
  * Global configuration for SNI verifier.
  */
 class Config {
-public:
-  Config(Stats::Scope& scope, uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
+ public:
+  Config(Stats::Scope& scope,
+         uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
 
   const SniVerifierStats& stats() const { return stats_; }
   bssl::UniquePtr<SSL> newSsl();
@@ -62,7 +63,7 @@ public:
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
-private:
+ private:
   SniVerifierStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
   const uint32_t max_client_hello_size_;
@@ -70,18 +71,23 @@ private:
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;
 
-class SniVerifierFilter : public Network::ReadFilter, Logger::Loggable<Logger::Id::filter> {
-public:
+class SniVerifierFilter : public Network::ReadFilter,
+                          Logger::Loggable<Logger::Id::filter> {
+ public:
   SniVerifierFilter(const ConfigSharedPtr config);
 
   // Network::ReadFilter
-  Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
-  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
-  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
+  Network::FilterStatus onData(Buffer::Instance& data,
+                               bool end_stream) override;
+  Network::FilterStatus onNewConnection() override {
+    return Network::FilterStatus::Continue;
+  }
+  void initializeReadFilterCallbacks(
+      Network::ReadFilterCallbacks& callbacks) override {
     read_callbacks_ = &callbacks;
   }
 
-private:
+ private:
   void parseClientHello(const void* data, size_t len);
   void done(bool success);
   void onServername(absl::string_view name);
@@ -101,6 +107,6 @@ private:
   friend class Config;
 };
 
-} // namespace SniVerifier
-} // namespace Tcp
-} // namespace Envoy
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -51,18 +51,18 @@ struct SniVerifierStats {
 class Config {
  public:
   Config(Stats::Scope& scope,
-         uint32_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
+         size_t max_client_hello_size = TLS_MAX_CLIENT_HELLO);
 
   const SniVerifierStats& stats() const { return stats_; }
   bssl::UniquePtr<SSL> newSsl();
-  uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
+  size_t maxClientHelloSize() const { return max_client_hello_size_; }
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
  private:
   SniVerifierStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;
-  const uint32_t max_client_hello_size_;
+  const size_t max_client_hello_size_;
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -60,7 +60,7 @@ class Config {
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
   // read at least this number of bytes before giving up on parsing
-  static constexpr size_t TLS_MIN_CLIENT_HELLO = 200;
+  static constexpr size_t TLS_MIN_CLIENT_HELLO = 100;
 
  private:
   SniVerifierStats stats_;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -59,6 +59,9 @@ class Config {
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
+  // read at least this number of bytes before giving up on parsing
+  static constexpr size_t TLS_MIN_CLIENT_HELLO = 100;
+
  private:
   SniVerifierStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -60,7 +60,7 @@ class Config {
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
   // read at least this number of bytes before giving up on parsing
-  static constexpr size_t TLS_MIN_CLIENT_HELLO = 100;
+  static constexpr size_t TLS_MIN_CLIENT_HELLO = 200;
 
  private:
   SniVerifierStats stats_;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -97,7 +97,7 @@ class SniVerifierFilter : public Network::ReadFilter,
   bool done_{false};
   bool is_match_{false};
 
-  static thread_local uint8_t buf_[Config::TLS_MAX_CLIENT_HELLO];
+  std::unique_ptr<uint8_t[]> buf_;
 
   // Allows callbacks on the SSL_CTX to set fields in this class.
   friend class Config;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -59,9 +59,6 @@ class Config {
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
 
-  // read at least this number of bytes before giving up on parsing
-  static constexpr size_t TLS_MIN_CLIENT_HELLO = 100;
-
  private:
   SniVerifierStats stats_;
   bssl::UniquePtr<SSL_CTX> ssl_ctx_;

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -31,16 +31,12 @@ namespace SniVerifier {
  * All stats for the SNI verifier. @see stats_macros.h
  */
 #define SNI_VERIFIER_STATS(COUNTER) \
-  COUNTER(connection_closed)        \
   COUNTER(client_hello_too_large)   \
-  COUNTER(read_error)               \
-  COUNTER(read_timeout)             \
   COUNTER(tls_found)                \
   COUNTER(tls_not_found)            \
-  COUNTER(alpn_found)               \
-  COUNTER(alpn_not_found)           \
-  COUNTER(sni_found)                \
-  COUNTER(sni_not_found)
+  COUNTER(inner_sni_found)          \
+  COUNTER(inner_sni_not_found)      \
+  COUNTER(snis_do_not_match)
 
 /**
  * Definition of all stats for the SNI verifier. @see stats_macros.h

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -48,11 +48,10 @@ TEST(SniVerifierTest, ConfigTest) {
   cb(connection);
 }
 
-// Test that an exception is thrown for an invalid value for
-// max_client_hello_size
 TEST(SniVerifierTest, MaxClientHelloSize) {
+  Stats::IsolatedStoreImpl store;
   EXPECT_THROW_WITH_MESSAGE(
-      Config(store_, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
+      Config(store, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
       "max_client_hello_size of 65537 is greater than maximum of 65536.");
 }
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -47,7 +47,7 @@ TEST(SniVerifierTest, ConfigTest) {
   cb(connection);
 }
 
-class SniVerifierTest : public testing::Test {
+class SniVerifierFilterTest : public testing::Test {
  protected:
   void SetUp() override {
     store_ = std::make_unique<Stats::IsolatedStoreImpl>();
@@ -84,12 +84,12 @@ class SniVerifierTest : public testing::Test {
   std::unique_ptr<Stats::Scope> store_;
 };
 
-TEST_F(SniVerifierTest, SnisMatch) {
+TEST_F(SniVerifierFilterTest, SnisMatch) {
   runTest("www.example.com", "www.example.com",
           Network::FilterStatus::Continue);
 }
 
-TEST_F(SniVerifierTest, SnisDoNotMatch) {
+TEST_F(SniVerifierFilterTest, SnisDoNotMatch) {
   runTest("www.example.com", "istio.io", Network::FilterStatus::StopIteration);
 }
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -49,7 +49,7 @@ TEST(SniVerifierTest, ConfigTest) {
 
 class SniVerifierFilterTest : public testing::Test {
  protected:
-  static constexpr size_t TLS_MAX_CLIENT_HELLO = 100;
+  static constexpr size_t TLS_MAX_CLIENT_HELLO = 200;
 
   void SetUp() override {
     store_ = std::make_unique<Stats::IsolatedStoreImpl>();

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -137,7 +137,7 @@ TEST_F(SniVerifierFilterTest, BothSnisEmpty) {
 }
 
 TEST_F(SniVerifierFilterTest, SniTooLarge) {
-  runTest("www.example.com", std::string(Config::TLS_MAX_CLIENT_HELLO, "a"),
+  runTest("www.example.com", std::string(Config::TLS_MAX_CLIENT_HELLO, 'a'),
           Network::FilterStatus::StopIteration);
   EXPECT_EQ(1, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(0, cfg_->stats().tls_found_.value());

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -49,9 +49,11 @@ TEST(SniVerifierTest, ConfigTest) {
 
 class SniVerifierFilterTest : public testing::Test {
  protected:
+  static constexpr size_t TLS_MAX_CLIENT_HELLO = 100;
+
   void SetUp() override {
     store_ = std::make_unique<Stats::IsolatedStoreImpl>();
-    cfg_ = std::make_shared<Config>(*store_);
+    cfg_ = std::make_shared<Config>(*store_, TLS_MAX_CLIENT_HELLO);
     filter_ = std::make_unique<SniVerifierFilter>(cfg_);
   }
 
@@ -137,7 +139,7 @@ TEST_F(SniVerifierFilterTest, BothSnisEmpty) {
 }
 
 TEST_F(SniVerifierFilterTest, SniTooLarge) {
-  runTest("www.example.com", std::string(Config::TLS_MAX_CLIENT_HELLO, 'a'),
+  runTest("www.example.com", std::string(TLS_MAX_CLIENT_HELLO, 'a'),
           Network::FilterStatus::StopIteration);
   EXPECT_EQ(1, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(0, cfg_->stats().tls_found_.value());

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -87,6 +87,8 @@ class SniVerifierFilterTest : public testing::Test {
   std::unique_ptr<Stats::Scope> store_;
 };
 
+constexpr size_t SniVerifierFilterTest::TLS_MAX_CLIENT_HELLO;  // definition
+
 TEST_F(SniVerifierFilterTest, SnisMatch) {
   runTest("www.example.com", "www.example.com",
           Network::FilterStatus::Continue);

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -51,7 +51,7 @@ class SniVerifierTest : public testing::Test {
  protected:
   void SetUp() override {
     store_ = std::make_unique<Stats::IsolatedStoreImpl>();
-    cfg_ = std::make_unique<Config>(store_);
+    cfg_ = std::make_unique<Config>(*store_);
     filter_ = std::make_unique<SniVerifierFilter>(cfg_);
   }
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -21,6 +21,7 @@
 #include "common/buffer/buffer_impl.h"
 
 #include "test/mocks/network/mocks.h"
+#include "test/mocks/server/mocks.h"
 #include "test/test_common/tls_utility.h"
 
 #include "gmock/gmock.h"

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -13,23 +13,29 @@
  * limitations under the License.
  */
 
-#include "src/envoy/tcp/sni_verifier/sni_verifier.h"
+#include <string>
+
 #include "src/envoy/tcp/sni_verifier/config.h"
+#include "src/envoy/tcp/sni_verifier/sni_verifier.h"
+
+#include "common/buffer/buffer_impl.h"
 
 #include "test/mocks/network/mocks.h"
-#include "test/mocks/server/mocks.h"
+#include "test/test_common/tls_utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using testing::_;
+using testing::NiceMock;
+using testing::Return;
 
 namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {
 
 // Test that a SniVerifier filter config works.
-TEST(SniVerifier, ConfigTest) {
+TEST(SniVerifierTest, ConfigTest) {
   NiceMock<Server::Configuration::MockFactoryContext> context;
   SniVerifierConfigFactory factory;
 
@@ -38,6 +44,52 @@ TEST(SniVerifier, ConfigTest) {
   Network::MockConnection connection;
   EXPECT_CALL(connection, addReadFilter(_));
   cb(connection);
+}
+
+class SniVerifierTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    store_ = std::make_unique<Stats::IsolatedStoreImpl>();
+    cfg_ = std::make_unique<Config>(store_);
+    filter_ = std::make_unique<SniVerifierFilter>(cfg_);
+  }
+
+  void TearDown() override {
+    filter_ = nullptr;
+    cfg_ = nullptr;
+    store_ = nullptr;
+  }
+
+  void runTest(std::string outer_sni, std::string inner_sni,
+               Network::FilterStatus expected_status) {
+    NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
+
+    ON_CALL(filter_callbacks.connection_, requestedServerName())
+        .WillByDefault(Return(outer_sni));
+
+    filter_.initializeReadFilterCallbacks(filter_callbacks);
+    filter_.onNewConnection();
+
+    auto client_hello = Tls::Test::generateClientHello(inner_sni, "");
+    Buffer::OwnedImpl data;
+    buffer.add(client_hello.data(), client_hello.size());
+
+    EXPECT_EQ(expected_status, filter_.onData(data, true));
+  }
+
+ private:
+  std::unique_ptr<SniVerifierFilter> filter_;
+  std::unique_ptr<Config> cfg_;
+  std::unique_ptr<Stats::Scope> store_;
+}
+
+TEST_F(SniVerifierTest, SnisMatch) {
+  runTest("www.example.com", "www.example.com",
+          Network::FilterStatus::Continue);
+}
+
+TEST_F(SniVerifierTest, SnisDoNotMatch) {
+  runTest("www.example.com", "istio.io", Network::FilterStatus::StopIteration);
 }
 
 }  // namespace SniVerifier

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -66,7 +66,7 @@ class SniVerifierFilterTest : public testing::Test {
 
   void runTest(std::string outer_sni, std::string inner_sni,
                Network::FilterStatus expected_status,
-               int data_installment_size = INT_MAX) {
+               uint32_t data_installment_size = UINT_MAX) {
     NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
 
     ON_CALL(filter_callbacks.connection_, requestedServerName())
@@ -76,14 +76,15 @@ class SniVerifierFilterTest : public testing::Test {
     filter_->onNewConnection();
 
     auto client_hello = Tls::Test::generateClientHello(inner_sni, "");
-    int sent_data = 0;
-    int remaining_data_to_send = client_hello.size();
+    uint32_t sent_data = 0;
+    uint32_t remaining_data_to_send = client_hello.size();
     auto status = Network::FilterStatus::StopIteration;
-    int data_to_send_size = data_installment_size < client_hello.size()
-                                ? data_installment_size
-                                : client_hello.size();
 
     while (remaining_data_to_send > 0) {
+      uint32_t data_to_send_size =
+          data_installment_size < remaining_data_to_send
+              ? data_installment_size
+              : remaining_data_to_send;
       Buffer::OwnedImpl data;
       data.add(client_hello.data() + sent_data, data_to_send_size);
       status = filter_->onData(data, true);

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -197,6 +197,28 @@ TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfTen) {
   EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
 }
 
+TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfFifty) {
+  runTestForClientHello("example.com", "example.com",
+                        Network::FilterStatus::Continue, 50);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfHundred) {
+  runTestForClientHello("example.com", "example.com",
+                        Network::FilterStatus::Continue, 100);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
 TEST_F(SniVerifierFilterTest, NonTLS) {
   std::vector<uint8_t> nonTLSData(TLS_MAX_CLIENT_HELLO, 7);
   runTestForData("example.com", nonTLSData,

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -99,9 +99,9 @@ class SniVerifierFilterTest : public testing::Test {
           data_installment_size < remaining_data_to_send
               ? data_installment_size
               : remaining_data_to_send;
-      Buffer::OwnedImpl data;
-      data.add(data.data() + sent_data, data_to_send_size);
-      status = filter_->onData(data, true);
+      Buffer::OwnedImpl buff;
+      buff.add(data.data() + sent_data, data_to_send_size);
+      status = filter_->onData(buff, true);
       sent_data += data_to_send_size;
       remaining_data_to_send -= data_to_send_size;
       if (remaining_data_to_send > 0) {

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -62,7 +62,7 @@ class SniVerifierFilterTest : public testing::Test {
   void SetUp() override {
     store_ = std::make_unique<Stats::IsolatedStoreImpl>();
     cfg_ = std::make_shared<Config>(*store_, TLS_MAX_CLIENT_HELLO);
-    filter_ = std::make_unique<SniVerifierFilter>(cfg_);
+    filter_ = std::make_unique<Filter>(cfg_);
   }
 
   void TearDown() override {
@@ -117,7 +117,7 @@ class SniVerifierFilterTest : public testing::Test {
   ConfigSharedPtr cfg_;
 
  private:
-  std::unique_ptr<SniVerifierFilter> filter_;
+  std::unique_ptr<Filter> filter_;
   std::unique_ptr<Stats::Scope> store_;
 };
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -73,7 +73,7 @@ class SniVerifierFilterTest : public testing::Test {
 
   void runTestForClientHello(std::string outer_sni, std::string inner_sni,
                              Network::FilterStatus expected_status,
-                             uint32_t data_installment_size = UINT_MAX) {
+                             size_t data_installment_size = UINT_MAX) {
     auto client_hello = Tls::Test::generateClientHello(inner_sni, "");
     runTestForData(outer_sni, client_hello, expected_status,
                    data_installment_size);
@@ -81,7 +81,7 @@ class SniVerifierFilterTest : public testing::Test {
 
   void runTestForData(std::string outer_sni, std::vector<uint8_t>& data,
                       Network::FilterStatus expected_status,
-                      uint32_t data_installment_size = UINT_MAX) {
+                      size_t data_installment_size = UINT_MAX) {
     NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
 
     ON_CALL(filter_callbacks.connection_, requestedServerName())
@@ -90,15 +90,14 @@ class SniVerifierFilterTest : public testing::Test {
     filter_->initializeReadFilterCallbacks(filter_callbacks);
     filter_->onNewConnection();
 
-    uint32_t sent_data = 0;
-    uint32_t remaining_data_to_send = data.size();
+    size_t sent_data = 0;
+    size_t remaining_data_to_send = data.size();
     auto status = Network::FilterStatus::StopIteration;
 
     while (remaining_data_to_send > 0) {
-      uint32_t data_to_send_size =
-          data_installment_size < remaining_data_to_send
-              ? data_installment_size
-              : remaining_data_to_send;
+      size_t data_to_send_size = data_installment_size < remaining_data_to_send
+                                     ? data_installment_size
+                                     : remaining_data_to_send;
       Buffer::OwnedImpl buff;
       buff.add(data.data() + sent_data, data_to_send_size);
       status = filter_->onData(buff, true);

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -136,6 +136,17 @@ TEST_F(SniVerifierFilterTest, BothSnisEmpty) {
   EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
 }
 
+TEST_F(SniVerifierFilterTest, SniTooLarge) {
+  runTest("www.example.com", std::string(Config::TLS_MAX_CLIENT_HELLO, "a"),
+          Network::FilterStatus::StopIteration);
+  EXPECT_EQ(1, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
 }  // namespace SniVerifier
 }  // namespace Tcp
 }  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include "src/envoy/tcp/sni_verifier/config.h"
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
+#include "src/envoy/tcp/sni_verifier/config.h"
 
 namespace Envoy {
 namespace Tcp {

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -66,7 +66,7 @@ class SniVerifierFilterTest : public testing::Test {
 
   void runTest(std::string outer_sni, std::string inner_sni,
                Network::FilterStatus expected_status,
-               int data_installment_size = MAX_INT) {
+               int data_installment_size = INT_MAX) {
     NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
 
     ON_CALL(filter_callbacks.connection_, requestedServerName())

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -16,6 +16,14 @@
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 #include "src/envoy/tcp/sni_verifier/config.h"
 
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/server/mocks.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+
 namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -82,7 +82,7 @@ class SniVerifierTest : public testing::Test {
   std::unique_ptr<SniVerifierFilter> filter_;
   std::unique_ptr<Config> cfg_;
   std::unique_ptr<Stats::Scope> store_;
-}
+};
 
 TEST_F(SniVerifierTest, SnisMatch) {
   runTest("www.example.com", "www.example.com",

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -78,9 +78,10 @@ class SniVerifierFilterTest : public testing::Test {
     EXPECT_EQ(expected_status, filter_->onData(data, true));
   }
 
+  ConfigSharedPtr cfg_;
+
  private:
   std::unique_ptr<SniVerifierFilter> filter_;
-  ConfigSharedPtr cfg_;
   std::unique_ptr<Stats::Scope> store_;
 };
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -1,0 +1,37 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/tcp/sni_verifier/config.h"
+#include "src/envoy/tcp/sni_verifier/sni_verifier.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+// Test that a SniVerifier filter config works.
+TEST(SniVerifier, ConfigTest) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  SniVerifierConfigFactory factory;
+
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(
+      *factory.createEmptyConfigProto(), context);
+  Network::MockConnection connection;
+  EXPECT_CALL(connection, addReadFilter(_));
+  cb(connection);
+}
+
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -106,6 +106,36 @@ TEST_F(SniVerifierFilterTest, SnisDoNotMatch) {
   EXPECT_EQ(1, cfg_->stats().snis_do_not_match_.value());
 }
 
+TEST_F(SniVerifierFilterTest, EmptyOuterSni) {
+  runTest("", "istio.io", Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, EmptyInnerSni) {
+  runTest("www.example.com", "", Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, BothSnisEmpty) {
+  runTest("", "", Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
 }  // namespace SniVerifier
 }  // namespace Tcp
 }  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -48,6 +48,14 @@ TEST(SniVerifierTest, ConfigTest) {
   cb(connection);
 }
 
+// Test that an exception is thrown for an invalid value for
+// max_client_hello_size
+TEST(SniVerifierTest, MaxClientHelloSize) {
+  EXPECT_THROW_WITH_MESSAGE(
+      Config(store_, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
+      "max_client_hello_size of 65537 is greater than maximum of 65536.");
+}
+
 class SniVerifierFilterTest : public testing::Test {
  protected:
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 200;

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -98,9 +98,9 @@ class SniVerifierFilterTest : public testing::Test {
       size_t data_to_send_size = data_installment_size < remaining_data_to_send
                                      ? data_installment_size
                                      : remaining_data_to_send;
-      Buffer::OwnedImpl buff;
-      buff.add(data.data() + sent_data, data_to_send_size);
-      status = filter_->onData(buff, true);
+      Buffer::OwnedImpl buf;
+      buf.add(data.data() + sent_data, data_to_send_size);
+      status = filter_->onData(buf, true);
       sent_data += data_to_send_size;
       remaining_data_to_send -= data_to_send_size;
       if (remaining_data_to_send > 0) {

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -124,7 +124,7 @@ class SniVerifierFilterTest : public testing::Test {
 constexpr size_t SniVerifierFilterTest::TLS_MAX_CLIENT_HELLO;  // definition
 
 TEST_F(SniVerifierFilterTest, SnisMatch) {
-  runTestForClientHello("www.example.com", "www.example.com",
+  runTestForClientHello("example.com", "example.com",
                         Network::FilterStatus::Continue);
   EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
@@ -135,7 +135,7 @@ TEST_F(SniVerifierFilterTest, SnisMatch) {
 }
 
 TEST_F(SniVerifierFilterTest, SnisDoNotMatch) {
-  runTestForClientHello("www.example.com", "istio.io",
+  runTestForClientHello("example.com", "istio.io",
                         Network::FilterStatus::StopIteration);
   EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
@@ -156,7 +156,7 @@ TEST_F(SniVerifierFilterTest, EmptyOuterSni) {
 }
 
 TEST_F(SniVerifierFilterTest, EmptyInnerSni) {
-  runTestForClientHello("www.example.com", "",
+  runTestForClientHello("example.com", "",
                         Network::FilterStatus::StopIteration);
   EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
@@ -177,8 +177,7 @@ TEST_F(SniVerifierFilterTest, BothSnisEmpty) {
 }
 
 TEST_F(SniVerifierFilterTest, SniTooLarge) {
-  runTestForClientHello("www.example.com",
-                        std::string(TLS_MAX_CLIENT_HELLO, 'a'),
+  runTestForClientHello("example.com", std::string(TLS_MAX_CLIENT_HELLO, 'a'),
                         Network::FilterStatus::StopIteration);
   EXPECT_EQ(1, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(0, cfg_->stats().tls_found_.value());
@@ -189,7 +188,7 @@ TEST_F(SniVerifierFilterTest, SniTooLarge) {
 }
 
 TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfTen) {
-  runTestForClientHello("www.example.com", "www.example.com",
+  runTestForClientHello("example.com", "example.com",
                         Network::FilterStatus::Continue, 10);
   EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
@@ -201,7 +200,7 @@ TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfTen) {
 
 TEST_F(SniVerifierFilterTest, NonTLS) {
   std::vector<uint8_t> nonTLSData(TLS_MAX_CLIENT_HELLO, 7);
-  runTestForData("www.example.com", nonTLSData,
+  runTestForData("example.com", nonTLSData,
                  Network::FilterStatus::StopIteration);
   EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(0, cfg_->stats().tls_found_.value());

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -73,7 +73,7 @@ class SniVerifierTest : public testing::Test {
 
     auto client_hello = Tls::Test::generateClientHello(inner_sni, "");
     Buffer::OwnedImpl data;
-    buffer.add(client_hello.data(), client_hello.size());
+    data.add(client_hello.data(), client_hello.size());
 
     EXPECT_EQ(expected_status, filter_->onData(data, true));
   }

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -51,7 +51,7 @@ class SniVerifierTest : public testing::Test {
  protected:
   void SetUp() override {
     store_ = std::make_unique<Stats::IsolatedStoreImpl>();
-    cfg_ = std::make_unique<Config>(*store_);
+    cfg_ = std::make_shared<Config>(*store_);
     filter_ = std::make_unique<SniVerifierFilter>(cfg_);
   }
 
@@ -80,7 +80,7 @@ class SniVerifierTest : public testing::Test {
 
  private:
   std::unique_ptr<SniVerifierFilter> filter_;
-  std::unique_ptr<Config> cfg_;
+  ConfigSharedPtr cfg_;
   std::unique_ptr<Stats::Scope> store_;
 };
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -170,9 +170,9 @@ TEST_F(SniVerifierFilterTest, SniTooLarge) {
   EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
 }
 
-TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfTen, 10) {
-  runTest("www.example.com", "www.example.com",
-          Network::FilterStatus::Continue);
+TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfTen) {
+  runTest("www.example.com", "www.example.com", Network::FilterStatus::Continue,
+          10);
   EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
   EXPECT_EQ(1, cfg_->stats().tls_found_.value());
   EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -68,14 +68,14 @@ class SniVerifierTest : public testing::Test {
     ON_CALL(filter_callbacks.connection_, requestedServerName())
         .WillByDefault(Return(outer_sni));
 
-    filter_.initializeReadFilterCallbacks(filter_callbacks);
-    filter_.onNewConnection();
+    filter_->initializeReadFilterCallbacks(filter_callbacks);
+    filter_->onNewConnection();
 
     auto client_hello = Tls::Test::generateClientHello(inner_sni, "");
     Buffer::OwnedImpl data;
     buffer.add(client_hello.data(), client_hello.size());
 
-    EXPECT_EQ(expected_status, filter_.onData(data, true));
+    EXPECT_EQ(expected_status, filter_->onData(data, true));
   }
 
  private:

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -87,10 +87,22 @@ class SniVerifierFilterTest : public testing::Test {
 TEST_F(SniVerifierFilterTest, SnisMatch) {
   runTest("www.example.com", "www.example.com",
           Network::FilterStatus::Continue);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
 }
 
 TEST_F(SniVerifierFilterTest, SnisDoNotMatch) {
   runTest("www.example.com", "istio.io", Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().snis_do_not_match_.value());
 }
 
 }  // namespace SniVerifier


### PR DESCRIPTION
This PR solves the security hole described in https://goo.gl/cQ29rX, "Enable egress policies per source workload". The solution is related to the following text:

> Set the outer SNI to be equal to the inner SNI in the sidecar proxy and then add a filter in the gateway’s proxy that will verify that the outer SNI and the inner SNI match.

This PR adds a filter "that will verify that the outer SNI and the inner SNI match".

Based on the TLS inspector of Envoy.