### PR TITLE
log authn permissive mode only when config is received

### DIFF
--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -34,8 +34,7 @@ namespace Istio {
 namespace AuthN {
 
 AuthenticationFilter::AuthenticationFilter(const FilterConfig& filter_config)
-    : filter_config_(filter_config) {
-}
+    : filter_config_(filter_config) {}
 
 AuthenticationFilter::~AuthenticationFilter() {}
 

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -35,24 +35,6 @@ namespace AuthN {
 
 AuthenticationFilter::AuthenticationFilter(const FilterConfig& filter_config)
     : filter_config_(filter_config) {
-  for (const auto& method : filter_config.policy().peers()) {
-    switch (method.params_case()) {
-      case iaapi::PeerAuthenticationMethod::ParamsCase::kMtls:
-        if (method.mtls().mode() == iaapi::MutualTls_Mode_PERMISSIVE) {
-          ENVOY_LOG(
-              warn,
-              "mTLS PERMISSIVE mode is used, connection can be either "
-              "plaintext or TLS, and client cert can be omitted. "
-              "Please consider to upgrade to mTLS STRICT mode for more secure "
-              "configuration that only allows TLS connection with client cert. "
-              "See https://istio.io/docs/tasks/security/mtls-migration/");
-          return;
-        }
-        break;
-      default:
-        break;
-    }
-  }
 }
 
 AuthenticationFilter::~AuthenticationFilter() {}

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -93,8 +93,10 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
                 warn,
                 "mTLS PERMISSIVE mode is used, connection can be either "
                 "plaintext or TLS, and client cert can be omitted. "
-                "Please consider to upgrade to mTLS STRICT mode for more secure "
-                "configuration that only allows TLS connection with client cert. "
+                "Please consider to upgrade to mTLS STRICT mode for more "
+                "secure "
+                "configuration that only allows TLS connection with client "
+                "cert. "
                 "See https://istio.io/docs/tasks/security/mtls-migration/");
             return;
           }

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -27,6 +27,8 @@ namespace Envoy {
 namespace Server {
 namespace Configuration {
 
+namespace iaapi = istio::authentication::v1alpha1;
+
 class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
                           public Logger::Loggable<Logger::Id::filter> {
  public:
@@ -75,7 +77,7 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
     auto filter_config = std::make_shared<FilterConfig>(config_pb);
     // Print a log to remind user to upgrade to the mTLS setting. This will only
     // be called when a new config is received by Envoy.
-    warnPermissiveMode(filter_config);
+    warnPermissiveMode(*filter_config);
     return
         [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
           callbacks.addStreamDecoderFilter(

--- a/src/envoy/http/authn/http_filter_factory.cc
+++ b/src/envoy/http/authn/http_filter_factory.cc
@@ -73,12 +73,36 @@ class AuthnFilterConfig : public NamedHttpFilterConfigFactory,
     // TODO(incfly): add a test to simulate different config can be handled
     // correctly similar to multiplexing on different port.
     auto filter_config = std::make_shared<FilterConfig>(config_pb);
+    // Print a log to remind user to upgrade to the mTLS setting. This will only
+    // be called when a new config is received by Envoy.
+    warnPermissiveMode(filter_config);
     return
         [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
           callbacks.addStreamDecoderFilter(
               std::make_shared<Http::Istio::AuthN::AuthenticationFilter>(
                   *filter_config));
         };
+  }
+
+  void warnPermissiveMode(const FilterConfig& filter_config) {
+    for (const auto& method : filter_config.policy().peers()) {
+      switch (method.params_case()) {
+        case iaapi::PeerAuthenticationMethod::ParamsCase::kMtls:
+          if (method.mtls().mode() == iaapi::MutualTls_Mode_PERMISSIVE) {
+            ENVOY_LOG(
+                warn,
+                "mTLS PERMISSIVE mode is used, connection can be either "
+                "plaintext or TLS, and client cert can be omitted. "
+                "Please consider to upgrade to mTLS STRICT mode for more secure "
+                "configuration that only allows TLS connection with client cert. "
+                "See https://istio.io/docs/tasks/security/mtls-migration/");
+            return;
+          }
+          break;
+        default:
+          break;
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Signed-off-by: Yangmin Zhu <ymzhu@google.com>

**What this PR does / why we need it**:
Envoy actually allocates the filter for every request, we need to move the log out of the constructor to avoid spamming the logs.


https://github.com/istio/istio/issues/11925

**Special notes for your reviewer**:
The next step is to update the Istio proxy sha to pick this change for 1.1.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
