### PR TITLE
telemetry: add grpc message counters

### DIFF
--- a/cc_gogo_protobuf.bzl
+++ b/cc_gogo_protobuf.bzl
@@ -17,6 +17,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 GOGO_PROTO_SHA = "100ba4e885062801d56799d78530b73b178a78f3"
+
 GOGO_PROTO_SHA256 = "b04eb8eddd2d15d8b12d111d4ef7816fca6e5c5d495adf45fb8478278aa80f79"
 
 def cc_gogoproto_repositories(bind = True):

--- a/googleapis.bzl
+++ b/googleapis.bzl
@@ -18,6 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Oct 21, 2016 (only release pre-dates sha)
 GOOGLEAPIS_SHA = "13ac2436c5e3d568bd0e938f6ed58b77a48aba15"
+
 GOOGLEAPIS_SHA256 = "f48956fb8c55617ed052c20884465f06b9a57b807164431185be397ea46993ca"
 
 def googleapis_repositories(bind = True):

--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -43,6 +43,8 @@ class ReportData {
     std::chrono::nanoseconds duration;
     int response_code;
     std::string response_flags;
+    uint64_t request_grpc_message_count;
+    uint64_t response_grpc_message_count;
   };
   virtual void GetReportInfo(ReportInfo *info) const = 0;
 

