### PR TITLE
add mixer error details into metadata

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -157,11 +157,7 @@ void Filter::completeCheck(const CheckResponseInfo& info) {
 
   route_directive_ = info.route_directive;
 
-  // set UAEX access log flag
-  if (!status.ok()) {
-    decoder_callbacks_->streamInfo().setResponseFlag(
-        StreamInfo::ResponseFlag::UnauthorizedExternalService);
-  }
+  Utils::CheckResponseInfoToStreamInfo(info, decoder_callbacks_->streamInfo());
 
   // handle direct response from the route directive
   if (route_directive_.direct_response_code() != 0) {

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -61,9 +61,8 @@ void Filter::callCheck() {
   state_ = State::Calling;
   filter_callbacks_->connection().readDisable(true);
   calling_check_ = true;
-  cancel_check_ = handler_->Check(this, [this](const CheckResponseInfo &info) {
-    completeCheck(info);
-  });
+  cancel_check_ = handler_->Check(
+      this, [this](const CheckResponseInfo &info) { completeCheck(info); });
   calling_check_ = false;
 }
 
@@ -139,7 +138,7 @@ Network::FilterStatus Filter::onNewConnection() {
 }
 
 void Filter::completeCheck(const CheckResponseInfo &info) {
-  const auto& status = info.response_status;
+  const auto &status = info.response_status;
   ENVOY_LOG(debug, "Called tcp filter completeCheck: {}", status.ToString());
   cancel_check_ = nullptr;
   if (state_ == State::Closed) {
@@ -147,8 +146,8 @@ void Filter::completeCheck(const CheckResponseInfo &info) {
   }
   state_ = State::Completed;
 
-  Utils::CheckResponseInfoToStreamInfo(info, filter_callbacks_->connection().streamInfo());
-
+  Utils::CheckResponseInfoToStreamInfo(
+      info, filter_callbacks_->connection().streamInfo());
 
   filter_callbacks_->connection().readDisable(false);
 

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -19,8 +19,8 @@
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "google/protobuf/struct.pb.h"
-#include "src/envoy/tcp/mixer/control.h"
 #include "include/istio/mixerclient/check_response.h"
+#include "src/envoy/tcp/mixer/control.h"
 
 namespace Envoy {
 namespace Tcp {

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -20,6 +20,7 @@
 #include "envoy/network/filter.h"
 #include "google/protobuf/struct.pb.h"
 #include "src/envoy/tcp/mixer/control.h"
+#include "include/istio/mixerclient/check_response.h"
 
 namespace Envoy {
 namespace Tcp {
@@ -80,7 +81,7 @@ class Filter : public Network::Filter,
   void callCheck();
 
   // Called when Check is done.
-  void completeCheck(const ::google::protobuf::util::Status &status);
+  void completeCheck(const ::istio::mixerclient::CheckResponseInfo &info);
 
   // Cancel the pending Check call.
   void cancelCheck();

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -89,6 +89,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":utils_lib",
+        "@envoy//test/mocks/stream_info:stream_info_mocks",
         "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -139,5 +139,20 @@ Status ParseJsonMessage(const std::string& json, Message* output) {
   return ::google::protobuf::util::JsonStringToMessage(json, output, options);
 }
 
+void CheckResponseInfoToStreamInfo(
+    const istio::mixerclient::CheckResponseInfo& check_response,
+    StreamInfo::StreamInfo& stream_info) {
+  static std::string metadata_key = "istio.mixer";
+
+  if (!check_response.response_status.ok()) {
+    stream_info.setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
+    ProtobufWkt::Struct metadata;
+    auto fields = *metadata.mutable_fields();
+    fields["status"].set_string_value(check_response.response_status.ToString());
+    stream_info.setDynamicMetadata(metadata_key, metadata);
+  }
+
+}
+
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -145,13 +145,14 @@ void CheckResponseInfoToStreamInfo(
   static std::string metadata_key = "istio.mixer";
 
   if (!check_response.response_status.ok()) {
-    stream_info.setResponseFlag(StreamInfo::ResponseFlag::UnauthorizedExternalService);
+    stream_info.setResponseFlag(
+        StreamInfo::ResponseFlag::UnauthorizedExternalService);
     ProtobufWkt::Struct metadata;
     auto fields = *metadata.mutable_fields();
-    fields["status"].set_string_value(check_response.response_status.ToString());
+    fields["status"].set_string_value(
+        check_response.response_status.ToString());
     stream_info.setDynamicMetadata(metadata_key, metadata);
   }
-
 }
 
 }  // namespace Utils

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -148,7 +148,7 @@ void CheckResponseInfoToStreamInfo(
     stream_info.setResponseFlag(
         StreamInfo::ResponseFlag::UnauthorizedExternalService);
     ProtobufWkt::Struct metadata;
-    auto fields = *metadata.mutable_fields();
+    auto& fields = *metadata.mutable_fields();
     fields["status"].set_string_value(
         check_response.response_status.ToString());
     stream_info.setDynamicMetadata(metadata_key, metadata);

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -21,6 +21,7 @@
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
 #include "google/protobuf/util/json_util.h"
+#include "include/istio/mixerclient/check_response.h"
 
 namespace Envoy {
 namespace Utils {
@@ -51,6 +52,10 @@ bool GetRequestedServerName(const Network::Connection* connection,
 // Parse JSON string into message.
 ::google::protobuf::util::Status ParseJsonMessage(
     const std::string& json, ::google::protobuf::Message* output);
+
+void CheckResponseInfoToStreamInfo(
+    const istio::mixerclient::CheckResponseInfo& check_response,
+    StreamInfo::StreamInfo& stream_info);
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -53,6 +53,7 @@ bool GetRequestedServerName(const Network::Connection* connection,
 ::google::protobuf::util::Status ParseJsonMessage(
     const std::string& json, ::google::protobuf::Message* output);
 
+// Add result of check to envoy stream info to allow better logging.
 void CheckResponseInfoToStreamInfo(
     const istio::mixerclient::CheckResponseInfo& check_response,
     StreamInfo::StreamInfo& stream_info);


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

**What this PR does / why we need it**:

For istio/istio#10965, add the error details into metadata so it can be included in access log.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
