### PR TITLE
API sha just changed, changing it again for proxy

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -4,7 +4,7 @@
 		"name": "ISTIO_API",
 		"repoName": "api",
 		"file": "repositories.bzl",
-		"lastStableSHA": "120a390e09bf11e1dc85b8331e96cc25a5bef93e"
+		"lastStableSHA": "eac219de3ebdeced584997a3f34873bacf3705e7"
 	},
 	{
 		"_comment": "",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -105,8 +105,8 @@ cc_library(
 # 2) wget https://github.com/istio/api/archive/ISTIO_API_SHA.tar.gz
 # 3) sha256sum ISTIO_API_SHA.tar.gz
 #
-ISTIO_API = "120a390e09bf11e1dc85b8331e96cc25a5bef93e"
-ISTIO_API_SHA256 = "79bb2bd35a26b784611d30393d42697befba78421c45a1d4043b06dcd4fd42c5"
+ISTIO_API = "eac219de3ebdeced584997a3f34873bacf3705e7"
+ISTIO_API_SHA256 = "9df9c90ff7bfec0e2cc33f2b26a14966911157fd8c20d05306e24f5e4dcfd511"
 
 def mixerapi_repositories(bind = True):
     BUILD = """


### PR DESCRIPTION
**What this PR does / why we need it**:
API sha just changed for relelase 1.1, changing it again for proxy

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Release