--- a/include/istio/utils/attribute_names.h
+++ b/include/istio/utils/attribute_names.h
@@ -52,6 +52,9 @@ struct AttributeName {
   static const char kRequestUserAgent[];
   static const char kRequestApiKey[];
 
+  static const char kRequestGrpcMessageCount[];
+  static const char kResponseGrpcMessageCount[];
+
   static const char kResponseCode[];
   static const char kResponseDuration[];
   static const char kResponseHeaders[];

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -17,6 +17,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 GOOGLETEST = "d225acc90bc3a8c420a9bcd1f033033c1ccd7fe0"
+
 GOOGLETEST_SHA256 = "01508c8f47c99509130f128924f07f3a60be05d039cff571bb11d60bb11a3581"
 
 def googletest_repositories(bind = True):

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -53,19 +53,20 @@ void incrementCounter(Buffer::Instance& data, GrpcMessageCounter* counter) {
       case GrpcMessageCounter::ExpectByte3:
       case GrpcMessageCounter::ExpectByte4:
         data.copyOut(pos, 1, &byte);
-        counter->current_size <<= 8;
+        counter->current_size = counter->current_size << 8;
         counter->current_size = counter->current_size | byte;
         pos += 1;
         counter->state =
             static_cast<GrpcMessageCounter::GrpcReadState>(counter->state + 1);
         break;
       case GrpcMessageCounter::ExpectMessage:
-        if (data.length() >= pos + counter->current_size) {
+        uint32_t available = data.length() - pos;
+        if (counter->current_size <= available) {
           pos += counter->current_size;
           counter->state = GrpcMessageCounter::ExpectByte0;
         } else {
           pos = data.length();
-          counter->current_size -= data.length() - pos;
+          counter->current_size = counter->current_size - available;
         }
         break;
     }

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -60,7 +60,7 @@ void incrementCounter(Buffer::Instance& data, GrpcMessageCounter* counter) {
             static_cast<GrpcMessageCounter::GrpcReadState>(counter->state + 1);
         break;
       case GrpcMessageCounter::ExpectMessage:
-        uint32_t available = data.length() - pos;
+        uint64_t available = data.length() - pos;
         if (counter->current_size <= available) {
           pos += counter->current_size;
           counter->state = GrpcMessageCounter::ExpectByte0;

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -19,6 +19,7 @@
 #include "envoy/access_log/access_log.h"
 #include "envoy/http/filter.h"
 #include "src/envoy/http/mixer/control.h"
+#include "src/envoy/utils/message_counter.h"
 
 namespace Envoy {
 namespace Http {
@@ -31,30 +32,6 @@ struct PerRouteServiceConfig : public Router::RouteSpecificFilterConfig {
 
   // Its config hash
   std::string hash;
-};
-
-// The struct to store gRPC message counter state.
-struct GrpcMessageCounter {
-  GrpcMessageCounter() : state(ExpectByte0), current_size(0), count(0){};
-
-  // gRPC uses 5 byte header to encode subsequent message length
-  enum GrpcReadState {
-    ExpectByte0 = 0,
-    ExpectByte1,
-    ExpectByte2,
-    ExpectByte3,
-    ExpectByte4,
-    ExpectMessage
-  };
-
-  // current read state
-  GrpcReadState state;
-
-  // current message size
-  uint64_t current_size;
-
-  // message counter
-  uint64_t count;
 };
 
 class Filter : public StreamFilter,
@@ -126,8 +103,8 @@ class Filter : public StreamFilter,
 
   // True for gRPC requests
   bool grpc_request_{false};
-  GrpcMessageCounter grpc_request_counter_;
-  GrpcMessageCounter grpc_response_counter_;
+  Utils::GrpcMessageCounter grpc_request_counter_;
+  Utils::GrpcMessageCounter grpc_response_counter_;
 
   // The stream decoder filter callback.
   StreamDecoderFilterCallbacks* decoder_callbacks_{nullptr};

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -51,7 +51,7 @@ struct GrpcMessageCounter {
   GrpcReadState state;
 
   // current message size
-  uint32_t current_size;
+  uint64_t current_size;
 
   // message counter
   uint64_t count;

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -61,6 +61,7 @@ class ReportData : public ::istio::control::http::ReportData,
   uint64_t response_grpc_message_count_;
 
  public:
+  // TODO: avoid large constructor list with parameters objects
   ReportData(const HeaderMap *headers, const HeaderMap *response_trailers,
              const StreamInfo::StreamInfo &info, uint64_t request_total_size,
              uint64_t request_grpc_message_count,

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -57,15 +57,21 @@ class ReportData : public ::istio::control::http::ReportData,
   const StreamInfo::StreamInfo &info_;
   uint64_t response_total_size_;
   uint64_t request_total_size_;
+  uint64_t request_grpc_message_count_;
+  uint64_t response_grpc_message_count_;
 
  public:
   ReportData(const HeaderMap *headers, const HeaderMap *response_trailers,
-             const StreamInfo::StreamInfo &info, uint64_t request_total_size)
+             const StreamInfo::StreamInfo &info, uint64_t request_total_size,
+             uint64_t request_grpc_message_count,
+             uint64_t response_grpc_message_count)
       : headers_(headers),
         trailers_(response_trailers),
         info_(info),
         response_total_size_(info.bytesSent()),
-        request_total_size_(request_total_size) {
+        request_total_size_(request_total_size),
+        request_grpc_message_count_(request_grpc_message_count),
+        response_grpc_message_count_(response_grpc_message_count) {
     if (headers != nullptr) {
       response_total_size_ += headers->byteSize();
     }
@@ -98,6 +104,8 @@ class ReportData : public ::istio::control::http::ReportData,
     data->response_code = info_.responseCode().value_or(500);
 
     data->response_flags = StreamInfo::ResponseFlagUtils::toShortString(info_);
+    data->request_grpc_message_count = request_grpc_message_count_;
+    data->response_grpc_message_count = response_grpc_message_count_;
   }
 
   bool GetDestinationIpPort(std::string *str_ip, int *port) const override {

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
     srcs = [
         "config.cc",
         "grpc_transport.cc",
+        "message_counter.cc",
         "mixer_control.cc",
         "stats.cc",
         "utils.cc",
@@ -55,6 +56,7 @@ envoy_cc_library(
         "config.h",
         "grpc_transport.h",
         "header_update.h",
+        "message_counter.h",
         "mixer_control.h",
         "stats.h",
         "utils.h",

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -97,6 +97,20 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "message_counter_test",
+    srcs = [
+        "message_counter_test.cc",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":utils_lib",
+        "@envoy//source/common/buffer:buffer_lib",
+        "@envoy//test/common/buffer:utility_lib",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)
+
+envoy_cc_test(
     name = "mixer_control_test",
     srcs = [
         "mixer_control_test.cc",

--- a/src/envoy/utils/message_counter.cc
+++ b/src/envoy/utils/message_counter.cc
@@ -18,7 +18,8 @@
 namespace Envoy {
 namespace Utils {
 
-void IncrementMessageCounter(Buffer::Instance& data, GrpcMessageCounter* counter) {
+void IncrementMessageCounter(Buffer::Instance& data,
+                             GrpcMessageCounter* counter) {
   uint64_t pos = 0;
   unsigned byte = 0;
   while (pos < data.length()) {

--- a/src/envoy/utils/message_counter.cc
+++ b/src/envoy/utils/message_counter.cc
@@ -21,7 +21,7 @@ namespace Utils {
 void IncrementMessageCounter(Buffer::Instance& data,
                              GrpcMessageCounter* counter) {
   uint64_t pos = 0;
-  unsigned byte = 0;
+  uint8_t byte = 0;
   while (pos < data.length()) {
     switch (counter->state) {
       case GrpcMessageCounter::ExpectByte0:

--- a/src/envoy/utils/message_counter.cc
+++ b/src/envoy/utils/message_counter.cc
@@ -1,0 +1,58 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/utils/message_counter.h"
+
+namespace Envoy {
+namespace Utils {
+
+void IncrementMessageCounter(Buffer::Instance& data, GrpcMessageCounter* counter) {
+  uint64_t pos = 0;
+  unsigned byte = 0;
+  while (pos < data.length()) {
+    switch (counter->state) {
+      case GrpcMessageCounter::ExpectByte0:
+        // skip compress flag, increment message count
+        counter->count += 1;
+        counter->current_size = 0;
+        pos += 1;
+        counter->state = GrpcMessageCounter::ExpectByte1;
+        break;
+      case GrpcMessageCounter::ExpectByte1:
+      case GrpcMessageCounter::ExpectByte2:
+      case GrpcMessageCounter::ExpectByte3:
+      case GrpcMessageCounter::ExpectByte4:
+        data.copyOut(pos, 1, &byte);
+        counter->current_size = counter->current_size << 8;
+        counter->current_size = counter->current_size | byte;
+        pos += 1;
+        counter->state =
+            static_cast<GrpcMessageCounter::GrpcReadState>(counter->state + 1);
+        break;
+      case GrpcMessageCounter::ExpectMessage:
+        uint64_t available = data.length() - pos;
+        if (counter->current_size <= available) {
+          pos += counter->current_size;
+          counter->state = GrpcMessageCounter::ExpectByte0;
+        } else {
+          pos = data.length();
+          counter->current_size = counter->current_size - available;
+        }
+        break;
+    }
+  }
+}
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/envoy/utils/message_counter.h
+++ b/src/envoy/utils/message_counter.h
@@ -44,9 +44,11 @@ struct GrpcMessageCounter {
   uint64_t count;
 };
 
-// Detect gRPC message boundaries and increment the counters: each message is prefixed by 5 bytes
-// length-prefix https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
-void IncrementMessageCounter(Buffer::Instance& data, GrpcMessageCounter* counter);
+// Detect gRPC message boundaries and increment the counters: each message is
+// prefixed by 5 bytes length-prefix
+// https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+void IncrementMessageCounter(Buffer::Instance& data,
+                             GrpcMessageCounter* counter);
 
 }  // namespace Utils
 }  // namespace Envoy

--- a/src/envoy/utils/message_counter.h
+++ b/src/envoy/utils/message_counter.h
@@ -1,0 +1,52 @@
+/* Copyright 2017 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "envoy/buffer/buffer.h"
+
+namespace Envoy {
+namespace Utils {
+
+// The struct to store gRPC message counter state.
+struct GrpcMessageCounter {
+  GrpcMessageCounter() : state(ExpectByte0), current_size(0), count(0){};
+
+  // gRPC uses 5 byte header to encode subsequent message length
+  enum GrpcReadState {
+    ExpectByte0 = 0,
+    ExpectByte1,
+    ExpectByte2,
+    ExpectByte3,
+    ExpectByte4,
+    ExpectMessage
+  };
+
+  // current read state
+  GrpcReadState state;
+
+  // current message size
+  uint64_t current_size;
+
+  // message counter
+  uint64_t count;
+};
+
+// Detect gRPC message boundaries and increment the counters: each message is prefixed by 5 bytes
+// length-prefix https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+void IncrementMessageCounter(Buffer::Instance& data, GrpcMessageCounter* counter);
+
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/envoy/utils/message_counter_test.cc
+++ b/src/envoy/utils/message_counter_test.cc
@@ -1,0 +1,95 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/utils/message_counter.h"
+
+#include "common/buffer/buffer_impl.h"
+
+#include "test/common/buffer/utility.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+namespace Utils {
+
+namespace {
+
+TEST(MessageCounterTest, IncrementMessageCounter) {
+  {
+    Buffer::OwnedImpl buffer;
+    GrpcMessageCounter counter;
+    IncrementMessageCounter(buffer, &counter);
+    EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte0);
+    EXPECT_EQ(counter.count, 0);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    GrpcMessageCounter counter;
+    Buffer::addSeq(buffer, {0});
+    IncrementMessageCounter(buffer, &counter);
+    EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte1);
+    EXPECT_EQ(counter.count, 1);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    GrpcMessageCounter counter;
+    Buffer::addSeq(buffer, {1, 0, 0, 0, 1, 0xFF});
+    IncrementMessageCounter(buffer, &counter);
+    EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte0);
+    EXPECT_EQ(counter.count, 1);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    GrpcMessageCounter counter;
+    Buffer::addSeq(buffer, {1, 0, 0, 0, 1, 0xFF});
+    Buffer::addSeq(buffer, {0, 0, 0, 0, 2, 0xFF, 0xFF});
+    IncrementMessageCounter(buffer, &counter);
+    EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte0);
+    EXPECT_EQ(counter.count, 2);
+  }
+
+  {
+    Buffer::OwnedImpl buffer1;
+    Buffer::OwnedImpl buffer2;
+    GrpcMessageCounter counter;
+    // message spans two buffers
+    Buffer::addSeq(buffer1, {1, 0, 0, 0, 2, 0xFF});
+    Buffer::addSeq(buffer2, {0xFF, 0, 0, 0, 0, 2, 0xFF, 0xFF});
+    IncrementMessageCounter(buffer1, &counter);
+    IncrementMessageCounter(buffer2, &counter);
+    EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte0);
+    EXPECT_EQ(counter.count, 2);
+  }
+
+  {
+    Buffer::OwnedImpl buffer;
+    GrpcMessageCounter counter;
+    // Add longer byte sequence
+    Buffer::addSeq(buffer, {1, 0, 0, 1, 0});
+    Buffer::addRepeated(buffer, 1 << 8, 0xFF);
+    // Start second message
+    Buffer::addSeq(buffer, {0});
+    IncrementMessageCounter(buffer, &counter);
+    EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte1);
+    EXPECT_EQ(counter.count, 2);
+  }
+}
+
+}  // namespace
+
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/envoy/utils/message_counter_test.cc
+++ b/src/envoy/utils/message_counter_test.cc
@@ -87,6 +87,15 @@ TEST(MessageCounterTest, IncrementMessageCounter) {
     EXPECT_EQ(counter.state, GrpcMessageCounter::GrpcReadState::ExpectByte1);
     EXPECT_EQ(counter.count, 2);
   }
+
+  {
+    // two empty messages
+    Buffer::OwnedImpl buffer;
+    GrpcMessageCounter counter;
+    Buffer::addRepeated(buffer, 10, 0);
+    IncrementMessageCounter(buffer, &counter);
+    EXPECT_EQ(counter.count, 2);
+  }
 }
 
 }  // namespace

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -259,6 +259,15 @@ void AttributesBuilder::ExtractReportAttributes(
                       grpc_status.message);
   }
 
+  if (info.request_grpc_message_count > 0) {
+    builder.AddInt64(utils::AttributeName::kRequestGrpcMessageCount,
+                     info.request_grpc_message_count);
+  }
+  if (info.response_grpc_message_count > 0) {
+    builder.AddInt64(utils::AttributeName::kResponseGrpcMessageCount,
+                     info.response_grpc_message_count);
+  }
+
   builder.AddString(utils::AttributeName::kContextProxyErrorCode,
                     info.response_flags);
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -774,6 +774,8 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         info->duration = std::chrono::nanoseconds(1);
         info->response_code = 404;
         info->response_flags = "NR";
+        info->request_grpc_message_count = 0;
+        info->response_grpc_message_count = 0;
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_))
       .WillOnce(Invoke([](ReportData::GrpcStatus *status) -> bool {
@@ -854,6 +856,8 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
         info->duration = std::chrono::nanoseconds(1);
         info->response_code = 404;
         info->response_flags = "NR";
+        info->request_grpc_message_count = 0;
+        info->response_grpc_message_count = 0;
       }));
   EXPECT_CALL(mock_data, GetGrpcStatus(_)).WillOnce(testing::Return(false));
   EXPECT_CALL(mock_data, GetRbacReportInfo(_))

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -47,6 +47,11 @@ const char AttributeName::kRequestTime[] = "request.time";
 const char AttributeName::kRequestUserAgent[] = "request.useragent";
 const char AttributeName::kRequestApiKey[] = "request.api_key";
 
+const char AttributeName::kRequestGrpcMessageCount[] =
+    "request.grpc_message_count";
+const char AttributeName::kResponseGrpcMessageCount[] =
+    "response.grpc_message_count";
+
 const char AttributeName::kResponseCode[] = "response.code";
 const char AttributeName::kResponseDuration[] = "response.duration";
 const char AttributeName::kResponseHeaders[] = "response.headers";

--- a/src/istio/utils/attribute_names.cc
+++ b/src/istio/utils/attribute_names.cc
@@ -48,9 +48,9 @@ const char AttributeName::kRequestUserAgent[] = "request.useragent";
 const char AttributeName::kRequestApiKey[] = "request.api_key";
 
 const char AttributeName::kRequestGrpcMessageCount[] =
-    "request.grpc_message_count";
+    "request.grpc.message_count";
 const char AttributeName::kResponseGrpcMessageCount[] =
-    "response.grpc_message_count";
+    "response.grpc.message_count";
 
 const char AttributeName::kResponseCode[] = "response.code";
 const char AttributeName::kResponseDuration[] = "response.duration";

--- a/x_tools_imports.bzl
+++ b/x_tools_imports.bzl
@@ -18,6 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Jun 23, 2017 (no releases)
 TOOLS_SHA = "e6cb469339aef5b7be0c89de730d5f3cc8e47e50"
+
 TOOLS_SHA256 = "fe9489eabcb598e13137d0641525ff3813d8af151e1418e6940e611850d90136"
 
 def go_x_tools_imports_repositories():


### PR DESCRIPTION
Add message counters for gRPC streams:
```
request.grpc.message_count: number of input messages
response.grpc.message_count: number of output messages
```

Counts are reported at the end of the request, identically to a normal HTTP request.
The implementation works by peeking into 5 bytes prefixing every message in h2 data for gRPC.

/assign @PiotrSikora 
/assign @duderino 

