### PR TITLE
Add sni verifier filter

### DIFF
--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -30,6 +30,8 @@ envoy_cc_binary(
         "//src/envoy/http/mixer:filter_lib",
         "//src/envoy/tcp/mixer:filter_lib",
         "//src/envoy/tcp/tcp_cluster_rewrite:config_lib",
+        "//src/envoy/tcp/sni_verifier:filter_lib",
+        "//src/envoy/alts:alts_socket_factory",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -30,8 +30,7 @@ envoy_cc_binary(
         "//src/envoy/http/mixer:filter_lib",
         "//src/envoy/tcp/mixer:filter_lib",
         "//src/envoy/tcp/tcp_cluster_rewrite:config_lib",
-        "//src/envoy/tcp/sni_verifier:filter_lib",
-        "//src/envoy/alts:alts_socket_factory",
+        "//src/envoy/tcp/sni_verifier:config_lib",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+)
+
+envoy_cc_library(
+    name = "filter_lib",
+    srcs = [
+        "control.cc",
+        "sni_verifier.h",
+        "sni_verifier.cc",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+)

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -23,10 +23,14 @@ load(
 envoy_cc_library(
     name = "filter_lib",
     srcs = [
-        "control.cc",
+        "config.cc",
         "sni_verifier.h",
         "sni_verifier.cc",
     ],
     repository = "@envoy",
     visibility = ["//visibility:public"],
+    external_deps = ["ssl"],
+    deps = [
+        "@envoy//source/exe:envoy_common_lib",
+    ],
 )

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -18,19 +18,41 @@
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_cc_test",
 )
 
 envoy_cc_library(
-    name = "filter_lib",
-    srcs = [
-        "config.cc",
-        "sni_verifier.h",
-        "sni_verifier.cc",
-    ],
+    name = "config_lib",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
     repository = "@envoy",
     visibility = ["//visibility:public"],
+    deps = [
+        ":sni_verifier_lib",
+        "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "sni_verifier_lib",
+    srcs = [ "sni_verifier.cc"],
+    hdrs = [ "sni_verifier.h"],
+    repository = "@envoy",
     external_deps = ["ssl"],
     deps = [
         "@envoy//source/exe:envoy_common_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "sni_verifier_test",
+    srcs = ["sni_verifier_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":sni_verifier_lib",
+        ":config_lib",
+        "@envoy//test/mocks/network:network_mocks",
+        "@envoy//test/mocks/server:server_mocks",
+        "@envoy//test/test_common:tls_utility_lib",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -1,0 +1,76 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "extensions/filters/listener/tls_inspector/tls_inspector.h"
+#include "extensions/filters/network/network_level_sni_reader/network_level_sni_reader.h"
+#include "extensions/filters/network/well_known_names.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+/**
+ * Config registration for the network level SNI reader filter. @see
+ * NamedNetworkFilterConfigFactory.
+ */
+class NetworkLevelSniReaderConfigFactory
+    : public Server::Configuration::NamedNetworkFilterConfigFactory {
+public:
+  // NamedNetworkFilterConfigFactory
+  Network::FilterFactoryCb
+  createFilterFactory(const Json::Object&,
+                      Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromContext(context);
+  }
+
+  Network::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message&,
+                               Server::Configuration::FactoryContext& context) override {
+    return createFilterFactoryFromContext(context);
+  }
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
+  }
+
+  std::string name() override { return NetworkFilterNames::get().NetworkLevelSniReader; }
+
+private:
+  Network::FilterFactoryCb
+  createFilterFactoryFromContext(Server::Configuration::FactoryContext& context) {
+    Extensions::ListenerFilters::TlsInspector::ConfigSharedPtr filter_config(
+        new Extensions::ListenerFilters::TlsInspector::Config(
+            context.scope(), Extensions::ListenerFilters::TlsInspector::Config::TLS_MAX_CLIENT_HELLO,
+            "network_level_sni_reader."));
+    return [filter_config](Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(std::make_shared<NetworkLevelSniReaderFilter>(filter_config));
+    };
+  }
+};
+
+/**
+ * Static registration for the echo filter. @see RegisterFactory.
+ */
+static Registry::RegisterFactory<NetworkLevelSniReaderConfigFactory,
+                                 Server::Configuration::NamedNetworkFilterConfigFactory>
+    registered_;
+
+} // namespace NetworkLevelSniReader
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -13,58 +13,45 @@
  * limitations under the License.
  */
 
+#include "src/envoy/tcp/sni_verifier/config.h"
 #include "envoy/registry/registry.h"
-#include "envoy/server/filter_config.h"
-
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 
 namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {
 
-/**
- * Config registration for the  SNI verifier filter. @see
- * NamedNetworkFilterConfigFactory.
- */
-class SniVerifierConfigFactory
-    : public Server::Configuration::NamedNetworkFilterConfigFactory {
-public:
-  // NamedNetworkFilterConfigFactory
-  Network::FilterFactoryCb
-  createFilterFactory(const Json::Object&,
-                      Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromContext(context);
-  }
+Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactory(
+    const Json::Object&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactoryFromContext(context);
+}
 
-  Network::FilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message&,
-                               Server::Configuration::FactoryContext& context) override {
-    return createFilterFactoryFromContext(context);
-  }
+Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message&, Server::Configuration::FactoryContext& context) {
+  return createFilterFactoryFromContext(context);
+}
 
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
-  }
+ProtobufTypes::MessagePtr SniVerifierConfigFactory::createEmptyConfigProto() {
+  return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
+}
 
-  std::string name() override { return "sni_verifier"; }
-
-private:
-  Network::FilterFactoryCb
-  createFilterFactoryFromContext(Server::Configuration::FactoryContext& context) {
-    ConfigSharedPtr filter_config(new Config(context.scope()));
-    return [filter_config](Network::FilterManager& filter_manager) -> void {
-      filter_manager.addReadFilter(std::make_shared<SniVerifierFilter>(filter_config));
-    };
-  }
-};
+Network::FilterFactoryCb
+SniVerifierConfigFactory::createFilterFactoryFromContext(
+    Server::Configuration::FactoryContext& context) {
+  ConfigSharedPtr filter_config(new Config(context.scope()));
+  return [filter_config](Network::FilterManager& filter_manager) -> void {
+    filter_manager.addReadFilter(std::make_shared<Filter>(filter_config));
+  };
+}
 
 /**
  * Static registration for the echo filter. @see RegisterFactory.
  */
-static Registry::RegisterFactory<SniVerifierConfigFactory,
-                                 Server::Configuration::NamedNetworkFilterConfigFactory>
+static Registry::RegisterFactory<
+    SniVerifierConfigFactory,
+    Server::Configuration::NamedNetworkFilterConfigFactory>
     registered_;
 
-} // namespace SniVerifier
-} // namespace Tcp
-} // namespace Envoy
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/config.h
+++ b/src/envoy/tcp/sni_verifier/config.h
@@ -1,0 +1,49 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "envoy/server/filter_config.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+/**
+ * Config registration for the  SNI verifier filter. @see
+ * NamedNetworkFilterConfigFactory.
+ */
+class SniVerifierConfigFactory
+    : public Server::Configuration::NamedNetworkFilterConfigFactory {
+ public:
+  // NamedNetworkFilterConfigFactory
+  Network::FilterFactoryCb createFilterFactory(
+      const Json::Object&,
+      Server::Configuration::FactoryContext& context) override;
+
+  Network::FilterFactoryCb createFilterFactoryFromProto(
+      const Protobuf::Message&,
+      Server::Configuration::FactoryContext& context) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+  std::string name() override { return "sni_verifier"; }
+
+ private:
+  Network::FilterFactoryCb createFilterFactoryFromContext(
+      Server::Configuration::FactoryContext& context);
+};
+
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -88,7 +88,7 @@ void SniVerifierFilter::onServername(absl::string_view servername) {
     if (servername == outerSni) {
         is_match_ = true;
     }
-    ENVOY_LOG(debug, "sni_verifier:onServerName(), requestedServerName: {}", servername);
+    ENVOY_LOG(debug, "sni_verifier:onServerName(), inner SNI: {}, outer SNI: {}, match: {}", servername, outerSni, is_match_);
   } else {
     config_->stats().sni_not_found_.inc();
   }

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -1,0 +1,85 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/filters/network/network_level_sni_reader/network_level_sni_reader.h"
+
+#include "envoy/buffer/buffer.h"
+#include "envoy/common/exception.h"
+#include "envoy/network/connection.h"
+#include "envoy/stats/scope.h"
+
+#include "common/common/assert.h"
+
+#include "openssl/bytestring.h"
+#include "openssl/ssl.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+thread_local uint8_t NetworkLevelSniReaderFilter::buf_
+    [Extensions::ListenerFilters::TlsInspector::Config::TLS_MAX_CLIENT_HELLO];
+
+NetworkLevelSniReaderFilter::NetworkLevelSniReaderFilter(
+    const Extensions::ListenerFilters::TlsInspector::ConfigSharedPtr config)
+    : config_(config), ssl_(config_->newSsl()) {
+  Extensions::ListenerFilters::TlsInspector::Filter::initializeSsl(
+      config->maxClientHelloSize(), sizeof(buf_), ssl_,
+      static_cast<Extensions::ListenerFilters::TlsInspector::TlsFilterBase*>(this));
+}
+
+Network::FilterStatus NetworkLevelSniReaderFilter::onData(Buffer::Instance& data, bool) {
+  ENVOY_CONN_LOG(trace, "NetworkLevelSniReader: got {} bytes", read_callbacks_->connection(),
+                 data.length());
+  if (done_) {
+    return Network::FilterStatus::Continue;
+  }
+
+  size_t freeSpaceInBuf = sizeof(buf_) - read_;
+  size_t lenToRead = (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
+  uint8_t* bufToParse = buf_ + read_;
+  data.copyOut(0, lenToRead, bufToParse);
+  read_ += lenToRead;
+  Extensions::ListenerFilters::TlsInspector::Filter::parseClientHello(
+      bufToParse, lenToRead, ssl_, read_, config_->maxClientHelloSize(), config_->stats(),
+      [&](bool success) -> void { done(success); }, alpn_found_, clienthello_success_,
+      []() -> void {});
+
+  return done_ ? Network::FilterStatus::Continue : Network::FilterStatus::StopIteration;
+}
+
+void NetworkLevelSniReaderFilter::onServername(absl::string_view servername) {
+  ENVOY_CONN_LOG(debug, "network level sni reader: servername: {}", read_callbacks_->connection(),
+                 servername);
+  Extensions::ListenerFilters::TlsInspector::Filter::doOnServername(
+      servername, config_->stats(),
+      [&](absl::string_view name) -> void {
+        read_callbacks_->networkLevelRequestedServerName(name);
+      },
+      clienthello_success_);
+}
+
+void NetworkLevelSniReaderFilter::done(bool success) {
+  ENVOY_LOG(trace, "network level sni reader: done: {}", success);
+  done_ = true;
+  if (success) {
+    read_callbacks_->continueReading();
+  }
+}
+
+} // namespace NetworkLevelSniReader
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -26,6 +26,7 @@
 #include "common/common/assert.h"
 
 #include "openssl/bytestring.h"
