### PR TITLE
Use shared_ptr to protect members which are passed to capture list of lambda function.

### DIFF
--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -292,11 +292,13 @@ class JwtAuthenticatorTest : public ::testing::Test {
     google::protobuf::util::Status status =
         ::google::protobuf::util::JsonStringToMessage(json_str, &config_);
     ASSERT_TRUE(status.ok());
-    store_.reset(new JwtAuthStore(config_));
+    config_ptr_ = std::make_shared<const JwtAuthentication>(config_);
+    store_.reset(new JwtAuthStore(config_ptr_));
     auth_.reset(new JwtAuthenticator(mock_cm_, *store_));
   }
 
   JwtAuthentication config_;
+  JwtAuthenticationConstSharedPtr config_ptr_;
   std::unique_ptr<JwtAuthStore> store_;
   std::unique_ptr<JwtAuthenticator> auth_;
   NiceMock<Upstream::MockClusterManager> mock_cm_;
@@ -482,7 +484,8 @@ TEST_F(JwtAuthenticatorTest, TestForwardJwt) {
   // Confit forward_jwt flag
   config_.mutable_rules(0)->set_forward(true);
   // Re-create store and auth objects.
-  store_.reset(new JwtAuthStore(config_));
+  config_ptr_ = std::make_shared<const JwtAuthentication>(config_);
+  store_.reset(new JwtAuthStore(config_ptr_));
   auth_.reset(new JwtAuthenticator(mock_cm_, *store_));
 
   MockUpstream mock_pubkey(mock_cm_, kPublicKey);
@@ -752,7 +755,8 @@ TEST_F(JwtAuthenticatorTest, TestInlineJwks) {
   local_jwks->set_inline_string(kPublicKey);
 
   // recreate store and auth with modified config.
-  store_.reset(new JwtAuthStore(config_));
+  config_ptr_ = std::make_shared<const JwtAuthentication>(config_);
+  store_.reset(new JwtAuthStore(config_ptr_));
   auth_.reset(new JwtAuthenticator(mock_cm_, *store_));
 
   MockUpstream mock_pubkey(mock_cm_, "");

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -23,17 +23,16 @@ namespace Envoy {
 namespace Http {
 namespace Mixer {
 
-Control::Control(const Config& config, Upstream::ClusterManager& cm,
+Control::Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
                  Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
-                 Utils::MixerFilterStats& stats,
                  const LocalInfo::LocalInfo& local_info)
-    : config_(config),
+    : config_(control_data->config()),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.check_cluster(), cm, scope, dispatcher.timeSystem())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.report_cluster(), cm, scope, dispatcher.timeSystem())),
-      stats_obj_(dispatcher, stats,
+      stats_obj_(dispatcher, control_data->stats(),
                  config_.config_pb().transport().stats_update_interval(),
                  [this](::istio::mixerclient::Statistics* stat) -> bool {
                    return GetStats(stat);

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -23,17 +23,22 @@ namespace Envoy {
 namespace Http {
 namespace Mixer {
 
-Control::Control(ControlData& control_data, Upstream::ClusterManager& cm,
-                 Event::Dispatcher& dispatcher,
+Control::Control(ControlDataSharedPtr control_data,
+                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
                  const LocalInfo::LocalInfo& local_info)
-    : config_(control_data.config()),
+    : control_data_(control_data),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.check_cluster(), cm, scope, dispatcher.timeSystem())),
+          control_data_->config().check_cluster(), cm, scope,
+          dispatcher.timeSystem())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.report_cluster(), cm, scope, dispatcher.timeSystem())),
-      stats_obj_(dispatcher, control_data.stats(),
-                 config_.config_pb().transport().stats_update_interval(),
+          control_data_->config().report_cluster(), cm, scope,
+          dispatcher.timeSystem())),
+      stats_obj_(dispatcher, control_data_->stats(),
+                 control_data_->config()
+                     .config_pb()
+                     .transport()
+                     .stats_update_interval(),
                  [this](::istio::mixerclient::Statistics* stat) -> bool {
                    return GetStats(stat);
                  }) {
@@ -47,8 +52,8 @@ Control::Control(ControlData& control_data, Upstream::ClusterManager& cm,
   ::istio::utils::SerializeForwardedAttributes(local_node,
                                                &serialized_forward_attributes_);
 
-  ::istio::control::http::Controller::Options options(config_.config_pb(),
-                                                      local_node);
+  ::istio::control::http::Controller::Options options(
+      control_data_->config().config_pb(), local_node);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -23,8 +23,8 @@ namespace Envoy {
 namespace Http {
 namespace Mixer {
 
-Control::Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
-                 Event::Dispatcher& dispatcher,
+Control::Control(ControlDataSharedPtr control_data,
+                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
                  const LocalInfo::LocalInfo& local_info)
     : config_(control_data->config()),

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -23,16 +23,16 @@ namespace Envoy {
 namespace Http {
 namespace Mixer {
 
-Control::Control(ControlDataSharedPtr control_data,
-                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+Control::Control(ControlData& control_data, Upstream::ClusterManager& cm,
+                 Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
                  const LocalInfo::LocalInfo& local_info)
-    : config_(control_data->config()),
+    : config_(control_data.config()),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.check_cluster(), cm, scope, dispatcher.timeSystem())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.report_cluster(), cm, scope, dispatcher.timeSystem())),
-      stats_obj_(dispatcher, control_data->stats(),
+      stats_obj_(dispatcher, control_data.stats(),
                  config_.config_pb().transport().stats_update_interval(),
                  [this](::istio::mixerclient::Statistics* stat) -> bool {
                    return GetStats(stat);

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -51,7 +51,7 @@ typedef std::shared_ptr<ControlData> ControlDataSharedPtr;
 class Control final : public ThreadLocal::ThreadLocalObject {
  public:
   // The constructor.
-  Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
+  Control(ControlData& control_data, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
           Stats::Scope& scope, const LocalInfo::LocalInfo& local_info);
 

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -32,14 +32,28 @@ namespace Envoy {
 namespace Http {
 namespace Mixer {
 
+class ControlData {
+ public:
+  ControlData(std::unique_ptr<Config> config, Utils::MixerFilterStats stats)
+      : config_(std::move(config)), stats_(stats) {}
+
+  const Config& config() { return *config_; }
+  Utils::MixerFilterStats& stats() { return stats_; }
+
+ private:
+  std::unique_ptr<Config> config_;
+  Utils::MixerFilterStats stats_;
+};
+
+typedef std::shared_ptr<ControlData> ControlDataSharedPtr;
+
 // The control object created per-thread.
 class Control final : public ThreadLocal::ThreadLocalObject {
  public:
   // The constructor.
-  Control(const Config& config, Upstream::ClusterManager& cm,
+  Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-          Stats::Scope& scope, Utils::MixerFilterStats& stats,
-          const LocalInfo::LocalInfo& local_info);
+          Stats::Scope& scope, const LocalInfo::LocalInfo& local_info);
 
   // Get low-level controller object.
   ::istio::control::http::Controller* controller() { return controller_.get(); }

--- a/src/envoy/http/mixer/control.h
+++ b/src/envoy/http/mixer/control.h
@@ -51,7 +51,7 @@ typedef std::shared_ptr<ControlData> ControlDataSharedPtr;
 class Control final : public ThreadLocal::ThreadLocalObject {
  public:
   // The constructor.
-  Control(ControlData& control_data, Upstream::ClusterManager& cm,
+  Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
           Stats::Scope& scope, const LocalInfo::LocalInfo& local_info);
 
@@ -65,8 +65,8 @@ class Control final : public ThreadLocal::ThreadLocalObject {
   // Call controller to get statistics.
   bool GetStats(::istio::mixerclient::Statistics* stat);
 
-  // The mixer config.
-  const Config& config_;
+  // The control data.
+  ControlDataSharedPtr control_data_;
   // Pre-serialized attributes_for_mixer_proxy.
   std::string serialized_forward_attributes_;
   // async client factories

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -48,7 +48,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     tls_->set([control_data = this->control_data_, &cm, &random, &scope,
                &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<Control>(*control_data, cm, dispatcher, random,
+      return std::make_shared<Control>(control_data, cm, dispatcher, random,
                                        scope, local_info);
     });
   }

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -36,9 +36,9 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)
-      : control_data_(
-            new ControlData(std::move(config),
-                            generateStats(kHttpStatsPrefix, context.scope()))),
+      : control_data_(std::make_shared<ControlData>(
+            std::move(config),
+            generateStats(kHttpStatsPrefix, context.scope()))),
         tls_(context.threadLocal().allocateSlot()) {
     Upstream::ClusterManager& cm = context.clusterManager();
     Runtime::RandomGenerator& random = context.random();

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -36,26 +36,27 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)
-      : control_data_(new ControlData(
-            std::move(config), generateStats(kHttpStatsPrefix, context.scope()))),
+      : control_data_(
+            new ControlData(std::move(config),
+                            generateStats(kHttpStatsPrefix, context.scope()))),
         tls_(context.threadLocal().allocateSlot()) {
     Upstream::ClusterManager& cm = context.clusterManager();
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set([control_data = this->control_data_, &cm, &random,
-               &scope, &local_info](Event::Dispatcher& dispatcher)
+    tls_->set([control_data = this->control_data_, &cm, &random, &scope,
+               &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<Control>(control_data, cm, dispatcher, random, scope,
-                                       local_info);
+      return std::make_shared<Control>(control_data, cm, dispatcher, random,
+                                       scope, local_info);
     });
   }
 
   Control& control() { return tls_->getTyped<Control>(); }
 
  private:
-   // Generates stats struct.
+  // Generates stats struct.
   static Utils::MixerFilterStats generateStats(const std::string& name,
                                                Stats::Scope& scope) {
     return {ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))};

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -36,32 +36,35 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)
-      : config_(std::move(config)),
-        tls_(context.threadLocal().allocateSlot()),
-        stats_{ALL_MIXER_FILTER_STATS(
-            POOL_COUNTER_PREFIX(context.scope(), kHttpStatsPrefix))} {
+      : control_data_(new ControlData(
+            std::move(config), generateStats(kHttpStatsPrefix, context.scope()))),
+        tls_(context.threadLocal().allocateSlot()) {
     Upstream::ClusterManager& cm = context.clusterManager();
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set([config = this->config_, &stats = this->stats_, &cm, &random,
+    tls_->set([control_data = this->control_data_, &cm, &random,
                &scope, &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<Control>(*config, cm, dispatcher, random, scope,
-                                       stats, local_info);
+      return std::make_shared<Control>(control_data, cm, dispatcher, random, scope,
+                                       local_info);
     });
   }
 
   Control& control() { return tls_->getTyped<Control>(); }
 
  private:
-  // Own the config object.
-  std::shared_ptr<Config> config_;
+   // Generates stats struct.
+  static Utils::MixerFilterStats generateStats(const std::string& name,
+                                               Stats::Scope& scope) {
+    return {ALL_MIXER_FILTER_STATS(POOL_COUNTER_PREFIX(scope, name))};
+  }
+
+  // The control data object
+  ControlDataSharedPtr control_data_;
   // Thread local slot.
   ThreadLocal::SlotPtr tls_;
-  // This stats object.
-  Utils::MixerFilterStats stats_;
 };
 
 }  // namespace Mixer

--- a/src/envoy/http/mixer/control_factory.h
+++ b/src/envoy/http/mixer/control_factory.h
@@ -48,7 +48,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::config> {
     tls_->set([control_data = this->control_data_, &cm, &random, &scope,
                &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return std::make_shared<Control>(control_data, cm, dispatcher, random,
+      return std::make_shared<Control>(*control_data, cm, dispatcher, random,
                                        scope, local_info);
     });
   }

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -25,21 +25,20 @@ namespace Envoy {
 namespace Tcp {
 namespace Mixer {
 
-Control::Control(const Config& config, Upstream::ClusterManager& cm,
+Control::Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
                  Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
-                 Utils::MixerFilterStats& stats, const std::string& uuid,
                  const LocalInfo::LocalInfo& local_info)
-    : config_(config),
+    : config_(control_data->config()),
       dispatcher_(dispatcher),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.check_cluster(), cm, scope, dispatcher.timeSystem())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.report_cluster(), cm, scope, dispatcher.timeSystem())),
-      stats_obj_(dispatcher, stats,
+      stats_obj_(dispatcher, control_data->stats(),
                  config_.config_pb().transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool { return GetStats(stat); }),
-      uuid_(uuid) {
+      uuid_(control_data->uuid()) {
   auto& logger = Logger::Registry::getLog(Logger::Id::config);
   LocalNode local_node;
   if (!Utils::ExtractNodeInfo(local_info.node(), &local_node)) {

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -25,8 +25,8 @@ namespace Envoy {
 namespace Tcp {
 namespace Mixer {
 
-Control::Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
-                 Event::Dispatcher& dispatcher,
+Control::Control(ControlDataSharedPtr control_data,
+                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
                  const LocalInfo::LocalInfo& local_info)
     : config_(control_data->config()),

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -25,20 +25,20 @@ namespace Envoy {
 namespace Tcp {
 namespace Mixer {
 
-Control::Control(ControlDataSharedPtr control_data,
-                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
+Control::Control(ControlData& control_data, Upstream::ClusterManager& cm,
+                 Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
                  const LocalInfo::LocalInfo& local_info)
-    : config_(control_data->config()),
+    : config_(control_data.config()),
       dispatcher_(dispatcher),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.check_cluster(), cm, scope, dispatcher.timeSystem())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
           config_.report_cluster(), cm, scope, dispatcher.timeSystem())),
-      stats_obj_(dispatcher, control_data->stats(),
+      stats_obj_(dispatcher, control_data.stats(),
                  config_.config_pb().transport().stats_update_interval(),
                  [this](Statistics* stat) -> bool { return GetStats(stat); }),
-      uuid_(control_data->uuid()) {
+      uuid_(control_data.uuid()) {
   auto& logger = Logger::Registry::getLog(Logger::Id::config);
   LocalNode local_node;
   if (!Utils::ExtractNodeInfo(local_info.node(), &local_node)) {

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -25,20 +25,24 @@ namespace Envoy {
 namespace Tcp {
 namespace Mixer {
 
-Control::Control(ControlData& control_data, Upstream::ClusterManager& cm,
-                 Event::Dispatcher& dispatcher,
+Control::Control(ControlDataSharedPtr control_data,
+                 Upstream::ClusterManager& cm, Event::Dispatcher& dispatcher,
                  Runtime::RandomGenerator& random, Stats::Scope& scope,
                  const LocalInfo::LocalInfo& local_info)
-    : config_(control_data.config()),
+    : control_data_(control_data),
       dispatcher_(dispatcher),
       check_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.check_cluster(), cm, scope, dispatcher.timeSystem())),
+          control_data_->config().check_cluster(), cm, scope,
+          dispatcher.timeSystem())),
       report_client_factory_(Utils::GrpcClientFactoryForCluster(
-          config_.report_cluster(), cm, scope, dispatcher.timeSystem())),
-      stats_obj_(dispatcher, control_data.stats(),
-                 config_.config_pb().transport().stats_update_interval(),
-                 [this](Statistics* stat) -> bool { return GetStats(stat); }),
-      uuid_(control_data.uuid()) {
+          control_data_->config().report_cluster(), cm, scope,
+          dispatcher.timeSystem())),
+      stats_obj_(dispatcher, control_data_->stats(),
+                 control_data_->config()
+                     .config_pb()
+                     .transport()
+                     .stats_update_interval(),
+                 [this](Statistics* stat) -> bool { return GetStats(stat); }) {
   auto& logger = Logger::Registry::getLog(Logger::Id::config);
   LocalNode local_node;
   if (!Utils::ExtractNodeInfo(local_info.node(), &local_node)) {
@@ -49,8 +53,8 @@ Control::Control(ControlData& control_data, Upstream::ClusterManager& cm,
   ::istio::utils::SerializeForwardedAttributes(local_node,
                                                &serialized_forward_attributes_);
 
-  ::istio::control::tcp::Controller::Options options(config_.config_pb(),
-                                                     local_node);
+  ::istio::control::tcp::Controller::Options options(
+      control_data_->config().config_pb(), local_node);
 
   Utils::CreateEnvironment(dispatcher, random, *check_client_factory_,
                            *report_client_factory_,

--- a/src/envoy/tcp/mixer/control.h
+++ b/src/envoy/tcp/mixer/control.h
@@ -32,11 +32,12 @@ namespace Mixer {
 
 class ControlData {
  public:
-  ControlData(std::unique_ptr<Config> config, Utils::MixerFilterStats stats, const std::string& uuid)
-   : config_(std::move(config)), stats_(stats), uuid_(uuid) {}
+  ControlData(std::unique_ptr<Config> config, Utils::MixerFilterStats stats,
+              const std::string& uuid)
+      : config_(std::move(config)), stats_(stats), uuid_(uuid) {}
 
-  const Config& config() {  return *config_; }
-  Utils::MixerFilterStats& stats() {  return stats_; }
+  const Config& config() { return *config_; }
+  Utils::MixerFilterStats& stats() { return stats_; }
   const std::string& uuid() { return uuid_; }
 
  private:

--- a/src/envoy/tcp/mixer/control.h
+++ b/src/envoy/tcp/mixer/control.h
@@ -51,7 +51,7 @@ typedef std::shared_ptr<ControlData> ControlDataSharedPtr;
 class Control final : public ThreadLocal::ThreadLocalObject {
  public:
   // The constructor.
-  Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
+  Control(ControlData& control_data, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
           Stats::Scope& scope, const LocalInfo::LocalInfo& local_info);
 

--- a/src/envoy/tcp/mixer/control.h
+++ b/src/envoy/tcp/mixer/control.h
@@ -30,13 +30,29 @@ namespace Envoy {
 namespace Tcp {
 namespace Mixer {
 
+class ControlData {
+ public:
+  ControlData(std::unique_ptr<Config> config, Utils::MixerFilterStats stats, const std::string& uuid)
+   : config_(std::move(config)), stats_(stats), uuid_(uuid) {}
+
+  const Config& config() {  return *config_; }
+  Utils::MixerFilterStats& stats() {  return stats_; }
+  const std::string& uuid() { return uuid_; }
+
+ private:
+  std::unique_ptr<Config> config_;
+  Utils::MixerFilterStats stats_;
+  const std::string uuid_;
+};
+
+typedef std::shared_ptr<ControlData> ControlDataSharedPtr;
+
 class Control final : public ThreadLocal::ThreadLocalObject {
  public:
   // The constructor.
-  Control(const Config& config, Upstream::ClusterManager& cm,
+  Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
-          Stats::Scope& scope, Utils::MixerFilterStats& stats,
-          const std::string& uuid, const LocalInfo::LocalInfo& local_info);
+          Stats::Scope& scope, const LocalInfo::LocalInfo& local_info);
 
   ::istio::control::tcp::Controller* controller() { return controller_.get(); }
 

--- a/src/envoy/tcp/mixer/control.h
+++ b/src/envoy/tcp/mixer/control.h
@@ -43,6 +43,7 @@ class ControlData {
  private:
   std::unique_ptr<Config> config_;
   Utils::MixerFilterStats stats_;
+  // UUID of the Envoy TCP mixer filter.
   const std::string uuid_;
 };
 
@@ -51,7 +52,7 @@ typedef std::shared_ptr<ControlData> ControlDataSharedPtr;
 class Control final : public ThreadLocal::ThreadLocalObject {
  public:
   // The constructor.
-  Control(ControlData& control_data, Upstream::ClusterManager& cm,
+  Control(ControlDataSharedPtr control_data, Upstream::ClusterManager& cm,
           Event::Dispatcher& dispatcher, Runtime::RandomGenerator& random,
           Stats::Scope& scope, const LocalInfo::LocalInfo& local_info);
 
@@ -59,16 +60,16 @@ class Control final : public ThreadLocal::ThreadLocalObject {
 
   Event::Dispatcher& dispatcher() { return dispatcher_; }
 
-  const std::string& uuid() const { return uuid_; }
+  const std::string& uuid() const { return control_data_->uuid(); }
 
-  const Config& config() const { return config_; }
+  const Config& config() const { return control_data_->config(); }
 
  private:
   // Call controller to get statistics.
   bool GetStats(::istio::mixerclient::Statistics* stat);
 
-  // The mixer config.
-  const Config& config_;
+  // The control data.
+  ControlDataSharedPtr control_data_;
 
   // dispatcher.
   Event::Dispatcher& dispatcher_;
@@ -82,8 +83,7 @@ class Control final : public ThreadLocal::ThreadLocalObject {
 
   // statistics
   Utils::MixerStatsObject stats_obj_;
-  // UUID of the Envoy TCP mixer filter.
-  const std::string& uuid_;
+
   // The mixer control
   std::unique_ptr<::istio::control::tcp::Controller> controller_;
 };

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -32,17 +32,20 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)
-      : control_data_(new ControlData(std::move(config), generateStats(kTcpStatsPrefix, context.scope()), context.random().uuid())),
+      : control_data_(new ControlData(
+            std::move(config), generateStats(kTcpStatsPrefix, context.scope()),
+            context.random().uuid())),
         tls_(context.threadLocal().allocateSlot()) {
     Runtime::RandomGenerator& random = context.random();
     Stats::Scope& scope = context.scope();
     const LocalInfo::LocalInfo& local_info = context.localInfo();
 
-    tls_->set([control_data = this->control_data_, &cm = context.clusterManager(),
-               &random, &scope, &local_info](Event::Dispatcher& dispatcher)
+    tls_->set([control_data = this->control_data_,
+               &cm = context.clusterManager(), &random, &scope,
+               &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return ThreadLocal::ThreadLocalObjectSharedPtr(new Control(
-          control_data, cm, dispatcher, random, scope, local_info));
+      return ThreadLocal::ThreadLocalObjectSharedPtr(
+          new Control(control_data, cm, dispatcher, random, scope, local_info));
     });
   }
 

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -44,8 +44,8 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
                &cm = context.clusterManager(), &random, &scope,
                &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return ThreadLocal::ThreadLocalObjectSharedPtr(new Control(
-          *control_data, cm, dispatcher, random, scope, local_info));
+      return ThreadLocal::ThreadLocalObjectSharedPtr(
+          new Control(control_data, cm, dispatcher, random, scope, local_info));
     });
   }
 

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -32,7 +32,7 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
  public:
   ControlFactory(std::unique_ptr<Config> config,
                  Server::Configuration::FactoryContext& context)
-      : control_data_(new ControlData(
+      : control_data_(std::make_shared<ControlData>(
             std::move(config), generateStats(kTcpStatsPrefix, context.scope()),
             context.random().uuid())),
         tls_(context.threadLocal().allocateSlot()) {

--- a/src/envoy/tcp/mixer/control_factory.h
+++ b/src/envoy/tcp/mixer/control_factory.h
@@ -44,8 +44,8 @@ class ControlFactory : public Logger::Loggable<Logger::Id::filter> {
                &cm = context.clusterManager(), &random, &scope,
                &local_info](Event::Dispatcher& dispatcher)
                   -> ThreadLocal::ThreadLocalObjectSharedPtr {
-      return ThreadLocal::ThreadLocalObjectSharedPtr(
-          new Control(control_data, cm, dispatcher, random, scope, local_info));
+      return ThreadLocal::ThreadLocalObjectSharedPtr(new Control(
+          *control_data, cm, dispatcher, random, scope, local_info));
     });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves the fix https://github.com/istio/proxy/pull/2080 by using shared_ptr to protect uuid and stats.
 
**Which issue this PR fixes** : 
fixes #2079 

**Release note**:
```NONE
```
