### PR TITLE
generate another map literal for mixer global dictionary

### DIFF
--- a/src/istio/mixerclient/attribute_compressor.cc
+++ b/src/istio/mixerclient/attribute_compressor.cc
@@ -159,13 +159,8 @@ class BatchCompressorImpl : public BatchCompressor {
 
 }  // namespace
 
-GlobalDictionary::GlobalDictionary() {
-  const std::vector<std::string>& global_words = GetGlobalWords();
-  for (unsigned int i = 0; i < global_words.size(); i++) {
-    global_dict_[global_words[i]] = i;
-  }
-  top_index_ = global_words.size();
-}
+GlobalDictionary::GlobalDictionary()
+    : global_dict_(GetGlobalDictionary()), top_index_(global_dict_.size()) {}
 
 // Lookup the index, return true if found.
 bool GlobalDictionary::GetIndex(const std::string name, int* index) const {

--- a/src/istio/mixerclient/attribute_compressor.h
+++ b/src/istio/mixerclient/attribute_compressor.h
@@ -38,7 +38,7 @@ class GlobalDictionary {
   int size() const { return top_index_; }
 
  private:
-  std::unordered_map<std::string, int> global_dict_;
+  const std::unordered_map<std::string, int>& global_dict_;
   // the last index of the global dictionary.
   // If mis-matched with server, it will set to base
   int top_index_;

--- a/src/istio/mixerclient/global_dictionary.h
+++ b/src/istio/mixerclient/global_dictionary.h
@@ -17,13 +17,17 @@
 #define ISTIO_MIXERCLIENT_GLOBAL_DICTIONARY_H
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace istio {
 namespace mixerclient {
 
-// Get automatically generated global words.
+// Get pre-compiled global words.
 const std::vector<std::string>& GetGlobalWords();
+
+// Get pre-compiled global dictionary. It is a reverse indexed global words.
+const std::unordered_map<std::string, int>& GetGlobalDictionary();
 
 }  // namespace mixerclient
 }  // namespace istio


### PR DESCRIPTION
**What this PR does / why we need it**:
Global dictionary is need by compressor in mixer. This is supposed to be a const value at compile time. However, currently we only have the forward index as const var but not reverse index. 
This PR avoid the reverse index generation from vector to map. The generation is triggered on each envoy worker thread per listener spawns.
It saves huge cpu and temporary heap usage when a listener is not healthy.

**Which issue this PR fixes** 
Step one for 1.1 istio cpu regresion

**Special notes for your reviewer**:
an intermediate generated cc file can be verified by running
`bazel build src/istio/mixerclient:global_dictionary_header_gen`

**Release note**:
TBD