### PR TITLE
Add additional telemetry report counters

### DIFF
--- a/include/istio/mixerclient/client.h
+++ b/include/istio/mixerclient/client.h
@@ -114,9 +114,17 @@ struct Statistics {
   //
 
   // Total number of report calls.
-  uint64_t total_report_calls_{0};
+  uint64_t total_report_calls_{0};  // 1.0
   // Total number of remote report calls.
-  uint64_t total_remote_report_calls_{0};
+  uint64_t total_remote_report_calls_{0};  // 1.0
+  // Remote report calls that are succeeed
+  uint64_t total_remote_report_successes_{0};  // 1.1
+  // Remote report calls that fail due to timeout waiting for the response
+  uint64_t total_remote_report_timeouts_{0};  // 1.1
+  // Remote report calls that fail sending the request (socket connect or write)
+  uint64_t total_remote_report_send_errors_{0};  // 1.1
+  // Remote report calls that fail do to some other error
+  uint64_t total_remote_report_other_errors_{0};  // 1.1
 };
 
 class MixerClient {

--- a/include/istio/mixerclient/client.h
+++ b/include/istio/mixerclient/client.h
@@ -117,7 +117,7 @@ struct Statistics {
   uint64_t total_report_calls_{0};  // 1.0
   // Total number of remote report calls.
   uint64_t total_remote_report_calls_{0};  // 1.0
-  // Remote report calls that are succeeed
+  // Remote report calls that succeeed
   uint64_t total_remote_report_successes_{0};  // 1.1
   // Remote report calls that fail due to timeout waiting for the response
   uint64_t total_remote_report_timeouts_{0};  // 1.1

--- a/src/envoy/utils/stats.cc
+++ b/src/envoy/utils/stats.cc
@@ -87,6 +87,10 @@ void MixerStatsObject::CheckAndUpdateStats(
 
   CHECK_AND_UPDATE_STATS(total_report_calls_);
   CHECK_AND_UPDATE_STATS(total_remote_report_calls_);
+  CHECK_AND_UPDATE_STATS(total_remote_report_successes_);
+  CHECK_AND_UPDATE_STATS(total_remote_report_timeouts_);
+  CHECK_AND_UPDATE_STATS(total_remote_report_send_errors_);
+  CHECK_AND_UPDATE_STATS(total_remote_report_other_errors_);
 
   // Copy new_stats to old_stats_ for next stats update.
   old_stats_ = new_stats;

--- a/src/envoy/utils/stats.h
+++ b/src/envoy/utils/stats.h
@@ -53,7 +53,11 @@ namespace Utils {
   COUNTER(total_remote_call_retries)          \
   COUNTER(total_remote_call_cancellations)    \
   COUNTER(total_report_calls)                 \
-  COUNTER(total_remote_report_calls)
+  COUNTER(total_remote_report_calls)          \
+  COUNTER(total_remote_report_successes)      \
+  COUNTER(total_remote_report_timeouts)       \
+  COUNTER(total_remote_report_send_errors)    \
+  COUNTER(total_remote_report_other_errors)
 // clang-format on
 
 /**

--- a/src/istio/mixerclient/BUILD
+++ b/src/istio/mixerclient/BUILD
@@ -40,7 +40,7 @@ cc_library(
         "attribute_compressor.h",
         "check_cache.cc",
         "check_cache.h",
-	"check_context.h",
+	    "check_context.h",
         "client_impl.cc",
         "client_impl.h",
         "global_dictionary.cc",
@@ -51,7 +51,9 @@ cc_library(
         "referenced.h",
         "report_batch.cc",
         "report_batch.h",
-	"shared_attributes.h",
+	    "shared_attributes.h",
+	    "status_util.cc",
+	    "status_util.h"
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/istio/mixerclient/BUILD
+++ b/src/istio/mixerclient/BUILD
@@ -52,8 +52,8 @@ cc_library(
         "report_batch.cc",
         "report_batch.h",
         "shared_attributes.h",
-	    "status_util.cc",
-	    "status_util.h"
+        "status_util.cc",
+        "status_util.h"
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/istio/mixerclient/BUILD
+++ b/src/istio/mixerclient/BUILD
@@ -40,7 +40,7 @@ cc_library(
         "attribute_compressor.h",
         "check_cache.cc",
         "check_cache.h",
-	    "check_context.h",
+        "check_context.h",
         "client_impl.cc",
         "client_impl.h",
         "global_dictionary.cc",
@@ -51,7 +51,7 @@ cc_library(
         "referenced.h",
         "report_batch.cc",
         "report_batch.h",
-	    "shared_attributes.h",
+        "shared_attributes.h",
 	    "status_util.cc",
 	    "status_util.h"
     ],

--- a/src/istio/mixerclient/report_batch.h
+++ b/src/istio/mixerclient/report_batch.h
@@ -44,6 +44,22 @@ class ReportBatch {
     return total_remote_report_calls_;
   }
 
+  uint64_t total_remote_report_successes() const {
+    return total_remote_report_successes_;
+  }
+
+  uint64_t total_remote_report_timeouts() const {
+    return total_remote_report_timeouts_;
+  }
+
+  uint64_t total_remote_report_send_errors() const {
+    return total_remote_report_send_errors_;
+  }
+
+  uint64_t total_remote_report_other_errors() const {
+    return total_remote_report_other_errors_;
+  }
+
  private:
   void FlushWithLock();
 
@@ -68,8 +84,12 @@ class ReportBatch {
   // batched report compressor
   std::unique_ptr<BatchCompressor> batch_compressor_;
 
-  std::atomic_int_fast64_t total_report_calls_;
-  std::atomic_int_fast64_t total_remote_report_calls_;
+  std::atomic<uint64_t> total_report_calls_{0};                // 1.0
+  std::atomic<uint64_t> total_remote_report_calls_{0};         // 1.0
+  std::atomic<uint64_t> total_remote_report_successes_{0};     // 1.1
+  std::atomic<uint64_t> total_remote_report_timeouts_{0};      // 1.1
+  std::atomic<uint64_t> total_remote_report_send_errors_{0};   // 1.1
+  std::atomic<uint64_t> total_remote_report_other_errors_{0};  // 1.1
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(ReportBatch);
 };

--- a/src/istio/mixerclient/status_util.cc
+++ b/src/istio/mixerclient/status_util.cc
@@ -1,0 +1,43 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/istio/mixerclient/status_util.h"
+
+namespace istio {
+namespace mixerclient {
+
+static ::google::protobuf::StringPiece TIMEOUT_MESSAGE(
+    "upstream request timeout");
+static ::google::protobuf::StringPiece SEND_ERROR_MESSAGE(
+    "upstream connect error or disconnect/reset before headers");
+
+TransportResult TransportStatus(const ::google::protobuf::util::Status &status) {
+  if (status.ok()) {
+    return TransportResult::SUCCESS;
+  }
+
+  if (::google::protobuf::util::error::Code::UNAVAILABLE == status.error_code()) {
+    if (TIMEOUT_MESSAGE == status.error_message()) {
+      return TransportResult::RESPONSE_TIMEOUT;
+    }
+    if (SEND_ERROR_MESSAGE == status.error_message()) {
+      return TransportResult::SEND_ERROR;
+    }
+  }
+
+  return TransportResult::OTHER;
+}
+}
+}

--- a/src/istio/mixerclient/status_util.cc
+++ b/src/istio/mixerclient/status_util.cc
@@ -1,4 +1,4 @@
-/* Copyright 2017 Istio Authors. All Rights Reserved.
+/* Copyright 2019 Istio Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,14 @@ static ::google::protobuf::StringPiece TIMEOUT_MESSAGE(
 static ::google::protobuf::StringPiece SEND_ERROR_MESSAGE(
     "upstream connect error or disconnect/reset before headers");
 
-TransportResult TransportStatus(const ::google::protobuf::util::Status &status) {
+TransportResult TransportStatus(
+    const ::google::protobuf::util::Status &status) {
   if (status.ok()) {
     return TransportResult::SUCCESS;
   }
 
-  if (::google::protobuf::util::error::Code::UNAVAILABLE == status.error_code()) {
+  if (::google::protobuf::util::error::Code::UNAVAILABLE ==
+      status.error_code()) {
     if (TIMEOUT_MESSAGE == status.error_message()) {
       return TransportResult::RESPONSE_TIMEOUT;
     }
@@ -39,5 +41,5 @@ TransportResult TransportStatus(const ::google::protobuf::util::Status &status) 
 
   return TransportResult::OTHER;
 }
-}
-}
+}  // namespace mixerclient
+}  // namespace istio

--- a/src/istio/mixerclient/status_util.h
+++ b/src/istio/mixerclient/status_util.h
@@ -1,0 +1,34 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "google/protobuf/stubs/status.h"
+
+namespace istio {
+namespace mixerclient {
+
+enum class TransportResult {
+  SUCCESS,           // Response received
+  SEND_ERROR,        // Cannot connect to peer or send request to peer.
+  RESPONSE_TIMEOUT,  // Connected to peer and sent request, but didn't receive a
+  // response in time.
+      OTHER              // Something else went wrong
+};
+
+extern TransportResult TransportStatus(const ::google::protobuf::util::Status &status);
+
+}
+}

--- a/src/istio/mixerclient/status_util.h
+++ b/src/istio/mixerclient/status_util.h
@@ -24,11 +24,12 @@ enum class TransportResult {
   SUCCESS,           // Response received
   SEND_ERROR,        // Cannot connect to peer or send request to peer.
   RESPONSE_TIMEOUT,  // Connected to peer and sent request, but didn't receive a
-  // response in time.
-      OTHER              // Something else went wrong
+                     // response in time.
+  OTHER              // Something else went wrong
 };
 
-extern TransportResult TransportStatus(const ::google::protobuf::util::Status &status);
+extern TransportResult TransportStatus(
+    const ::google::protobuf::util::Status &status);
 
-}
-}
+}  // namespace mixerclient
+}  // namespace istio


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds counters to the mixer telemetry reports so we can see how many succeed vs. fail and get a coarse grained understanding of the cause of the failures.

**Which issue this PR fixes**

Helps diagnose issues related to https://github.com/istio/istio/issues/8224
