### PR TITLE
Add Venil to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ reviewers:
   - rshriram
   - linsun
   - JimmyCYJ
+  - venilnoronha
 approvers:
   - qiwzhang
   - lizan
@@ -12,3 +13,4 @@ approvers:
   - rshriram
   - linsun
   - JimmyCYJ
+  - venilnoronha


### PR DESCRIPTION
@venilnoronha has been doing a lot of work on both Envoy and Istio front
and understands the end to end control flow very well. He also maintains
the tcp_cluster_rewrite filter that is used heavily by the multicluster setups.
Adding him to reviewers/approvers.

Signed-off-by: Shriram Rajagopalan <shriramr@vmware.com>