### PR TITLE
Add retries to policy checks on failed transport error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ BAZEL_STARTUP_ARGS ?=
 BAZEL_BUILD_ARGS ?=
 BAZEL_TEST_ARGS ?=
 BAZEL_TARGETS ?= //...
+# Some tests run so slowly under the santizers that they always timeout.
+SANITIZER_EXCLUSIONS ?= -test/integration:mixer_fault_test
 HUB ?=
 TAG ?=
 ifeq "$(origin CC)" "default"
@@ -49,11 +51,11 @@ test:
 	@bazel shutdown
 
 test_asan:
-	PATH=$(PATH) CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-asan $(BAZEL_TARGETS)
+	PATH=$(PATH) CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-asan -- $(BAZEL_TARGETS) $(SANITIZER_EXCLUSIONS)
 	@bazel shutdown
 
 test_tsan:
-	PATH=$(PATH) CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-tsan $(BAZEL_TARGETS)
+	PATH=$(PATH) CC=$(CC) CXX=$(CXX) bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-tsan -- $(BAZEL_TARGETS) $(SANITIZER_EXCLUSIONS)
 	@bazel shutdown
 
 check:

--- a/include/istio/control/http/request_handler.h
+++ b/include/istio/control/http/request_handler.h
@@ -35,10 +35,13 @@ class RequestHandler {
   // * extract attributes from the config.
   // * if necessary, forward some attributes to downstream
   // * make a Check call.
-  virtual ::istio::mixerclient::CancelFunc Check(
-      CheckData* check_data, HeaderUpdate* header_update,
-      ::istio::mixerclient::TransportCheckFunc transport,
-      ::istio::mixerclient::CheckDoneFunc on_done) = 0;
+  virtual void Check(CheckData* check_data, HeaderUpdate* header_update,
+                     const ::istio::mixerclient::TransportCheckFunc& transport,
+                     const ::istio::mixerclient::CheckDoneFunc& on_done) = 0;
+
+  virtual void ResetCancel() = 0;
+
+  virtual void CancelCheck() = 0;
 
   // Make a Report call. It will:
   // * check service config to see if Report is required

--- a/include/istio/control/tcp/request_handler.h
+++ b/include/istio/control/tcp/request_handler.h
@@ -32,8 +32,12 @@ class RequestHandler {
   // Perform a Check call. It will:
   // * extract downstream tcp connection attributes
   // * check config, make a Check call if necessary.
-  virtual ::istio::mixerclient::CancelFunc Check(
-      CheckData* check_data, ::istio::mixerclient::CheckDoneFunc on_done) = 0;
+  virtual void Check(CheckData* check_data,
+                     const ::istio::mixerclient::CheckDoneFunc& on_done) = 0;
+
+  virtual void ResetCancel() = 0;
+
+  virtual void CancelCheck() = 0;
 
   // Make report call.
   virtual void Report(ReportData* report_data,

--- a/include/istio/mixerclient/client.h
+++ b/include/istio/mixerclient/client.h
@@ -133,9 +133,9 @@ class MixerClient {
   // The response data from mixer will be consumed by mixer client.
 
   // A check call.
-  virtual CancelFunc Check(istio::mixerclient::CheckContextSharedPtr& context,
-                           TransportCheckFunc transport,
-                           CheckDoneFunc on_done) = 0;
+  virtual void Check(istio::mixerclient::CheckContextSharedPtr& context,
+                     const TransportCheckFunc& transport,
+                     const CheckDoneFunc& on_done) = 0;
 
   // A report call.
   virtual void Report(

--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -39,7 +39,17 @@ struct CheckOptions {
   const int num_entries;
 
   // If true, Check is passed for any network failures.
-  bool network_fail_open = true;
+  bool network_fail_open{true};
+
+  // Number of retries on transport error
+  uint32_t retries{0};
+
+  // Base milliseconds to sleep between retries.  Will be adjusted by
+  // exponential backoff and jitter.
+  uint32_t base_retry_ms{80};
+
+  // Max milliseconds to sleep between retries.
+  uint32_t max_retry_ms{1000};
 };
 
 // Options controlling report batch.

--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "92b7ddc0f30b3aab6a5e82a861e54bf55fe249bd"
+		"lastStableSHA": "5945a02236f53ad860d518772f730594709b1234"
 	},
 	{
 		"_comment": "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -99,8 +99,14 @@ cc_library(
             actual = "@googletest_git//:googletest_prod",
         )
 
-ISTIO_API = "92b7ddc0f30b3aab6a5e82a861e54bf55fe249bd"
-ISTIO_API_SHA256 = "03fc53fe2a2ac980d2fbe9eeab9cf5526f8e493c786f72ba456d4c4e78b44e6b"
+#
+# To update these...
+# 1) find the ISTIO_API SHA you want in git
+# 2) wget https://github.com/istio/api/archive/ISTIO_API_SHA.tar.gz
+# 3) sha256sum ISTIO_API_SHA.tar.gz
+#
+ISTIO_API = "5945a02236f53ad860d518772f730594709b1234"
+ISTIO_API_SHA256 = "b75411deda635c70bdbf12cd1d405129d1f23e6a56a5eebbe69c75cfa3d6009e"
 
 def mixerapi_repositories(bind = True):
     BUILD = """

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -89,8 +89,6 @@ class Filter : public StreamFilter,
   Control& control_;
   // The request handler.
   std::unique_ptr<::istio::control::http::RequestHandler> handler_;
-  // The pending callback object.
-  istio::mixerclient::CancelFunc cancel_check_;
 
   enum State { NotStarted, Calling, Complete, Responded };
   // The state

--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -43,14 +43,12 @@ void Filter::initializeReadFilterCallbacks(
 }
 
 void Filter::cancelCheck() {
-  if (state_ != State::Calling) {
-    cancel_check_ = nullptr;
+  if (state_ != State::Calling && handler_) {
+    handler_->ResetCancel();
   }
   state_ = State::Closed;
-  if (cancel_check_) {
-    ENVOY_LOG(debug, "Cancelling check call");
-    cancel_check_();
-    cancel_check_ = nullptr;
+  if (handler_) {
+    handler_->CancelCheck();
   }
 }
 
@@ -61,7 +59,7 @@ void Filter::callCheck() {
   state_ = State::Calling;
   filter_callbacks_->connection().readDisable(true);
   calling_check_ = true;
-  cancel_check_ = handler_->Check(
+  handler_->Check(
       this, [this](const CheckResponseInfo &info) { completeCheck(info); });
   calling_check_ = false;
 }
@@ -140,7 +138,7 @@ Network::FilterStatus Filter::onNewConnection() {
 void Filter::completeCheck(const CheckResponseInfo &info) {
   const auto &status = info.status();
   ENVOY_LOG(debug, "Called tcp filter completeCheck: {}", status.ToString());
-  cancel_check_ = nullptr;
+  handler_->ResetCancel();
   if (state_ == State::Closed) {
     return;
   }

--- a/src/envoy/tcp/mixer/filter.h
+++ b/src/envoy/tcp/mixer/filter.h
@@ -86,8 +86,6 @@ class Filter : public Network::Filter,
   // Cancel the pending Check call.
   void cancelCheck();
 
-  // the cancel check
-  istio::mixerclient::CancelFunc cancel_check_;
   // the control object.
   Control &control_;
   // pre-request handler

--- a/src/envoy/utils/utils_test.cc
+++ b/src/envoy/utils/utils_test.cc
@@ -51,7 +51,7 @@ TEST(UtilsTest, ParseMessageWithUnknownField) {
 TEST(UtilsTest, CheckResponseInfoToStreamInfo) {
   auto attributes = std::make_shared<::istio::mixerclient::SharedAttributes>();
   ::istio::mixerclient::CheckContext check_response(
-      false /* fail_open */, attributes);  // by default status is unknown
+      0U, false /* fail_open */, attributes);  // by default status is unknown
   Envoy::StreamInfo::MockStreamInfo mock_stream_info;
 
   EXPECT_CALL(

--- a/src/istio/control/client_context_base.h
+++ b/src/istio/control/client_context_base.h
@@ -17,6 +17,7 @@
 #define ISTIO_CONTROL_CLIENT_CONTEXT_BASE_H
 
 #include "include/istio/mixerclient/client.h"
+#include "include/istio/mixerclient/timer.h"
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/local_attributes.h"
 #include "mixer/v1/config/client/client_config.pb.h"
@@ -42,15 +43,15 @@ class ClientContextBase {
       : mixer_client_(std::move(mixer_client)),
         outbound_(outbound),
         local_attributes_(local_attributes),
-        network_fail_open_(false) {}
+        network_fail_open_(false),
+        retries_(0) {}
   // virtual destrutor
   virtual ~ClientContextBase() {}
 
   // Use mixer client object to make a Check call.
-  ::istio::mixerclient::CancelFunc SendCheck(
-      const ::istio::mixerclient::TransportCheckFunc& transport,
-      const ::istio::mixerclient::CheckDoneFunc& on_done,
-      ::istio::mixerclient::CheckContextSharedPtr& check_context);
+  void SendCheck(const ::istio::mixerclient::TransportCheckFunc& transport,
+                 const ::istio::mixerclient::CheckDoneFunc& on_done,
+                 ::istio::mixerclient::CheckContextSharedPtr& check_context);
 
   // Use mixer client object to make a Report call.
   void SendReport(
@@ -66,6 +67,8 @@ class ClientContextBase {
 
   bool NetworkFailOpen() const { return network_fail_open_; }
 
+  uint32_t Retries() const { return retries_; }
+
  private:
   // The mixer client object with check cache and report batch features.
   std::unique_ptr<::istio::mixerclient::MixerClient> mixer_client_;
@@ -77,6 +80,7 @@ class ClientContextBase {
   ::istio::utils::LocalAttributes local_attributes_;
 
   bool network_fail_open_;
+  uint32_t retries_;
 };
 
 }  // namespace control

--- a/src/istio/control/http/request_handler_impl.h
+++ b/src/istio/control/http/request_handler_impl.h
@@ -30,11 +30,16 @@ class RequestHandlerImpl : public RequestHandler {
  public:
   RequestHandlerImpl(std::shared_ptr<ServiceContext> service_context);
 
+  virtual ~RequestHandlerImpl() = default;
+
   // Makes a Check call.
-  ::istio::mixerclient::CancelFunc Check(
-      CheckData* check_data, HeaderUpdate* header_update,
-      ::istio::mixerclient::TransportCheckFunc transport,
-      ::istio::mixerclient::CheckDoneFunc on_done) override;
+  void Check(CheckData* check_data, HeaderUpdate* header_update,
+             const ::istio::mixerclient::TransportCheckFunc& transport,
+             const ::istio::mixerclient::CheckDoneFunc& on_done) override;
+
+  void ResetCancel() override;
+
+  void CancelCheck() override;
 
   // Make a Report call.
   void Report(CheckData* check_data, ReportData* report_data) override;

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -28,6 +28,7 @@ using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::config::client::HttpClientConfig;
 using ::istio::mixer::v1::config::client::ServiceConfig;
 using ::istio::mixerclient::CancelFunc;
+using ::istio::mixerclient::CheckContextSharedPtr;
 using ::istio::mixerclient::CheckDoneFunc;
 using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::mixerclient::DoneFunc;
@@ -253,13 +254,12 @@ TEST_F(RequestHandlerImplTest, TestPerRouteAttributes) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["per-route-key"].string_value(), "per-route-value");
-        return nullptr;
       }));
 
   ServiceConfig config;
@@ -280,13 +280,12 @@ TEST_F(RequestHandlerImplTest, TestDefaultRouteAttributes) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["route0-key"].string_value(), "route0-value");
-        return nullptr;
       }));
 
   // Attribute is forwarded: route override
@@ -318,13 +317,12 @@ TEST_F(RequestHandlerImplTest, TestRouteAttributes) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["global-key"].string_value(), "service-value");
         EXPECT_EQ(map["route1-key"].string_value(), "route1-value");
-        return nullptr;
       }));
 
   // Attribute is forwarded: global
@@ -348,15 +346,14 @@ TEST_F(RequestHandlerImplTest, TestPerRouteQuota) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(context->quotaRequirements().size(), 1);
         EXPECT_EQ(context->quotaRequirements()[0].quota, "route0-quota");
         EXPECT_EQ(context->quotaRequirements()[0].charge, 10);
-        return nullptr;
       }));
 
   ServiceConfig config;
@@ -389,14 +386,13 @@ TEST_F(RequestHandlerImplTest, TestPerRouteApiSpec) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["global-key"].string_value(), "global-value");
         EXPECT_EQ(map["api.name"].string_value(), "test-name");
         EXPECT_EQ(map["api.operation"].string_value(), "test-method");
-        return nullptr;
       }));
 
   ServiceConfig config;
@@ -448,13 +444,12 @@ TEST_F(RequestHandlerImplTest, TestDefaultApiKey) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map[utils::AttributeName::kRequestApiKey].string_value(),
                   "test-api-key");
-        return nullptr;
       }));
 
   // destionation.server is empty, will use default one
@@ -548,13 +543,12 @@ TEST_F(OutboundRequestHandlerImplTest, TestLocalAttributes) {
   ::testing::NiceMock<MockHeaderUpdate> mock_header;
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["source.uid"].string_value(),
                   "kubernetes://src-client-84469dc8d7-jbbxt.default");
-        return nullptr;
       }));
 
   ServiceConfig config;
@@ -581,13 +575,12 @@ TEST_F(OutboundRequestHandlerImplTest, TestLocalAttributesOverride) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["source.uid"].string_value(), "fwded");
         EXPECT_NE(map["destination.uid"].string_value(), "ignored");
-        return nullptr;
       }));
 
   ServiceConfig config;

--- a/src/istio/control/mock_mixer_client.h
+++ b/src/istio/control/mock_mixer_client.h
@@ -25,10 +25,10 @@ namespace control {
 // The mock object for MixerClient interface.
 class MockMixerClient : public ::istio::mixerclient::MixerClient {
  public:
-  MOCK_METHOD3(Check, ::istio::mixerclient::CancelFunc(
-                          ::istio::mixerclient::CheckContextSharedPtr& context,
-                          ::istio::mixerclient::TransportCheckFunc transport,
-                          ::istio::mixerclient::CheckDoneFunc on_done));
+  MOCK_METHOD3(Check,
+               void(::istio::mixerclient::CheckContextSharedPtr& context,
+                    const ::istio::mixerclient::TransportCheckFunc& transport,
+                    const ::istio::mixerclient::CheckDoneFunc& on_done));
   MOCK_METHOD1(
       Report,
       void(const istio::mixerclient::SharedAttributesSharedPtr& attributes));

--- a/src/istio/control/tcp/request_handler_impl.h
+++ b/src/istio/control/tcp/request_handler_impl.h
@@ -30,9 +30,12 @@ class RequestHandlerImpl : public RequestHandler {
   RequestHandlerImpl(std::shared_ptr<ClientContext> client_context);
 
   // Make a Check call.
-  ::istio::mixerclient::CancelFunc Check(
-      CheckData* check_data,
-      ::istio::mixerclient::CheckDoneFunc on_done) override;
+  void Check(CheckData* check_data,
+             const ::istio::mixerclient::CheckDoneFunc& on_done) override;
+
+  void ResetCancel() override;
+
+  void CancelCheck() override;
 
   // Make a Report call.
   void Report(ReportData* report_data,

--- a/src/istio/control/tcp/request_handler_impl_test.cc
+++ b/src/istio/control/tcp/request_handler_impl_test.cc
@@ -26,6 +26,7 @@ using ::google::protobuf::util::Status;
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::config::client::TcpClientConfig;
 using ::istio::mixerclient::CancelFunc;
+using ::istio::mixerclient::CheckContextSharedPtr;
 using ::istio::mixerclient::CheckDoneFunc;
 using ::istio::mixerclient::CheckResponseInfo;
 using ::istio::mixerclient::DoneFunc;
@@ -124,15 +125,14 @@ TEST_F(RequestHandlerImplTest, TestHandlerCheck) {
 
   // Check should be called.
   EXPECT_CALL(*mock_client_, Check(_, _, _))
-      .WillOnce(Invoke([](istio::mixerclient::CheckContextSharedPtr &context,
-                          TransportCheckFunc transport,
-                          CheckDoneFunc on_done) -> CancelFunc {
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["key1"].string_value(), "value1");
         EXPECT_EQ(context->quotaRequirements().size(), 1);
         EXPECT_EQ(context->quotaRequirements()[0].quota, "quota");
         EXPECT_EQ(context->quotaRequirements()[0].charge, 5);
-        return nullptr;
       }));
 
   auto handler = controller_->CreateRequestHandler();

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -14,8 +14,11 @@
  */
 #include "src/istio/mixerclient/client_impl.h"
 #include <google/protobuf/arena.h>
+#include <algorithm>
+#include <cmath>
 #include "include/istio/mixerclient/check_response.h"
 #include "include/istio/utils/protobuf.h"
+#include "src/istio/utils/logger.h"
 
 using ::google::protobuf::util::Status;
 using ::google::protobuf::util::error::Code;
@@ -62,11 +65,12 @@ TransportResult TransportStatus(const Status &status) {
 
 MixerClientImpl::MixerClientImpl(const MixerClientOptions &options)
     : options_(options) {
+  timer_create_ = options.env.timer_create_func;
   check_cache_ =
       std::unique_ptr<CheckCache>(new CheckCache(options.check_options));
   report_batch_ = std::unique_ptr<ReportBatch>(
       new ReportBatch(options.report_options, options_.env.report_transport,
-                      options.env.timer_create_func, compressor_));
+                      timer_create_, compressor_));
   quota_cache_ =
       std::unique_ptr<QuotaCache>(new QuotaCache(options.quota_options));
 
@@ -77,15 +81,31 @@ MixerClientImpl::MixerClientImpl(const MixerClientOptions &options)
 
 MixerClientImpl::~MixerClientImpl() {}
 
-CancelFunc MixerClientImpl::Check(CheckContextSharedPtr &context,
-                                  TransportCheckFunc transport,
-                                  CheckDoneFunc on_done) {
+uint32_t MixerClientImpl::RetryDelay(uint32_t retry_attempt) {
+  const uint32_t max_retry_ms =
+      std::min(options_.check_options.max_retry_ms,
+               options_.check_options.base_retry_ms *
+                   static_cast<uint32_t>(std::pow(2, retry_attempt)));
+
+  std::uniform_int_distribution<uint32_t> distribution(
+      options_.check_options.base_retry_ms, max_retry_ms);
+
+  return distribution(rand_);
+}
+
+void MixerClientImpl::Check(CheckContextSharedPtr &context,
+                            const TransportCheckFunc &transport,
+                            const CheckDoneFunc &on_done) {
   //
   // Always check the policy cache
   //
 
   context->checkPolicyCache(*check_cache_);
   ++total_check_calls_;
+
+  MIXER_DEBUG("Policy cache hit=%s, status=%s",
+              context->policyCacheHit() ? "true" : "false",
+              context->policyStatus().ToString().c_str());
 
   if (context->policyCacheHit()) {
     ++total_check_cache_hits_;
@@ -97,7 +117,7 @@ CancelFunc MixerClientImpl::Check(CheckContextSharedPtr &context,
       ++total_check_cache_hit_denies_;
       context->setFinalStatus(context->policyStatus());
       on_done(*context);
-      return nullptr;
+      return;
     }
 
     //
@@ -108,15 +128,22 @@ CancelFunc MixerClientImpl::Check(CheckContextSharedPtr &context,
     if (!context->quotaCheckRequired()) {
       context->setFinalStatus(context->policyStatus());
       on_done(*context);
-      return nullptr;
+      return;
     }
   } else {
     ++total_check_cache_misses_;
   }
 
+  bool remote_quota_prefetch{false};
+
   if (context->quotaCheckRequired()) {
     context->checkQuotaCache(*quota_cache_);
     ++total_quota_calls_;
+
+    MIXER_DEBUG("Quota cache hit=%s, status=%s, remote_call=%s",
+                context->quotaCacheHit() ? "true" : "false",
+                context->quotaStatus().ToString().c_str(),
+                context->remoteQuotaRequestRequired() ? "true" : "false");
 
     if (context->quotaCacheHit()) {
       ++total_quota_cache_hits_;
@@ -135,11 +162,9 @@ CancelFunc MixerClientImpl::Check(CheckContextSharedPtr &context,
         //
         context->setFinalStatus(context->quotaStatus());
         on_done(*context);
-        on_done = nullptr;
-        if (!context->remoteQuotaRequestRequired()) {
-          return nullptr;
-        } else {
-          ++total_remote_quota_prefetch_calls_;
+        remote_quota_prefetch = context->remoteQuotaRequestRequired();
+        if (!remote_quota_prefetch) {
+          return;
         }
       }
     } else {
@@ -151,10 +176,6 @@ CancelFunc MixerClientImpl::Check(CheckContextSharedPtr &context,
   context->compressRequest(
       compressor_,
       deduplication_id_base_ + std::to_string(deduplication_id_.fetch_add(1)));
-
-  if (!transport) {
-    transport = options_.env.check_transport;
-  }
 
   //
   // Classify and track reason for remote request
@@ -170,82 +191,136 @@ CancelFunc MixerClientImpl::Check(CheckContextSharedPtr &context,
     ++total_remote_quota_calls_;
   }
 
-  return transport(context->request(), context->response(),
-                   [this, context, on_done](const Status &status) {
-                     //
-                     // Classify and track transport errors
-                     //
+  if (remote_quota_prefetch) {
+    ++total_remote_quota_prefetch_calls_;
+  }
 
-                     TransportResult result = TransportStatus(status);
+  RemoteCheck(context, transport ? transport : options_.env.check_transport,
+              remote_quota_prefetch ? nullptr : on_done);
+}
 
-                     switch (result) {
-                       case TransportResult::SUCCESS:
-                         ++total_remote_call_successes_;
-                         break;
-                       case TransportResult::RESPONSE_TIMEOUT:
-                         ++total_remote_call_timeouts_;
-                         break;
-                       case TransportResult::SEND_ERROR:
-                         ++total_remote_call_send_errors_;
-                         break;
-                       case TransportResult::OTHER:
-                         ++total_remote_call_other_errors_;
-                         break;
-                     }
+void MixerClientImpl::RemoteCheck(CheckContextSharedPtr context,
+                                  const TransportCheckFunc &transport,
+                                  const CheckDoneFunc &on_done) {
+  //
+  // This lambda and any lambdas it creates for retry will inc the ref count
+  // on the CheckContext shared pointer.
+  //
+  // The other captures (this/MixerClientImpl, transport func, and on_done func
+  // are assumed to be long-lived objects that exist until shutdown.
+  //
+  CancelFunc cancel_func = transport(
+      context->request(), context->response(),
+      [this, context, transport, on_done](const Status &status) {
+        context->resetCancel();
 
-                     //
-                     // Update caches.  This has the side-effect of updating
-                     // status, so track those too
-                     //
+        //
+        // Classify and track transport errors
+        //
 
-                     if (!context->policyCacheHit()) {
-                       context->updatePolicyCache(status, *context->response());
+        TransportResult result = TransportStatus(status);
 
-                       if (context->policyStatus().ok()) {
-                         ++total_remote_check_accepts_;
-                       } else {
-                         ++total_remote_check_denies_;
-                       }
-                     }
+        switch (result) {
+          case TransportResult::SUCCESS:
+            ++total_remote_call_successes_;
+            break;
+          case TransportResult::RESPONSE_TIMEOUT:
+            ++total_remote_call_timeouts_;
+            break;
+          case TransportResult::SEND_ERROR:
+            ++total_remote_call_send_errors_;
+            break;
+          case TransportResult::OTHER:
+            ++total_remote_call_other_errors_;
+            break;
+        }
 
-                     if (context->quotaCheckRequired()) {
-                       context->updateQuotaCache(status, *context->response());
+        if (result != TransportResult::SUCCESS && context->retryable()) {
+          ++total_remote_call_retries_;
+          const uint32_t retry_ms = RetryDelay(context->retryAttempt());
 
-                       if (context->quotaStatus().ok()) {
-                         ++total_remote_quota_accepts_;
-                       } else {
-                         ++total_remote_quota_denies_;
-                       }
-                     }
+          MIXER_DEBUG("Retry %u in %u msec due to transport error=%s",
+                      context->retryAttempt() + 1, retry_ms,
+                      status.ToString().c_str());
 
-                     //
-                     // Determine final status for Filter::completeCheck(). This
-                     // will send an error response to the downstream client if
-                     // the final status is not Status::OK
-                     //
+          context->retry(retry_ms,
+                         timer_create_([this, context, transport, on_done]() {
+                           RemoteCheck(context, transport, on_done);
+                         }));
 
-                     if (result != TransportResult::SUCCESS) {
-                       if (context->networkFailOpen()) {
-                         context->setFinalStatus(Status::OK);
-                       } else {
-                         context->setFinalStatus(status);
-                       }
-                     } else if (!context->quotaCheckRequired()) {
-                       context->setFinalStatus(context->policyStatus());
-                     } else if (!context->policyStatus().ok()) {
-                       context->setFinalStatus(context->policyStatus());
-                     } else {
-                       context->setFinalStatus(context->quotaStatus());
-                     }
+          return;
+        }
 
-                     if (on_done) {
-                       on_done(*context);
-                     }
+        //
+        // Update caches.  This has the side-effect of updating
+        // status, so track those too
+        //
 
-                     if (utils::InvalidDictionaryStatus(status)) {
-                       compressor_.ShrinkGlobalDictionary();
-                     }
-                   });
+        if (!context->policyCacheHit()) {
+          context->updatePolicyCache(status, *context->response());
+
+          if (context->policyStatus().ok()) {
+            ++total_remote_check_accepts_;
+          } else {
+            ++total_remote_check_denies_;
+          }
+        }
+
+        if (context->quotaCheckRequired()) {
+          context->updateQuotaCache(status, *context->response());
+
+          if (context->quotaStatus().ok()) {
+            ++total_remote_quota_accepts_;
+          } else {
+            ++total_remote_quota_denies_;
+          }
+        }
+
+        MIXER_DEBUG(
+            "CheckResult transport=%s, policy=%s, quota=%s, attempt=%u",
+            status.ToString().c_str(),
+            result == TransportResult::SUCCESS
+                ? context->policyStatus().ToString().c_str()
+                : "NA",
+            result == TransportResult::SUCCESS && context->quotaCheckRequired()
+                ? context->policyStatus().ToString().c_str()
+                : "NA",
+            context->retryAttempt());
+
+        //
+        // Determine final status for Filter::completeCheck(). This
+        // will send an error response to the downstream client if
+        // the final status is not Status::OK
+        //
+
+        if (result != TransportResult::SUCCESS) {
+          if (context->networkFailOpen()) {
+            context->setFinalStatus(Status::OK);
+          } else {
+            context->setFinalStatus(status);
+          }
+        } else if (!context->quotaCheckRequired()) {
+          context->setFinalStatus(context->policyStatus());
+        } else if (!context->policyStatus().ok()) {
+          context->setFinalStatus(context->policyStatus());
+        } else {
+          context->setFinalStatus(context->quotaStatus());
+        }
+
+        if (on_done) {
+          on_done(*context);
+        }
+
+        if (utils::InvalidDictionaryStatus(status)) {
+          // TODO(jblatt) verify this is threadsafe
+          compressor_.ShrinkGlobalDictionary();
+        }
+      });
+
+  context->setCancel([this, cancel_func]() {
+    ++total_remote_call_cancellations_;
+    cancel_func();
+  });
 }
 
 void MixerClientImpl::Report(const SharedAttributesSharedPtr &attributes) {

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -206,8 +206,12 @@ void MixerClientImpl::RemoteCheck(CheckContextSharedPtr context,
   // This lambda and any lambdas it creates for retry will inc the ref count
   // on the CheckContext shared pointer.
   //
-  // The other captures (this/MixerClientImpl, transport func, and on_done func
-  // are assumed to be long-lived objects that exist until shutdown.
+  // The CheckDoneFunc is valid as long as the Filter object is valid.  This
+  // has a lifespan similar to the CheckContext, but TODO(jblatt) it would be
+  // good to move this into the CheckContext anyways.
+  //
+  // The other captures (this/MixerClientImpl and TransportCheckFunc's
+  // references) have lifespans much greater than any individual transaction.
   //
   CancelFunc cancel_func = transport(
       context->request(), context->response(),

--- a/src/istio/mixerclient/client_impl_test.cc
+++ b/src/istio/mixerclient/client_impl_test.cc
@@ -19,6 +19,7 @@
 #include "include/istio/mixerclient/client.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "src/istio/mixerclient/status_test_util.h"
+#include "src/istio/utils/logger.h"
 
 using ::google::protobuf::util::Status;
 using ::google::protobuf::util::error::Code;
@@ -128,11 +129,12 @@ class MixerClientImplTest : public ::testing::Test {
   }
 
   CheckContextSharedPtr CreateContext(int quota_request) {
+    uint32_t retries{0};
     bool fail_open{false};
     istio::mixerclient::SharedAttributesSharedPtr attributes{
         new SharedAttributes()};
     istio::mixerclient::CheckContextSharedPtr context{
-        new CheckContext(fail_open, attributes)};
+        new CheckContext(retries, fail_open, attributes)};
     if (0 < quota_request) {
       context->quotaRequirements().push_back({kRequestCount, quota_request});
     }

--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -72,6 +72,9 @@ void ReportBatch::FlushWithLock() {
   ++total_remote_report_calls_;
   auto request = batch_compressor_->Finish();
   ReportResponse* response = new ReportResponse;
+
+  // TODO(jblatt) should an async call be made while this lock is held?  Can the
+  // request send block()?
   transport_(request, response, [this, response](const Status& status) {
     delete response;
     if (!status.ok()) {

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -58,6 +58,20 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "mixer_fault_test",
+    srcs = [
+        "mixer_fault_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        "//include/istio/utils:attribute_names_header",
+        "//src/envoy/http/mixer:filter_lib",
+        "//src/envoy/utils:filter_names_lib",
+        ":int_client_server",
+    ],
+)
+
+envoy_cc_test(
     name = "int_client_server_test",
     srcs = [
         "int_client_server_test.cc",

--- a/test/integration/mixer_fault_test.cc
+++ b/test/integration/mixer_fault_test.cc
@@ -1038,7 +1038,7 @@ TEST_F(MixerFaultTest, CancelCheck) {
                   connections_to_initiate / 2, 2 * connections_to_initiate);
   EXPECT_EQ(counters["http_mixer_filter.total_check_cache_hits"], 0);
   EXPECT_IN_RANGE(counters["http_mixer_filter.total_remote_call_cancellations"],
-            connections_to_initiate * 0.8, connections_to_initiate);
+                  connections_to_initiate * 0.8, connections_to_initiate);
   EXPECT_GE(counters["http_mixer_filter.total_remote_calls"],
             connections_to_initiate);
   EXPECT_EQ(counters["http_mixer_filter.total_remote_quota_accepts"], 0);

--- a/test/integration/mixer_fault_test.cc
+++ b/test/integration/mixer_fault_test.cc
@@ -1,0 +1,1069 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <future>
+#include "gtest/gtest.h"
+#include "include/istio/mixerclient/options.h"
+#include "int_client.h"
+#include "int_server.h"
+#include "mixer/v1/mixer.pb.h"
+#include "test/integration/http_integration.h"
+#include "test/test_common/network_utility.h"
+
+namespace Mixer {
+namespace Integration {
+
+enum class NetworkFailPolicy { FAIL_OPEN = 0, FAIL_CLOSED = 1 };
+
+inline static int networkFailPolicyToInt(NetworkFailPolicy policy) {
+  switch (policy) {
+    case NetworkFailPolicy::FAIL_OPEN:
+      return 0;
+    default:
+      return 1;
+  }
+}
+
+class MixerFaultTest : public Envoy::HttpIntegrationTest, public testing::Test {
+ public:
+  MixerFaultTest()
+      : HttpIntegrationTest(
+            Envoy::Http::CodecClient::Type::HTTP1,
+            Envoy::Network::Address::IpVersion::v4,
+            std::make_unique<Envoy::Event::TestRealTimeSystem>()),
+        transport_socket_factory_(),
+        client_("client") {
+    Envoy::Http::CodecClient::Type origin_protocol =
+        Envoy::Http::CodecClient::Type::HTTP2;
+    setUpstreamProtocol(Envoy::Http::CodecClient::Type::HTTP2 == origin_protocol
+                            ? Envoy::FakeHttpConnection::Type::HTTP2
+                            : Envoy::FakeHttpConnection::Type::HTTP1);
+
+    // Tell the base class that we will create our own upstream origin server.
+    fake_upstreams_count_ = 0;
+
+    origin_listeners_.emplace_back(new LocalListenSocket());
+    origin_servers_.emplace_back(
+        new Server(fmt::sprintf("origin-0"), *origin_listeners_.back(),
+                   transport_socket_factory_, origin_protocol));
+  }
+
+  virtual ~MixerFaultTest() {}
+
+  // TODO modify BaseIntegrationTest in Envoy to eliminate this copy of the
+  // createEnvoy function.
+  virtual void createEnvoy() override {
+    std::vector<uint32_t> ports;
+
+    // TODO modify BaseIntegrationTest to add additional ports without having to
+    // make them fake upstreams
+    addPorts(ports);
+
+    config_helper_.finalize(ports);
+
+    // TODO modify BaseIntegrationTest use protected inheritance for
+    // Envoy::Logger::Loggable so tests can use ENVOY_LOG fprintf(stderr,
+    // "Running Envoy with configuration:\n%s",
+    // config_helper_.bootstrap().DebugString().c_str());
+
+    const std::string bootstrap_path =
+        Envoy::TestEnvironment::writeStringToFileForTest(
+            "bootstrap.json", Envoy::MessageUtil::getJsonStringFromMessage(
+                                  config_helper_.bootstrap()));
+
+    std::vector<std::string> named_ports;
+    const auto &static_resources =
+        config_helper_.bootstrap().static_resources();
+    for (int i = 0; i < static_resources.listeners_size(); ++i) {
+      named_ports.push_back(static_resources.listeners(i).name());
+    }
+    createGeneratedApiTestServer(bootstrap_path, named_ports);
+  }
+
+  void extractMixerCounters(const Envoy::Stats::Store &stats,
+                            std::unordered_map<std::string, uint64_t> &map) {
+    const std::string prefix("http_mixer_filter");
+
+    for (auto counter : stats.counters()) {
+      if (!std::equal(prefix.begin(), prefix.begin() + prefix.size(),
+                      counter->name().begin())) {
+        continue;
+      }
+
+      map[counter->name()] = counter->value();
+    }
+  }
+
+ protected:
+  LoadGeneratorPtr startServers(NetworkFailPolicy fail_policy,
+                                ServerCallbackHelper &origin_callbacks,
+                                ClusterHelper &policy_cluster,
+                                ClusterHelper &telemetry_cluster,
+                                uint32_t retries = 0,
+                                uint32_t base_retry_ms = 10,
+                                uint32_t max_retry_ms = 100) {
+    for (size_t i = 0; i < origin_servers_.size(); ++i) {
+      origin_servers_[i]->start(origin_callbacks);
+    }
+
+    for (size_t i = 0; i < policy_cluster.servers().size(); ++i) {
+      policy_listeners_.emplace_back(new LocalListenSocket());
+      policy_servers_.emplace_back(new Server(
+          fmt::sprintf("policy-%d", i), *policy_listeners_.back(),
+          transport_socket_factory_, Envoy::Http::CodecClient::Type::HTTP2));
+      policy_servers_.back()->start(*policy_cluster.servers()[i]);
+    }
+
+    for (size_t i = 0; i < telemetry_cluster.servers().size(); ++i) {
+      telemetry_listeners_.emplace_back(new LocalListenSocket());
+      telemetry_servers_.emplace_back(new Server(
+          fmt::sprintf("telemetry-%d", i), *telemetry_listeners_.back(),
+          transport_socket_factory_, Envoy::Http::CodecClient::Type::HTTP2));
+      telemetry_servers_.back()->start(*telemetry_cluster.servers()[i]);
+    }
+
+    std::string telemetry_name("telemetry-backend");
+    std::string policy_name("policy-backend");
+
+    addNodeMetadata();
+    configureMixerFilter(fail_policy, policy_name, telemetry_name, retries,
+                         base_retry_ms, max_retry_ms);
+    addCluster(telemetry_name, telemetry_listeners_);
+    addCluster(policy_name, policy_listeners_);
+
+    // This calls createEnvoy() (see below) and then starts envoy
+    HttpIntegrationTest::initialize();
+
+    auto addr = Envoy::Network::Utility::parseInternetAddress(
+        "127.0.0.1", static_cast<uint16_t>(lookupPort("http")));
+    return std::make_unique<LoadGenerator>(client_, transport_socket_factory_,
+                                           HttpVersion::HTTP1, addr);
+  }
+
+ private:
+  void addPorts(std::vector<uint32_t> &ports) {
+    // origin must come first.  The order of the rest depends on the order their
+    // cluster was added to the config.
+    for (size_t i = 0; i < origin_listeners_.size(); ++i) {
+      ports.push_back(origin_listeners_[i]->localAddress()->ip()->port());
+    }
+
+    for (size_t i = 0; i < telemetry_listeners_.size(); ++i) {
+      ports.push_back(telemetry_listeners_[i]->localAddress()->ip()->port());
+    }
+
+    for (size_t i = 0; i < policy_listeners_.size(); ++i) {
+      ports.push_back(policy_listeners_[i]->localAddress()->ip()->port());
+    }
+  }
+
+  void addNodeMetadata() {
+    config_helper_.addConfigModifier(
+        [](envoy::config::bootstrap::v2::Bootstrap &bootstrap) {
+          ::google::protobuf::Struct meta;
+
+          Envoy::MessageUtil::loadFromJson(R"({
+        "ISTIO_VERSION": "1.0.1",
+        "NODE_UID": "pod",
+        "NODE_NAMESPACE": "kubernetes://dest.pod"
+      })",
+                                           meta);
+
+          bootstrap.mutable_node()->mutable_metadata()->MergeFrom(meta);
+        });
+  }
+
+  void configureMixerFilter(NetworkFailPolicy fail_policy,
+                            const std::string &policy_name,
+                            const std::string &telemetry_name, uint32_t retries,
+                            uint32_t base_retry_ms, uint32_t max_retry_ms) {
+    const uint32_t base_retry_sec = base_retry_ms / 1000;
+    const uint32_t base_retry_nanos = base_retry_sec % 1000 * 1'000'000;
+    const uint32_t max_retry_sec = max_retry_ms / 1000;
+    const uint32_t max_retry_nanos = max_retry_sec % 1000 * 1'000'000;
+    constexpr char sourceUID[] = "kubernetes://src.pod";
+
+    std::string mixer_conf{fmt::sprintf(
+        R"EOF(
+  name: mixer
+  config:
+    defaultDestinationService: "default"
+    mixerAttributes:
+      attributes: {}
+    serviceConfigs: {
+      "default": {}
+    }
+    transport:
+      attributes_for_mixer_proxy:
+        attributes: {
+          "source.uid": {
+            string_value: %s
+          }
+        }
+      network_fail_policy: {
+        policy: %d,
+        max_retry: %u,
+        base_retry_wait: {
+          seconds: %u,
+          nanos: %u
+        },
+        max_retry_wait: {
+          seconds: %u,
+          nanos: %u
+        }
+      }
+      report_cluster: %s
+      check_cluster: %s
+                  )EOF",
+        sourceUID, networkFailPolicyToInt(fail_policy), retries, base_retry_sec,
+        base_retry_nanos, max_retry_sec, max_retry_nanos,
+        telemetry_name.c_str(), policy_name.c_str())};
+    config_helper_.addFilter(mixer_conf);
+  }
+
+  void addCluster(
+      const std::string &name,
+      const std::vector<Envoy::Network::TcpListenSocketPtr> &listeners) {
+    constexpr uint32_t max_uint32 =
+        2147483647U;  // protobuf max, not language max
+
+    // See
+    // https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/cds.proto#cluster
+
+    // TODO something in the base class clobbers the connection timeout here
+    std::string cluster_conf{fmt::sprintf(R"EOF(
+                      name: %s
+                      type: STATIC
+                      lb_policy: ROUND_ROBIN
+                      http2_protocol_options: {
+                         max_concurrent_streams: %u
+                      }
+                      connect_timeout: 1s
+                      max_requests_per_connection: %u
+                      hosts:
+                  )EOF",
+                                          name.c_str(), max_uint32,
+                                          max_uint32)};
+
+    for (size_t i = 0; i < listeners.size(); ++i) {
+      cluster_conf.append({fmt::sprintf(
+          R"EOF(
+                        - socket_address:
+                            address: %s
+                            port_value: %d
+                  )EOF",
+          Envoy::Network::Test::getLoopbackAddressString(version_),
+          listeners[i]->localAddress()->ip()->port())});
+    }
+
+    config_helper_.addConfigModifier(
+        [cluster_conf](envoy::config::bootstrap::v2::Bootstrap &bootstrap) {
+          bootstrap.mutable_static_resources()->add_clusters()->CopyFrom(
+              Envoy::TestUtility::parseYaml<envoy::api::v2::Cluster>(
+                  cluster_conf));
+        });
+  }
+
+  Envoy::Network::RawBufferSocketFactory transport_socket_factory_;
+  Client client_;
+  std::vector<Envoy::Network::TcpListenSocketPtr> origin_listeners_;
+  std::vector<Envoy::Network::TcpListenSocketPtr> policy_listeners_;
+  std::vector<Envoy::Network::TcpListenSocketPtr> telemetry_listeners_;
+  // These three vectors could store Server directly if
+  // Envoy::Stats::IsolatedStoreImpl was made movable.
+  std::vector<ServerPtr> origin_servers_;
+  std::vector<ServerPtr> policy_servers_;
+  std::vector<ServerPtr> telemetry_servers_;
+  Envoy::Network::Address::InstanceConstSharedPtr
+      envoy_address_;  // at most 1 envoy
+};
+
+TEST_F(MixerFaultTest, HappyPath) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 300;
+  constexpr uint32_t requests_to_send = 30 * connections_to_initiate;
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+        // Send a gRPC success response immediately to every policy check
+        ::istio::mixer::v1::CheckResponse response;
+        response.mutable_precondition()->mutable_status()->set_code(
+            google::protobuf::util::error::Code::OK);
+        stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                std::chrono::milliseconds(0));
+      })});
+
+  ClusterHelper telemetry_cluster(
+      {new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+        // Send a gRPC success response immediately to every telemetry report.
+        ::istio::mixer::v1::ReportResponse response;
+        stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                std::chrono::milliseconds(0));
+      })});
+
+  LoadGeneratorPtr client = startServers(fail_policy, origin_callbacks,
+                                         policy_cluster, telemetry_cluster);
+
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+  client->run(connections_to_initiate, requests_to_send, std::move(request));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client response callback is called for every request sent
+  EXPECT_EQ(client->responsesReceived(), requests_to_send);
+  // Every response was a 2xx class
+  EXPECT_EQ(client->class2xxResponses(), requests_to_send);
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(0, client->class5xxResponses());
+  EXPECT_EQ(0, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // assert that the origin request callback is called for every client request
+  // sent
+  EXPECT_EQ(origin_callbacks.requestsReceived(), requests_to_send);
+
+  // assert that the policy request callback is called for every client request
+  // sent
+  EXPECT_EQ(policy_cluster.requestsReceived(), requests_to_send);
+}
+
+TEST_F(MixerFaultTest, FailClosedAndClosePolicySocketAfterAccept) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 30;
+  constexpr uint32_t requests_to_send = 30 * connections_to_initiate;
+
+  //
+  // Setup
+  //
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {// Policy server immediately closes any connection accepted.
+       new ServerCallbackHelper(
+           [](ServerConnection &, ServerStream &,
+              Envoy::Http::HeaderMapPtr &&) {
+             GTEST_FATAL_FAILURE_(
+                 "Connections immediately closed so no response should be "
+                 "received");
+           },
+           [](ServerConnection &) -> ServerCallbackResult {
+             return ServerCallbackResult::CLOSE;
+           })});
+
+  ClusterHelper telemetry_cluster(
+      {// Telemetry server sends a gRPC success response immediately to every
+       // telemetry report.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::ReportResponse response;
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  LoadGeneratorPtr client = startServers(fail_policy, origin_callbacks,
+                                         policy_cluster, telemetry_cluster);
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+  client->run(connections_to_initiate, requests_to_send, std::move(request));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client response callback is called for every request sent
+  EXPECT_EQ(client->responsesReceived(), requests_to_send);
+  // Every response was a 5xx class
+  EXPECT_EQ(0, client->class2xxResponses());
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(requests_to_send, client->class5xxResponses());
+  EXPECT_EQ(0, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // Origin server should see no requests since the mixer filter is configured
+  // to fail closed.
+  EXPECT_EQ(0, origin_callbacks.requestsReceived());
+
+  // Policy server accept callback is called for every client connection
+  // initiated.
+  EXPECT_GE(policy_cluster.connectionsAccepted(), connections_to_initiate);
+  // Policy server request callback is never called
+  EXPECT_EQ(0, policy_cluster.requestsReceived());
+  // Policy server closes every connection
+  EXPECT_EQ(policy_cluster.connectionsAccepted(), policy_cluster.localCloses());
+  EXPECT_EQ(0, policy_cluster.remoteCloses());
+}
+
+TEST_F(MixerFaultTest, FailClosedAndSendPolicyResponseSlowly) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 30 * 30;
+  constexpr uint32_t requests_to_send = 1 * connections_to_initiate;
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {// Send a gRPC success response after 60 seconds to every policy check
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(60'000));
+       })});
+
+  ClusterHelper telemetry_cluster(
+      {// Sends a gRPC success response immediately to every telemetry report.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::ReportResponse response;
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  LoadGeneratorPtr client = startServers(fail_policy, origin_callbacks,
+                                         policy_cluster, telemetry_cluster);
+
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+
+  client->run(connections_to_initiate, requests_to_send, std::move(request),
+              std::chrono::milliseconds(10'000));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client response callback is called for every request sent
+  EXPECT_EQ(client->responsesReceived(), requests_to_send);
+  // Every response was a 5xx class
+  EXPECT_EQ(0, client->class2xxResponses());
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(requests_to_send, client->class5xxResponses());
+  EXPECT_EQ(0, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // Origin server should see no requests since the mixer filter is configured
+  // to fail closed.
+  EXPECT_EQ(0, origin_callbacks.requestsReceived());
+
+  // Policy server accept callback is called at least once (h2 socket reuse
+  // means may only be called once)
+  EXPECT_GE(policy_cluster.connectionsAccepted(), 1);
+  // Policy server request callback sees every policy check
+  EXPECT_EQ(requests_to_send, policy_cluster.requestsReceived());
+  // Policy server closes every connection
+  EXPECT_EQ(policy_cluster.connectionsAccepted(),
+            policy_cluster.localCloses() + policy_cluster.remoteCloses());
+}
+
+TEST_F(MixerFaultTest, TolerateTelemetryBlackhole) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 30;
+  constexpr uint32_t requests_to_send = 30 * connections_to_initiate;
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  // Over provision the policy cluster to reduce the change it becomes a source
+  // of error
+
+  ClusterHelper policy_cluster(
+      {// Send a gRPC success response immediately to every policy check
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       }),
+       // Send a gRPC success response immediately to every policy check
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       }),
+       // Send a gRPC success response immediately to every policy check
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  ClusterHelper telemetry_cluster(
+      {// Telemetry receives the telemetry report requests but never sends a
+       // response.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         // eat the request and do nothing
+       })});
+
+  LoadGeneratorPtr client = startServers(fail_policy, origin_callbacks,
+                                         policy_cluster, telemetry_cluster);
+
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+  client->run(connections_to_initiate, requests_to_send, std::move(request),
+              std::chrono::milliseconds(10'000));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client response callback is called for every request sent
+  EXPECT_EQ(client->responsesReceived(), requests_to_send);
+  // Every response was a 2xx class
+  EXPECT_EQ(client->class2xxResponses(), requests_to_send);
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(0, client->class5xxResponses());
+  EXPECT_EQ(0, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // assert that the origin request callback is called for every client request
+  // sent
+  EXPECT_EQ(origin_callbacks.requestsReceived(), requests_to_send);
+
+  // Policy server accept callback is called at least once (h2 socket reuse
+  // means may only be called once)
+  EXPECT_GE(policy_cluster.connectionsAccepted(), 1);
+  // Policy server request callback sees every policy check
+  EXPECT_EQ(requests_to_send, policy_cluster.requestsReceived());
+  // Policy server closes every connection
+  EXPECT_EQ(policy_cluster.connectionsAccepted(),
+            policy_cluster.localCloses() + policy_cluster.remoteCloses());
+
+  // Telemetry server accept callback is called at least once (h2 socket reuse
+  // means may only be called once)
+  EXPECT_GE(telemetry_cluster.connectionsAccepted(), 1);
+}
+
+TEST_F(MixerFaultTest, FailOpenAndSendPolicyResponseSlowly) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_OPEN;
+  constexpr uint32_t connections_to_initiate = 30;
+  constexpr uint32_t requests_to_send = 3 * connections_to_initiate;
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {// Policy server sends a gRPC success response after 60 seconds to every
+       // policy check
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(60'000));
+       })});
+
+  ClusterHelper telemetry_cluster(
+      {// Telemetry server sends a gRPC success response immediately to every
+       // telemetry report.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::ReportResponse response;
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  LoadGeneratorPtr client = startServers(fail_policy, origin_callbacks,
+                                         policy_cluster, telemetry_cluster);
+
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+
+  client->run(connections_to_initiate, requests_to_send, std::move(request),
+              std::chrono::milliseconds(10'000));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client response callback is called for every request sent
+  EXPECT_EQ(client->responsesReceived(), requests_to_send);
+  // Every response was a 2xx class
+  EXPECT_EQ(client->class2xxResponses(), requests_to_send);
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(0, client->class5xxResponses());
+  EXPECT_EQ(0, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // Origin server should see every requests since the mixer filter is
+  // configured to fail open.
+  EXPECT_EQ(origin_callbacks.requestsReceived(), requests_to_send);
+
+  // Policy server accept callback is called at least once (h2 socket reuse
+  // means may only be called once)
+  EXPECT_GE(policy_cluster.connectionsAccepted(), 1);
+  // Policy server request callback sees every policy check
+  EXPECT_EQ(requests_to_send, policy_cluster.requestsReceived());
+  // Policy server closes every connection
+  EXPECT_EQ(policy_cluster.connectionsAccepted(),
+            policy_cluster.localCloses() + policy_cluster.remoteCloses());
+}
+
+TEST_F(MixerFaultTest, RetryOnTransportError) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  uint32_t retries = 10;
+  uint32_t base_retry_ms = 1;
+  uint32_t max_retry_ms = 10;
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 30;
+  constexpr uint32_t requests_to_send = 30 * connections_to_initiate;
+
+  //
+  // Setup
+  //
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {// One policy server immediately closes any connection accepted.
+       new ServerCallbackHelper(
+           [](ServerConnection &, ServerStream &,
+              Envoy::Http::HeaderMapPtr &&) {
+             GTEST_FATAL_FAILURE_(
+                 "Connections immediately closed so no response should be "
+                 "received");
+           },
+           [](ServerConnection &) -> ServerCallbackResult {
+             return ServerCallbackResult::CLOSE;
+           }),
+       // Two other policy servers immediately send gRPC OK responses
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       }),
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  ClusterHelper telemetry_cluster(
+      {// Telemetry server sends a gRPC success response immediately to every
+       // telemetry report.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::ReportResponse response;
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  LoadGeneratorPtr client =
+      startServers(fail_policy, origin_callbacks, policy_cluster,
+                   telemetry_cluster, retries, base_retry_ms, max_retry_ms);
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+  client->run(connections_to_initiate, requests_to_send, std::move(request));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client response callback is called for every request sent
+  EXPECT_EQ(client->responsesReceived(), requests_to_send);
+  // Every response was a 2xx class
+  EXPECT_EQ(client->class2xxResponses(), requests_to_send);
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(0, client->class5xxResponses());
+  EXPECT_EQ(0, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // assert that the origin request callback is called for every client request
+  // sent
+  EXPECT_EQ(origin_callbacks.requestsReceived(), requests_to_send);
+
+  // assert that the policy request callback is called for every client request
+  // sent
+  EXPECT_EQ(policy_cluster.requestsReceived(), requests_to_send);
+}
+
+TEST_F(MixerFaultTest, CancelCheck) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  uint32_t retries = 10;
+  uint32_t base_retry_ms = 1;
+  uint32_t max_retry_ms = 10;
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 30;
+  constexpr uint32_t requests_to_send = 30 * connections_to_initiate;
+
+  //
+  // Setup
+  //
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {// One policy server immediately closes any connection accepted.
+       new ServerCallbackHelper(
+           [](ServerConnection &, ServerStream &,
+              Envoy::Http::HeaderMapPtr &&) {
+             GTEST_FATAL_FAILURE_(
+                 "Connections immediately closed so no response should be "
+                 "received");
+           },
+           [](ServerConnection &) -> ServerCallbackResult {
+             return ServerCallbackResult::CLOSE;
+           }),
+       // One policy server is really slow - client will timeout first and
+       // cancel check
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(60'000));
+       }),
+       // One policy server is nice and zippy
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::CheckResponse response;
+         response.mutable_precondition()->mutable_status()->set_code(
+             google::protobuf::util::error::Code::OK);
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  ClusterHelper telemetry_cluster(
+      {// Telemetry server sends a gRPC success response immediately to every
+       // telemetry report.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::ReportResponse response;
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  LoadGeneratorPtr client =
+      startServers(fail_policy, origin_callbacks, policy_cluster,
+                   telemetry_cluster, retries, base_retry_ms, max_retry_ms);
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+  client->run(connections_to_initiate, requests_to_send, std::move(request),
+              std::chrono::milliseconds(5'000));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Not all responses are received due to timeouts
+  EXPECT_LE(client->responsesReceived(), requests_to_send);
+  EXPECT_GE(client->responsesReceived(), 1);
+  // Every response was a 2xx class
+  EXPECT_EQ(client->class2xxResponses(), client->responsesReceived());
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(0, client->class5xxResponses());
+  // Or a timeout.  Implementational artifact: timeouts kill the connection and
+  // new connections are not created to take their place.
+  EXPECT_EQ(connections_to_initiate, client->responseTimeouts());
+  // No client sockets are rudely closed by server.  They timeout instead.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // assert that the origin request callback is called for every response
+  // received by the client.
+  EXPECT_GE(origin_callbacks.requestsReceived(), client->responsesReceived());
+
+  // assert that the policy request callback is called for every response
+  // received by the client.
+  EXPECT_GE(policy_cluster.requestsReceived(), client->responsesReceived());
+}
+
+TEST_F(MixerFaultTest, CancelRetry) {
+  Envoy::Logger::Registry::setLogLevel(spdlog::level::err);
+
+  // Force client timeout while requests are waiting between retries.
+  uint32_t retries = 1;
+  uint32_t base_retry_ms = 10'000;
+  uint32_t max_retry_ms = 10'000;
+  constexpr NetworkFailPolicy fail_policy = NetworkFailPolicy::FAIL_CLOSED;
+  constexpr uint32_t connections_to_initiate = 30;
+  constexpr uint32_t requests_to_send = 30 * connections_to_initiate;
+
+  //
+  // Setup
+  //
+
+  // Origin server immediately sends a simple 200 OK to every request
+  ServerCallbackHelper origin_callbacks;
+
+  ClusterHelper policy_cluster(
+      {// One policy server immediately closes any connection accepted.
+       new ServerCallbackHelper(
+           [](ServerConnection &, ServerStream &,
+              Envoy::Http::HeaderMapPtr &&) {
+             GTEST_FATAL_FAILURE_(
+                 "Connections immediately closed so no response should be "
+                 "received");
+           },
+           [](ServerConnection &) -> ServerCallbackResult {
+             return ServerCallbackResult::CLOSE;
+           })});
+
+  ClusterHelper telemetry_cluster(
+      {// Telemetry server sends a gRPC success response immediately to every
+       // telemetry report.
+       new ServerCallbackHelper([](ServerConnection &, ServerStream &stream,
+                                   Envoy::Http::HeaderMapPtr &&) {
+         ::istio::mixer::v1::ReportResponse response;
+         stream.sendGrpcResponse(Envoy::Grpc::Status::Ok, response,
+                                 std::chrono::milliseconds(0));
+       })});
+
+  LoadGeneratorPtr client =
+      startServers(fail_policy, origin_callbacks, policy_cluster,
+                   telemetry_cluster, retries, base_retry_ms, max_retry_ms);
+  //
+  // Exec test and wait for it to finish
+  //
+
+  Envoy::Http::HeaderMapPtr request{
+      new Envoy::Http::TestHeaderMapImpl{{":method", "GET"},
+                                         {":path", "/"},
+                                         {":scheme", "http"},
+                                         {":authority", "host"}}};
+  client->run(connections_to_initiate, requests_to_send, std::move(request),
+              std::chrono::milliseconds(500));
+
+  // shutdown envoy by destroying it
+  test_server_ = nullptr;
+  // wait until the upstreams have closed all connections they accepted.
+  // shutting down envoy should close them all
+  origin_callbacks.wait();
+  policy_cluster.wait();
+  telemetry_cluster.wait();
+
+  //
+  // Evaluate test
+  //
+
+  // All client connections are successfully established.
+  EXPECT_EQ(client->connectSuccesses(), connections_to_initiate);
+  EXPECT_EQ(0, client->connectFailures());
+  // Client close callback called for every client connection.
+  EXPECT_EQ(client->localCloses(), connections_to_initiate);
+  // Client doesn't receive any responses
+  EXPECT_EQ(0, client->responsesReceived());
+  EXPECT_EQ(0, client->class2xxResponses());
+  EXPECT_EQ(0, client->class4xxResponses());
+  EXPECT_EQ(0, client->class5xxResponses());
+  // All requests timeout.  Implementational artifact: timeouts kill the
+  // connection and new connections are not created to take their place.
+  EXPECT_EQ(connections_to_initiate, client->responseTimeouts());
+  // No client sockets are rudely closed by server / no client sockets are
+  // reset.
+  EXPECT_EQ(0, client->remoteCloses());
+
+  // The origin server receives no requests
+  EXPECT_EQ(0, origin_callbacks.requestsReceived());
+
+  // The policy server receives no requests
+  EXPECT_EQ(0, policy_cluster.requestsReceived());
+}
+
+}  // namespace Integration
+}  // namespace Mixer

--- a/test/integration/mixer_fault_test.cc
+++ b/test/integration/mixer_fault_test.cc
@@ -102,7 +102,7 @@ class MixerFaultTest : public Envoy::HttpIntegrationTest, public testing::Test {
   void extractCounters(const std::string &prefix,
                        std::unordered_map<std::string, double> &counters) {
     for (auto counter : test_server_->stat_store().counters()) {
-      if (absl::StartsWith(counter->name(), prefix)) {
+      if (!absl::StartsWith(counter->name(), prefix)) {
         continue;
       }
 

--- a/test/integration/mixer_fault_test.cc
+++ b/test/integration/mixer_fault_test.cc
@@ -14,6 +14,8 @@
  */
 
 #include <future>
+
+#include "absl/strings/match.h"
 #include "gtest/gtest.h"
 #include "include/istio/mixerclient/options.h"
 #include "int_client.h"
@@ -100,8 +102,7 @@ class MixerFaultTest : public Envoy::HttpIntegrationTest, public testing::Test {
   void extractCounters(const std::string &prefix,
                        std::unordered_map<std::string, double> &counters) {
     for (auto counter : test_server_->stat_store().counters()) {
-      if (!std::equal(prefix.begin(), prefix.begin() + prefix.size(),
-                      counter->name().begin())) {
+      if (absl::StartsWith(counter->name(), prefix)) {
         continue;
       }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

On transport error only, retry a policy/quota check with exponential backoff and jitter

**Which issue this PR fixes** 

https://github.com/istio/istio/issues/9992

**Special notes for your reviewer**:

This PR takes advantage of the newly introduced CheckContext with its memory scoped by a smart pointer.  This lets us more easily implement retry - each retry lambda just increments the smart pointer.

Note that I also moved the mixer client cancellation lambda into the CheckContext to make sure it too stays valid as long as the CheckContext is referenced.  

A new retry lambda was also introduced and handled similarly to the cancellation lambda.   

The semantic difference between the two:  the cancellation lambda is invoked if the downstream client goes away.  the retry lambda is invoked if a transport error occurs and the mixer filter wants to wait a bit before retrying against another mixer upstream.

1) I recommend reviewing the changes with ignore whitespace because clang-format varies the indentation on the lambda inside mixer_client_impl.cc quite a bit.   See https://github.com/istio/proxy/pull/2113/files?w=1

2) After this is merged I will update https://github.com/istio/istio/pull/11591 to import the new istio/proxy.  That pull request makes the istio/mixerclient unit tests pass against the new mixer filter counters.
