### PR TITLE
Handle inflight request canceling properly

### DIFF
--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -83,6 +83,7 @@ void GrpcTransport<RequestType, ResponseType>::onFailure(
 template <class RequestType, class ResponseType>
 void GrpcTransport<RequestType, ResponseType>::Cancel() {
   ENVOY_LOG(debug, "Cancel gRPC request {}", descriptor().name());
+  request_->cancel();
   delete this;
 }
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

While reading Proxy code, found that in-flight request is not canceled properly.
cancel() should be called. Otherwise, if it is called, but memory is freed. it may cause crash

**Release note**:
```release-note
None
```
