### PR TITLE
Bump enoy version to pickup json access log fix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,8 +30,10 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "fcc68f1165d0343891d3ce14c2952019fe403743"
-ENVOY_SHA256 = "44b38c68be6f80deffb26c91151d3bf7e97575d286d5316770473dc1dc2198de"
+#
+# Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/COMMIT.zip && sha256sum COMMIT.zip`
+ENVOY_SHA = "cc991fe653d1918256856ed8dc2323c5f4cd7979"
+ENVOY_SHA256 = "800831b406bca1bbc45a86e6700332b8055d1e429ef38b1ec8015981c1c39d17"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "fcc68f1165d0343891d3ce14c2952019fe403743"
+		"lastStableSHA": "cc991fe653d1918256856ed8dc2323c5f4cd7979"
 	}
 ]


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**What this PR does / why we need it**:
Bump envoy version to pickup json access log fix envoyproxy/envoy#5024

```release-note
fix json access logging
```
