### PR TITLE
Upgrade Envoy to b3be5713f

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,6 @@ jobs:
     steps:
       - run: sudo ntpdate -vu time.apple.com
       - run: brew install bazel cmake coreutils go libtool ninja wget
-      - run: sudo ln -s /usr/local/bin/gsha256sum /usr/local/bin/sha256sum
       - checkout
       - restore_cache:
           keys:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,8 +35,8 @@ bind(
 # When updating envoy sha manually please update the sha in istio.deps file also
 #
 # Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/COMMIT.tar.gz && sha256sum COMMIT.tar.gz`
-ENVOY_SHA = "bbf5674c2c9a901ec4e964e4dd1d845516e672b2"
-ENVOY_SHA256 = "a4e56688cd274db367a5ab905e4d02da6d271189c564ae05e87812c63790c7d6"
+ENVOY_SHA = "b3be5713f2100ab5c40316e73ce34581245bd26a"
+ENVOY_SHA256 = "79629284ae143d66b873c08883dc6382fac2e8ed45f6f3521f7e7282b6650216"
 
 http_archive(
     name = "envoy",

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "bbf5674c2c9a901ec4e964e4dd1d845516e672b2"
+		"lastStableSHA": "b3be5713f2100ab5c40316e73ce34581245bd26a"
 	}
 ]

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -60,6 +60,9 @@ class Filter : public StreamFilter,
   FilterTrailersStatus encodeTrailers(HeaderMap&) override {
     return FilterTrailersStatus::Continue;
   }
+  Http::FilterMetadataStatus encodeMetadata(MetadataMap&) override {
+    return FilterMetadataStatus::Continue;
+  }
   void setEncoderFilterCallbacks(StreamEncoderFilterCallbacks&) override {}
 
   // This is the callback function when Check is done.

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -53,6 +53,6 @@ envoy_cc_test(
         ":config_lib",
         "@envoy//test/mocks/network:network_mocks",
         "@envoy//test/mocks/server:server_mocks",
-        "@envoy//test/test_common:tls_utility_lib",
+        "@envoy//test/extensions/filters/listener/tls_inspector:tls_utility_lib",
     ],
 )

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -21,9 +21,9 @@
 
 #include "common/buffer/buffer_impl.h"
 
+#include "test/extensions/filters/listener/tls_inspector/tls_utility.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
-#include "test/test_common/tls_utility.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates Envoy SHA to [b3be5713f2100ab5c40316e73ce34581245bd26a](https://github.com/envoyproxy/envoy/commit/b3be5713f2100ab5c40316e73ce34581245bd26a).

**Release note**:
```release-note
NONE
```