### PR TITLE
use route directive regardless of rpc status

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -155,21 +155,16 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
     return;
   }
 
-  if (!status.ok()) {
-    state_ = Responded;
-    int status_code = ::istio::utils::StatusHttpCode(status.error_code());
-    decoder_callbacks_->sendLocalReply(Code(status_code), status.ToString(),
-                                       nullptr, absl::nullopt);
-    decoder_callbacks_->streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UnauthorizedExternalService);
-    return;
-  }
-
-  state_ = Complete;
   route_directive_ = info.route_directive;
 
+  // set UAEX access log flag
+  if (!status.ok()) {
+    decoder_callbacks_->streamInfo().setResponseFlag(
+        StreamInfo::ResponseFlag::UnauthorizedExternalService);
+  }
+
   // handle direct response from the route directive
-  if (status.ok() && route_directive_.direct_response_code() != 0) {
+  if (route_directive_.direct_response_code() != 0) {
     ENVOY_LOG(debug, "Mixer::Filter direct response");
     state_ = Responded;
     decoder_callbacks_->sendLocalReply(
@@ -181,6 +176,18 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
         absl::nullopt);
     return;
   }
+
+  // create a local reply for status not OK even if there is no direct response
+  if (!status.ok()) {
+    state_ = Responded;
+
+    int status_code = ::istio::utils::StatusHttpCode(status.error_code());
+    decoder_callbacks_->sendLocalReply(Code(status_code), status.ToString(),
+                                       nullptr, absl::nullopt);
+    return;
+  }
+
+  state_ = Complete;
 
   // handle request header operations
   if (nullptr != headers_) {

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -165,11 +165,11 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
 
   // handle direct response from the route directive
   if (route_directive_.direct_response_code() != 0) {
-    ENVOY_LOG(debug, "Mixer::Filter direct response");
+    int status_code = route_directive_.direct_response_code();
+    ENVOY_LOG(debug, "Mixer::Filter direct response {}", status_code);
     state_ = Responded;
     decoder_callbacks_->sendLocalReply(
-        Code(route_directive_.direct_response_code()),
-        route_directive_.direct_response_body(),
+        Code(status_code), route_directive_.direct_response_body(),
         [this](HeaderMap& headers) {
           UpdateHeaders(headers, route_directive_.response_header_operations());
         },

--- a/src/istio/mixerclient/check_cache.h
+++ b/src/istio/mixerclient/check_cache.h
@@ -76,7 +76,7 @@ class CheckCache {
     // Check status.
     ::google::protobuf::util::Status status_;
 
-    // Route directive (if status is OK).
+    // Route directive
     ::istio::mixer::v1::RouteDirective route_directive_;
 
     // The function to set check response.


### PR DESCRIPTION
Use route directive no matter what check status is.
Needed for https://github.com/istio/api/pull/765
Tests are in istio/istio, so need to stage this first.

/assign @mandarjog 
/assign @duderino 

Signed-off-by: Kuat Yessenov <kuat@google.com>
