### PR TITLE
Forwarded attributes override statically configured Local Attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ARTIFACTS_DIR ?= $(LOCAL_ARTIFACTS_DIR)
 BAZEL_STARTUP_ARGS ?=
 BAZEL_BUILD_ARGS ?=
 BAZEL_TEST_ARGS ?=
+BAZEL_TARGETS ?= //...
 HUB ?=
 TAG ?=
 ifeq "$(origin CC)" "default"
@@ -30,7 +31,7 @@ CXX := clang++-6.0
 endif
 
 build:
-	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) //...
+	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_TARGETS)
 	@bazel shutdown
 
 # Build only envoy - fast
@@ -43,15 +44,15 @@ clean:
 	@bazel shutdown
 
 test:
-	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) //...
+	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) $(BAZEL_TARGETS)
 	@bazel shutdown
 
 test_asan:
-	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-asan //...
+	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-asan $(BAZEL_TARGETS)
 	@bazel shutdown
 
 test_tsan:
-	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-tsan //...
+	CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-tsan $(BAZEL_TARGETS)
 	@bazel shutdown
 
 check:

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -31,6 +31,11 @@ struct AttributeName {
   static const char kSourceUID[];
   static const char kDestinationPrincipal[];
 
+  static const char kDestinationServiceName[];
+  static const char kDestinationServiceUID[];
+  static const char kDestinationServiceHost[];
+  static const char kDestinationServiceNamespace[];
+
   static const char kRequestHeaders[];
   static const char kRequestHost[];
   static const char kRequestMethod[];

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -16,7 +16,6 @@
 #include "src/istio/control/http/attributes_builder.h"
 
 #include <set>
-
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "include/istio/utils/status.h"
@@ -131,7 +130,8 @@ void AttributesBuilder::ExtractForwardedAttributes(CheckData *check_data) {
     return;
   }
   Attributes v2_format;
-  if (v2_format.ParseFromString(forwarded_data)) {
+  auto ok = v2_format.ParseFromString(forwarded_data);
+  if (ok) {
     request_->attributes->MergeFrom(v2_format);
     return;
   }

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -16,6 +16,7 @@
 #include "src/istio/control/http/attributes_builder.h"
 
 #include <set>
+
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "include/istio/utils/status.h"
@@ -130,8 +131,7 @@ void AttributesBuilder::ExtractForwardedAttributes(CheckData *check_data) {
     return;
   }
   Attributes v2_format;
-  auto ok = v2_format.ParseFromString(forwarded_data);
-  if (ok) {
+  if (v2_format.ParseFromString(forwarded_data)) {
     request_->attributes->MergeFrom(v2_format);
     return;
   }

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -545,7 +545,7 @@ void SetDestinationIp(RequestContext *request, const std::string &ip) {
 
 TEST(AttributesBuilderTest, TestExtractForwardedAttributes) {
   Attributes attr;
-  (*attr.mutable_attributes())["test_key"].set_string_value("test_value");
+  (*attr.mutable_attributes())["source.uid"].set_string_value("test_value");
 
   ::testing::StrictMock<MockCheckData> mock_data;
   EXPECT_CALL(mock_data, ExtractIstioAttributes(_))

--- a/src/istio/control/http/request_handler_impl.cc
+++ b/src/istio/control/http/request_handler_impl.cc
@@ -64,12 +64,12 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
                                      HeaderUpdate* header_update,
                                      TransportCheckFunc transport,
                                      CheckDoneFunc on_done) {
-  service_context_->InjectForwardedAttributes(header_update);
   // Forwarded attributes need to be stored regardless Check is needed
   // or not since the header will be updated or removed.
   AddCheckAttributes(check_data);
   AddForwardAttributes(check_data);
   header_update->RemoveIstioAttributes();
+  service_context_->InjectForwardedAttributes(header_update);
 
   if (!service_context_->enable_mixer_check()) {
     CheckResponseInfo check_response_info;

--- a/src/istio/control/http/request_handler_impl.cc
+++ b/src/istio/control/http/request_handler_impl.cc
@@ -64,11 +64,12 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
                                      HeaderUpdate* header_update,
                                      TransportCheckFunc transport,
                                      CheckDoneFunc on_done) {
+  service_context_->InjectForwardedAttributes(header_update);
   // Forwarded attributes need to be stored regardless Check is needed
   // or not since the header will be updated or removed.
+  AddCheckAttributes(check_data);
   AddForwardAttributes(check_data);
   header_update->RemoveIstioAttributes();
-  service_context_->InjectForwardedAttributes(header_update);
 
   if (!service_context_->enable_mixer_check()) {
     CheckResponseInfo check_response_info;
@@ -77,7 +78,6 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
     return nullptr;
   }
 
-  AddCheckAttributes(check_data);
 
   service_context_->AddQuotas(&request_context_);
 

--- a/src/istio/control/http/request_handler_impl.cc
+++ b/src/istio/control/http/request_handler_impl.cc
@@ -78,7 +78,6 @@ CancelFunc RequestHandlerImpl::Check(CheckData* check_data,
     return nullptr;
   }
 
-
   service_context_->AddQuotas(&request_context_);
 
   return service_context_->client_context()->SendCheck(transport, on_done,

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -49,7 +49,7 @@ const char kLocalInbound[] = R"(
 attributes {
   key: "destination.uid"
   value {
-    string_value: "kubernetes://client-84469dc8d7-jbbxt.default"
+    string_value: "kubernetes://dest-client-84469dc8d7-jbbxt.default"
   }
 }
 )";
@@ -58,7 +58,7 @@ const char kLocalOutbound[] = R"(
 attributes {
   key: "source.uid"
   value {
-    string_value: "kubernetes://client-84469dc8d7-jbbxt.default"
+    string_value: "kubernetes://src-client-84469dc8d7-jbbxt.default"
   }
 }
 )";
@@ -67,7 +67,16 @@ const char kLocalForward[] = R"(
 attributes {
   key: "source.uid"
   value {
-    string_value: "kubernetes://client-84469dc8d7-jbbxt.default"
+    string_value: "kubernetes://src-client-84469dc8d7-jbbxt.default"
+  }
+}
+)";
+
+const char kForwardedAttrib[] = R"(
+attributes {
+  key: "source.uid"
+  value {
+    string_value: "kubernetes://forwarded.default"
   }
 }
 )";
@@ -149,6 +158,10 @@ class RequestHandlerImplTest : public ::testing::Test {
     ASSERT_TRUE(
         TextFormat::ParseFromString(local_forward_attributes, &la.forward));
 
+    Attributes forwarded_attr;
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(kForwardedAttrib, &forwarded_attr));
+
     mock_client_ = new ::testing::NiceMock<MockMixerClient>;
     // set LRU cache size is 3
 
@@ -219,9 +232,6 @@ TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheckReport) {
 TEST_F(RequestHandlerImplTest, TestHandlerDisabledCheck) {
   ::testing::NiceMock<MockCheckData> mock_data;
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
-  // Report is enabled so Check Attributes are not extracted.
-  EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(0);
-  EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(0);
 
   // Check should NOT be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _)).Times(0);
@@ -244,6 +254,14 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
   EXPECT_CALL(mock_data, GetSourceIpPort(_, _)).Times(1);
   EXPECT_CALL(mock_data, GetPrincipal(_, _)).Times(2);
 
+  EXPECT_CALL(mock_data, ExtractIstioAttributes(_))
+      .WillOnce(Invoke([](std::string* data) -> bool{
+        Attributes fwd_attr;
+        //(*fwd_attr.mutable_attributes())["source.uid"].set_string_value("fwded");        
+        fwd_attr.SerializeToString(data);
+        return true;
+      }));
+
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _, _))
       .WillOnce(Invoke([](const Attributes &attributes,
@@ -253,12 +271,17 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
         auto map = attributes.attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["per-route-key"].string_value(), "per-route-value");
+        std::string out_str;
+        TextFormat::PrintToString(attributes, &out_str);
+        EXPECT_EQ(out_str, "bobo");
+        EXPECT_EQ(map["source.uid"].string_value(), "fwded");
         return nullptr;
       }));
 
   ServiceConfig config;
   auto map2 = config.mutable_mixer_attributes()->mutable_attributes();
   (*map2)["per-route-key"].set_string_value("per-route-value");
+  (*map2)["context.repoter.kind"].set_string_value("inbound");
   Controller::PerRouteConfig per_route;
   ApplyPerRouteConfig(config, &per_route);
 

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -25,6 +25,14 @@ const char AttributeName::kSourceNamespace[] = "source.namespace";
 const char AttributeName::kSourceUID[] = "source.uid";
 const char AttributeName::kDestinationPrincipal[] = "destination.principal";
 
+const char AttributeName::kDestinationServiceName[] =
+    "destination.service.name";
+const char AttributeName::kDestinationServiceUID[] = "destination.service.uid";
+const char AttributeName::kDestinationServiceHost[] =
+    "destination.service.host";
+const char AttributeName::kDestinationServiceNamespace[] =
+    "destination.service.namespace";
+
 const char AttributeName::kRequestHeaders[] = "request.headers";
 const char AttributeName::kRequestHost[] = "request.host";
 const char AttributeName::kRequestMethod[] = "request.method";


### PR DESCRIPTION
source.uid is used from forwarded attribute if present, else Local attributes are used.

This restores / fixes source.workload.ui behaviour to 1.0.x

fixes [#10873](https://github.com/istio/istio/issues/10873)

