### PR TITLE
remove unused bytestring include from sni_verifier for openssl

### DIFF
--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -25,7 +25,6 @@
 
 #include "common/common/assert.h"
 
-#include "openssl/bytestring.h"
 #include "openssl/err.h"
 #include "openssl/ssl.h"
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -20,7 +20,6 @@
 
 #include "common/common/logger.h"
 
-#include "openssl/bytestring.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {


### PR DESCRIPTION
What this PR does / why we need it:
The bytestring includes in sni_verifier are unused. This header is unique to BoringSSL (i.e. OpenSSL does not provide it). Removing the include makes pluggable openssl easier. 

Which issue this PR fixes:
None

Special notes for your reviewer:
None

Release note:
NONE