### PR TITLE
Fix build on macOS.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,16 +77,15 @@ jobs:
     steps:
       - run: sudo ntpdate -vu time.apple.com
       - run: brew install bazel cmake coreutils go libtool ninja wget
-      - run: sudo ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
       - checkout
       - restore_cache:
           keys:
-            - macos_fastbuild_v2-bazel-cache-{{ checksum "WORKSPACE" }}
+            - macos_fastbuild-bazel-cache-{{ checksum "WORKSPACE" }}
       - run: rm ~/.gitconfig
       - run: make build_envoy
       - run: make test
       - save_cache:
-          key: macos_fastbuild_v2-bazel-cache-{{ checksum "WORKSPACE" }}
+          key: macos_fastbuild-bazel-cache-{{ checksum "WORKSPACE" }}
           paths:
             - /Users/distiller/.cache/bazel
 


### PR DESCRIPTION
sha256sum shouldn't be necessary, since we use gsha256sum on macOS.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>