### PR TITLE
Removes dangling pointer in capture list of lambda function.

### DIFF
--- a/src/envoy/http/jwt_auth/auth_store.h
+++ b/src/envoy/http/jwt_auth/auth_store.h
@@ -66,12 +66,14 @@ class JwtAuthStoreFactory : public Logger::Loggable<Logger::Id::config> {
   JwtAuthStoreFactory(const ::istio::envoy::config::filter::http::jwt_auth::
                           v2alpha1::JwtAuthentication& config,
                       Server::Configuration::FactoryContext& context)
-      : config_(std::make_shared<::istio::envoy::config::filter::http::jwt_auth::v2alpha1::JwtAuthentication>(config)), 
-      tls_(context.threadLocal().allocateSlot()) {
-    tls_->set(
-        [config=this->config_](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-          return std::make_shared<JwtAuthStore>(*config);
-        });
+      : config_(
+            std::make_shared<::istio::envoy::config::filter::http::jwt_auth::
+                                 v2alpha1::JwtAuthentication>(config)),
+        tls_(context.threadLocal().allocateSlot()) {
+    tls_->set([config = this->config_](Event::Dispatcher&)
+                  -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return std::make_shared<JwtAuthStore>(*config);
+    });
     ENVOY_LOG(debug, "Loaded JwtAuthConfig: {}",
               MessageUtil::getJsonStringFromMessage(*config_, true));
   }
@@ -81,7 +83,8 @@ class JwtAuthStoreFactory : public Logger::Loggable<Logger::Id::config> {
 
  private:
   // The auth config.
-  std::shared_ptr<::istio::envoy::config::filter::http::jwt_auth::v2alpha1::JwtAuthentication>
+  std::shared_ptr<::istio::envoy::config::filter::http::jwt_auth::v2alpha1::
+                      JwtAuthentication>
       config_;
   // Thread local slot to store per-thread auth store
   ThreadLocal::SlotPtr tls_;

--- a/src/envoy/http/jwt_auth/auth_store.h
+++ b/src/envoy/http/jwt_auth/auth_store.h
@@ -66,13 +66,14 @@ class JwtAuthStoreFactory : public Logger::Loggable<Logger::Id::config> {
   JwtAuthStoreFactory(const ::istio::envoy::config::filter::http::jwt_auth::
                           v2alpha1::JwtAuthentication& config,
                       Server::Configuration::FactoryContext& context)
-      : config_(config), tls_(context.threadLocal().allocateSlot()) {
+      : config_(std::make_shared<::istio::envoy::config::filter::http::jwt_auth::v2alpha1::JwtAuthentication>(config)), 
+      tls_(context.threadLocal().allocateSlot()) {
     tls_->set(
-        [this](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
-          return std::make_shared<JwtAuthStore>(config_);
+        [config=this->config_](Event::Dispatcher&) -> ThreadLocal::ThreadLocalObjectSharedPtr {
+          return std::make_shared<JwtAuthStore>(*config);
         });
     ENVOY_LOG(debug, "Loaded JwtAuthConfig: {}",
-              MessageUtil::getJsonStringFromMessage(config_, true));
+              MessageUtil::getJsonStringFromMessage(*config_, true));
   }
 
   // Get per-thread auth store object.
@@ -80,7 +81,7 @@ class JwtAuthStoreFactory : public Logger::Loggable<Logger::Id::config> {
 
  private:
   // The auth config.
-  ::istio::envoy::config::filter::http::jwt_auth::v2alpha1::JwtAuthentication
+  std::shared_ptr<::istio::envoy::config::filter::http::jwt_auth::v2alpha1::JwtAuthentication>
       config_;
   // Thread local slot to store per-thread auth store
   ThreadLocal::SlotPtr tls_;

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -45,12 +45,12 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set(
-        [config=this->config_, &stats=this->stats_, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
-            -> ThreadLocal::ThreadLocalObjectSharedPtr {
-          return std::make_shared<Control>(*config, cm, dispatcher, random,
-                                           scope, stats, local_info);
-        });
+    tls_->set([config = this->config_, &stats = this->stats_, &cm, &random,
+               &scope, &local_info](Event::Dispatcher& dispatcher)
+                  -> ThreadLocal::ThreadLocalObjectSharedPtr {
+      return std::make_shared<Control>(*config, cm, dispatcher, random, scope,
+                                       stats, local_info);
+    });
   }
 
   Control& control() { return tls_->getTyped<Control>(); }

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -46,10 +46,10 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
     tls_->set(
-        [this, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
+        [config=this->config_, &stats=this->stats_, &cm, &random, &scope, &local_info](Event::Dispatcher& dispatcher)
             -> ThreadLocal::ThreadLocalObjectSharedPtr {
-          return std::make_shared<Control>(*config_, cm, dispatcher, random,
-                                           scope, stats_, local_info);
+          return std::make_shared<Control>(*config, cm, dispatcher, random,
+                                           scope, stats, local_info);
         });
   }
 
@@ -57,7 +57,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
 
  private:
   // Own the config object.
-  std::unique_ptr<Config> config_;
+  std::shared_ptr<Config> config_;
   // Thread local slot.
   ThreadLocal::SlotPtr tls_;
   // This stats object.

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -41,7 +41,8 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set([config=this->config_, &cm=this->cm_, uuid=this->uuid_, &stats=this->stats_, &random, &scope,
+    tls_->set([config = this->config_, &cm = this->cm_, uuid = this->uuid_,
+               &stats = this->stats_, &random, &scope,
                &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
       return ThreadLocal::ThreadLocalObjectSharedPtr(new Control(

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -41,11 +41,11 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set([this, &random, &scope,
+    tls_->set([config=this->config_, &cm=this->cm_, uuid=this->uuid_, &stats=this->stats_, &random, &scope,
                &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
       return ThreadLocal::ThreadLocalObjectSharedPtr(new Control(
-          *config_, cm_, dispatcher, random, scope, stats_, uuid_, local_info));
+          *config, cm, dispatcher, random, scope, stats, uuid, local_info));
     });
   }
 
@@ -60,7 +60,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
   }
 
   // The config object
-  std::unique_ptr<Config> config_;
+  std::shared_ptr<Config> config_;
   // The cluster manager
   Upstream::ClusterManager& cm_;
   // the thread local slots


### PR DESCRIPTION
**What this PR does / why we need it**:
The ControlFactory for HTTP Mixer filter post a callback into worker threads' dispatcher, which will be invoked by event loop. The callback is a lambda function that has a this pointer in the capture list, and the pointer points to ControlFactory. When Envoy rejects a bad listener config, the ControlFactory is destructed accordingly, and therefore the "this" pointer becomes dangling pointer. TCP Mixer filter and JwtAuthStoreFactory have the same issue, too. This PR removes "this" pointer from capture list, and passes shared_ptr of components that are needed by the lambda function. Tests will be added in a following PR.

**Which issue this PR fixes** : 
fixes #2079 

**Release note**:
```NONE
```
