### PR TITLE
make build work with bazel 0.20

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,9 @@
 ################################################################################
 #
 
+# http_archive is not a native function since bazel 0.19
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 load(
      "//:repositories.bzl",
      "googletest_repositories",


### PR DESCRIPTION
http_archive is not a native function since bazel 0.19, so it must be imported.