+#include "openssl/err.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -177,6 +178,8 @@ void Filter::parseClientHello(const void* data, size_t len) {
       done(false);
       break;
   }
+
+  ERR_clear_error();
 }
 
 }  // namespace SniVerifier

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -29,73 +29,91 @@ namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {
 
-Config::Config(Stats::Scope& scope, uint32_t max_client_hello_size)
+Config::Config(Stats::Scope& scope, size_t max_client_hello_size)
     : stats_{SNI_VERIFIER_STATS(POOL_COUNTER_PREFIX(scope, "sni_verifier."))},
       ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())),
       max_client_hello_size_(max_client_hello_size) {
-
   if (max_client_hello_size_ > TLS_MAX_CLIENT_HELLO) {
-    throw EnvoyException(fmt::format("max_client_hello_size of {} is greater than maximum of {}.",
-                                     max_client_hello_size_, size_t(TLS_MAX_CLIENT_HELLO)));
+    throw EnvoyException(fmt::format(
+        "max_client_hello_size of {} is greater than maximum of {}.",
+        max_client_hello_size_, size_t(TLS_MAX_CLIENT_HELLO)));
   }
 
   SSL_CTX_set_options(ssl_ctx_.get(), SSL_OP_NO_TICKET);
   SSL_CTX_set_session_cache_mode(ssl_ctx_.get(), SSL_SESS_CACHE_OFF);
   SSL_CTX_set_tlsext_servername_callback(
       ssl_ctx_.get(), [](SSL* ssl, int* out_alert, void*) -> int {
-        SniVerifierFilter* filter = static_cast<SniVerifierFilter*>(SSL_get_app_data(ssl));
-        filter->onServername(SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
+        Filter* filter = static_cast<Filter*>(SSL_get_app_data(ssl));
 
-        // Return an error to stop the handshake; we have what we wanted already.
+        if (filter != nullptr) {
+          filter->onServername(
+              SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
+        }
+
+        // Return an error to stop the handshake; we have what we wanted
+        // already.
         *out_alert = SSL_AD_USER_CANCELLED;
         return SSL_TLSEXT_ERR_ALERT_FATAL;
       });
 }
 
-bssl::UniquePtr<SSL> Config::newSsl() { return bssl::UniquePtr<SSL>{SSL_new(ssl_ctx_.get())}; }
+bssl::UniquePtr<SSL> Config::newSsl() {
+  return bssl::UniquePtr<SSL>{SSL_new(ssl_ctx_.get())};
+}
 
-thread_local uint8_t SniVerifierFilter::buf_[Config::TLS_MAX_CLIENT_HELLO];
-
-SniVerifierFilter::SniVerifierFilter(const ConfigSharedPtr config)
-    : config_(config), ssl_(config_->newSsl()) {
-  RELEASE_ASSERT(sizeof(buf_) >= config_->maxClientHelloSize(), "");
-
-  SSL_set_app_data(ssl_.get(), this);
+Filter::Filter(const ConfigSharedPtr config)
+    : config_(config),
+      ssl_(config_->newSsl()),
+      buf_(std::make_unique<uint8_t[]>(config_->maxClientHelloSize())) {
   SSL_set_accept_state(ssl_.get());
 }
 
-Network::FilterStatus SniVerifierFilter::onData(Buffer::Instance& data, bool) {
-  ENVOY_CONN_LOG(trace, "SniVerifier: got {} bytes", read_callbacks_->connection(),
-                 data.length());
+Network::FilterStatus Filter::onData(Buffer::Instance& data, bool) {
+  ENVOY_CONN_LOG(trace, "SniVerifier: got {} bytes",
+                 read_callbacks_->connection(), data.length());
   if (done_) {
-    return is_match_ ? Network::FilterStatus::Continue : Network::FilterStatus::StopIteration;
+    return is_match_ ? Network::FilterStatus::Continue
+                     : Network::FilterStatus::StopIteration;
   }
 
-  size_t freeSpaceInBuf = sizeof(buf_) - read_;
-  size_t lenToRead = (data.length() < freeSpaceInBuf) ? data.length() : freeSpaceInBuf;
-  uint8_t* bufToParse = buf_ + read_;
-  data.copyOut(0, lenToRead, bufToParse);
-  read_ += lenToRead;
-  parseClientHello(bufToParse, lenToRead);
+  size_t left_space_in_buf = config_->maxClientHelloSize() - read_;
+  size_t data_to_read =
+      (data.length() < left_space_in_buf) ? data.length() : left_space_in_buf;
+  data.copyOut(0, data_to_read, buf_.get() + read_);
 
-  return is_match_ ? Network::FilterStatus::Continue : Network::FilterStatus::StopIteration;
+  auto start_handshake_data =
+      restart_handshake_ ? buf_.get() : buf_.get() + read_;
+  auto handshake_size =
+      restart_handshake_ ? read_ + data_to_read : data_to_read;
+
+  read_ += data_to_read;
+  parseClientHello(start_handshake_data, handshake_size);
+
+  return is_match_ ? Network::FilterStatus::Continue
+                   : Network::FilterStatus::StopIteration;
 }
 
-void SniVerifierFilter::onServername(absl::string_view servername) {
+void Filter::onServername(absl::string_view servername) {
   if (!servername.empty()) {
-    config_->stats().sni_found_.inc();
-    absl::string_view outerSni = read_callbacks_->connection().requestedServerName();
-    if (servername == outerSni) {
-        is_match_ = true;
+    config_->stats().inner_sni_found_.inc();
+    absl::string_view outer_sni =
+        read_callbacks_->connection().requestedServerName();
+
+    is_match_ = (servername == outer_sni);
+    if (!is_match_) {
+      config_->stats().snis_do_not_match_.inc();
     }
-    ENVOY_LOG(debug, "sni_verifier:onServerName(), inner SNI: {}, outer SNI: {}, match: {}", servername, outerSni, is_match_);
+    ENVOY_LOG(
+        debug,
+        "sni_verifier:onServerName(), inner SNI: {}, outer SNI: {}, match: {}",
+        servername, outer_sni, is_match_);
   } else {
-    config_->stats().sni_not_found_.inc();
+    config_->stats().inner_sni_not_found_.inc();
   }
   clienthello_success_ = true;
 }
 
-void SniVerifierFilter::done(bool success) {
+void Filter::done(bool success) {
   ENVOY_LOG(trace, "sni_verifier: done: {}", success);
   done_ = true;
   if (success) {
@@ -103,7 +121,7 @@ void SniVerifierFilter::done(bool success) {
   }
 }
 
-void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
+void Filter::parseClientHello(const void* data, size_t len) {
   // Ownership is passed to ssl_ in SSL_set_bio()
   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(data, len));
 
@@ -114,33 +132,50 @@ void SniVerifierFilter::parseClientHello(const void* data, size_t len) {
   SSL_set_bio(ssl_.get(), bio.get(), bio.get());
   bio.release();
 
+  restart_handshake_ = false;
+  SSL_set_app_data(ssl_.get(), this);
   int ret = SSL_do_handshake(ssl_.get());
 
-  // This should never succeed because an error is always returned from the SNI callback.
+  // reset the app data
+  SSL_set_app_data(ssl_.get(), nullptr);
+
+  // This should never succeed because an error is always returned from the SNI
+  // callback.
   ASSERT(ret <= 0);
   switch (SSL_get_error(ssl_.get(), ret)) {
-  case SSL_ERROR_WANT_READ:
-    if (read_ == config_->maxClientHelloSize()) {
-      // We've hit the specified size limit. This is an unreasonably large ClientHello;
-      // indicate failure.
-      config_->stats().client_hello_too_large_.inc();
+    case SSL_ERROR_WANT_READ:
+      if (read_ == config_->maxClientHelloSize()) {
+        // We've hit the specified size limit. This is an unreasonably large
+        // ClientHello; indicate failure.
+        config_->stats().client_hello_too_large_.inc();
+        done(false);
+      }
+      break;  // do nothing until more data arrives
+    case SSL_ERROR_SSL:
+      if (clienthello_success_) {
+        config_->stats().tls_found_.inc();
+        done(true);
+      } else {
+        if (read_ >= config_->maxClientHelloSize()) {
+          // give up on client hello parsing at this point
+          config_->stats().tls_not_found_.inc();
+          done(false);
+        } else {  // clean the SSL object to allow another handshake once we get
+                  // more data
+          SSL_shutdown(ssl_.get());
+          SSL_clear(ssl_.get());
+          // once we get more data - restart the hanshake with the data from the
+          // beginning
+          restart_handshake_ = true;
+        }
+      }
+      break;
+    default:
       done(false);
-    }
-    break;
-  case SSL_ERROR_SSL:
-    if (clienthello_success_) {
-      config_->stats().tls_found_.inc();
-    } else {
-      config_->stats().tls_not_found_.inc();
-    }
-    done(true);
-    break;
-  default:
-    done(false);
-    break;
+      break;
   }
 }
 
-} // namespace SniVerifier
-} // namespace Tcp
-} // namespace Envoy
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -13,6 +13,9 @@
  * limitations under the License.
  */
 
+// the implementation (extracting the SNI) is based on the TLS inspector
+// listener filter of Envoy
+
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 
 #include "envoy/buffer/buffer.h"

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -1,0 +1,68 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "envoy/network/filter.h"
+#include "envoy/stats/scope.h"
+
+#include "common/common/logger.h"
+
+#include "extensions/filters/listener/tls_inspector/tls_inspector.h"
+
+#include "openssl/bytestring.h"
+#include "openssl/ssl.h"
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+class NetworkLevelSniReaderFilter : public Network::ReadFilter,
+                                    public Extensions::ListenerFilters::TlsInspector::TlsFilterBase,
+                                    Logger::Loggable<Logger::Id::filter> {
+public:
+  NetworkLevelSniReaderFilter(
+      const Extensions::ListenerFilters::TlsInspector::ConfigSharedPtr config);
+
+  // Network::ReadFilter
+  Network::FilterStatus onData(Buffer::Instance& data, bool end_stream) override;
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
+    read_callbacks_ = &callbacks;
+  }
+
+private:
+  void done(bool success);
+  // Extensions::ListenerFilters::TlsInspector::TlsFilterBase
+  void onServername(absl::string_view name) override;
+  void onALPN(const unsigned char*, unsigned int) override{};
+
+  Extensions::ListenerFilters::TlsInspector::ConfigSharedPtr config_;
+  Network::ReadFilterCallbacks* read_callbacks_{};
+
+  bssl::UniquePtr<SSL> ssl_;
+  uint64_t read_{0};
+  bool alpn_found_{false};
+  bool clienthello_success_{false};
+  bool done_{false};
+
+  static thread_local uint8_t
+      buf_[Extensions::ListenerFilters::TlsInspector::Config::TLS_MAX_CLIENT_HELLO];
+};
+
+} // namespace NetworkLevelSniReader
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -1,0 +1,236 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <climits>
+#include <string>
+
+#include "src/envoy/tcp/sni_verifier/config.h"
+#include "src/envoy/tcp/sni_verifier/sni_verifier.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "test/mocks/network/mocks.h"
+#include "test/mocks/server/mocks.h"
+#include "test/test_common/tls_utility.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+using testing::NiceMock;
+using testing::Return;
+
+namespace Envoy {
+namespace Tcp {
+namespace SniVerifier {
+
+// Test that a SniVerifier filter config works.
+TEST(SniVerifierTest, ConfigTest) {
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  SniVerifierConfigFactory factory;
+
+  Network::FilterFactoryCb cb = factory.createFilterFactoryFromProto(
+      *factory.createEmptyConfigProto(), context);
+  Network::MockConnection connection;
+  EXPECT_CALL(connection, addReadFilter(_));
+  cb(connection);
+}
+
+TEST(SniVerifierTest, MaxClientHelloSize) {
+  Stats::IsolatedStoreImpl store;
+  EXPECT_THROW_WITH_MESSAGE(
+      Config(store, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
+      "max_client_hello_size of 65537 is greater than maximum of 65536.");
+}
+
+class SniVerifierFilterTest : public testing::Test {
+ protected:
+  static constexpr size_t TLS_MAX_CLIENT_HELLO = 200;
+
+  void SetUp() override {
+    store_ = std::make_unique<Stats::IsolatedStoreImpl>();
+    cfg_ = std::make_shared<Config>(*store_, TLS_MAX_CLIENT_HELLO);
+    filter_ = std::make_unique<Filter>(cfg_);
+  }
+
+  void TearDown() override {
+    filter_ = nullptr;
+    cfg_ = nullptr;
+    store_ = nullptr;
+  }
+
+  void runTestForClientHello(std::string outer_sni, std::string inner_sni,
+                             Network::FilterStatus expected_status,
+                             size_t data_installment_size = UINT_MAX) {
+    auto client_hello = Tls::Test::generateClientHello(inner_sni, "");
+    runTestForData(outer_sni, client_hello, expected_status,
+                   data_installment_size);
+  }
+
+  void runTestForData(std::string outer_sni, std::vector<uint8_t>& data,
+                      Network::FilterStatus expected_status,
+                      size_t data_installment_size = UINT_MAX) {
+    NiceMock<Network::MockReadFilterCallbacks> filter_callbacks;
+
+    ON_CALL(filter_callbacks.connection_, requestedServerName())
+        .WillByDefault(Return(outer_sni));
+
+    filter_->initializeReadFilterCallbacks(filter_callbacks);
+    filter_->onNewConnection();
+
+    size_t sent_data = 0;
+    size_t remaining_data_to_send = data.size();
+    auto status = Network::FilterStatus::StopIteration;
+
+    while (remaining_data_to_send > 0) {
+      size_t data_to_send_size = data_installment_size < remaining_data_to_send
+                                     ? data_installment_size
+                                     : remaining_data_to_send;
+      Buffer::OwnedImpl buf;
+      buf.add(data.data() + sent_data, data_to_send_size);
+      status = filter_->onData(buf, true);
+      sent_data += data_to_send_size;
+      remaining_data_to_send -= data_to_send_size;
+      if (remaining_data_to_send > 0) {
+        // expect that until the whole hello message is parsed, the status is
+        // stop iteration
+        EXPECT_EQ(Network::FilterStatus::StopIteration, status);
+      }
+    }
+
+    EXPECT_EQ(expected_status, status);
+  }
+
+  ConfigSharedPtr cfg_;
+
+ private:
+  std::unique_ptr<Filter> filter_;
+  std::unique_ptr<Stats::Scope> store_;
+};
+
+constexpr size_t SniVerifierFilterTest::TLS_MAX_CLIENT_HELLO;  // definition
+
+TEST_F(SniVerifierFilterTest, SnisMatch) {
+  runTestForClientHello("example.com", "example.com",
+                        Network::FilterStatus::Continue);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, SnisDoNotMatch) {
+  runTestForClientHello("example.com", "istio.io",
+                        Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, EmptyOuterSni) {
+  runTestForClientHello("", "istio.io", Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, EmptyInnerSni) {
+  runTestForClientHello("example.com", "",
+                        Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, BothSnisEmpty) {
+  runTestForClientHello("", "", Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, SniTooLarge) {
+  runTestForClientHello("example.com", std::string(TLS_MAX_CLIENT_HELLO, 'a'),
+                        Network::FilterStatus::StopIteration);
+  EXPECT_EQ(1, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfTen) {
+  runTestForClientHello("example.com", "example.com",
+                        Network::FilterStatus::Continue, 10);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfFifty) {
+  runTestForClientHello("example.com", "example.com",
+                        Network::FilterStatus::Continue, 50);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, SnisMatchSendDataInChunksOfHundred) {
+  runTestForClientHello("example.com", "example.com",
+                        Network::FilterStatus::Continue, 100);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(1, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+TEST_F(SniVerifierFilterTest, NonTLS) {
+  std::vector<uint8_t> nonTLSData(TLS_MAX_CLIENT_HELLO, 7);
+  runTestForData("example.com", nonTLSData,
+                 Network::FilterStatus::StopIteration);
+  EXPECT_EQ(0, cfg_->stats().client_hello_too_large_.value());
+  EXPECT_EQ(0, cfg_->stats().tls_found_.value());
+  EXPECT_EQ(1, cfg_->stats().tls_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_found_.value());
+  EXPECT_EQ(0, cfg_->stats().inner_sni_not_found_.value());
+  EXPECT_EQ(0, cfg_->stats().snis_do_not_match_.value());
+}
+
+}  // namespace SniVerifier
+}  // namespace Tcp
+}  // namespace Envoy


### PR DESCRIPTION
Resubmission of https://github.com/istio/proxy/pull/2046 into release-1.1.

This PR solves the security hole described in https://goo.gl/cQ29rX, "Enable egress policies per source workload". The solution is related to the following text:

> Set the outer SNI to be equal to the inner SNI in the sidecar proxy and then add a filter in the gateway’s proxy that will verify that the outer SNI and the inner SNI match.

This PR adds a filter "that will verify that the outer SNI and the inner SNI match".

Based on the TLS inspector of Envoy.