### PR TITLE
ignore istio.mixer in report

### DIFF
--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -26,6 +26,8 @@
 namespace istio {
 namespace utils {
 
+const char kMixerMetadataKey[] = "istio.mixer";
+
 // Builder class to add attribute to protobuf Attributes.
 // Its usage:
 //    builder(attribute).Add("key", value)
@@ -142,7 +144,9 @@ class AttributesBuilder {
     }
 
     for (const auto &filter : filter_state) {
-      AddProtoStructStringMap(filter.first, filter.second);
+      if (FiltersToIgnore().find(filter.first) == FiltersToIgnore().end()) {
+        AddProtoStructStringMap(filter.first, filter.second);
+      }
     }
   }
 
@@ -152,6 +156,12 @@ class AttributesBuilder {
   }
 
  private:
+  const std::unordered_set<std::string> &FiltersToIgnore() {
+    static const auto *filters =
+        new std::unordered_set<std::string>{kMixerMetadataKey};
+    return *filters;
+  }
+
   ::istio::mixer::v1::Attributes *attributes_;
 };
 

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/utils.h"
+#include "include/istio/utils/attributes_builder.h"
 #include "mixer/v1/attributes.pb.h"
 
 using ::google::protobuf::Message;
@@ -142,8 +143,6 @@ Status ParseJsonMessage(const std::string& json, Message* output) {
 void CheckResponseInfoToStreamInfo(
     const istio::mixerclient::CheckResponseInfo& check_response,
     StreamInfo::StreamInfo& stream_info) {
-  static std::string metadata_key = "istio.mixer";
-
   if (!check_response.response_status.ok()) {
     stream_info.setResponseFlag(
         StreamInfo::ResponseFlag::UnauthorizedExternalService);
@@ -151,7 +150,7 @@ void CheckResponseInfoToStreamInfo(
     auto& fields = *metadata.mutable_fields();
     fields["status"].set_string_value(
         check_response.response_status.ToString());
-    stream_info.setDynamicMetadata(metadata_key, metadata);
+    stream_info.setDynamicMetadata(istio::utils::kMixerMetadataKey, metadata);
   }
 }
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -742,6 +742,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   listval.mutable_list_value()->add_values()->set_string_value("c");
   (*struct_obj.mutable_fields())["list"] = listval;
   filter_metadata["foo.bar.com"] = struct_obj;
+  filter_metadata["istio.mixer"] = struct_obj;  // to be ignored
 
   EXPECT_CALL(mock_data, GetDestinationIpPort(_, _))
       .WillOnce(Invoke([](std::string *ip, int *port) -> bool {

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -487,6 +487,7 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
   listval.mutable_list_value()->add_values()->set_string_value("c");
   (*struct_obj.mutable_fields())["list"] = listval;
   filter_metadata["foo.bar.com"] = struct_obj;
+  filter_metadata["istio.mixer"] = struct_obj;  // to be ignored
 
   EXPECT_CALL(mock_data, GetDestinationIpPort(_, _))
       .Times(4)


### PR DESCRIPTION
**What this PR does / why we need it**:

Partially address #2096 to unblock istio/istio tests.

**Release note**:
```release-note
None
```
