### PR TITLE
[draft] add context proto

### DIFF
--- a/src/istio/context/BUILD
+++ b/src/istio/context/BUILD
@@ -17,8 +17,11 @@
 
 package(default_visibility = ["//visibility:public"])
 
+licenses(["notice"])
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
     "envoy_proto_library",
 )
 
@@ -27,5 +30,19 @@ envoy_proto_library(
     srcs = ["context.proto"],
     external_deps = [
         "well_known_protos",
+    ],
+)
+
+envoy_cc_library(
+    name = "context_lib",
+    srcs = [
+        "http_builder.cc",
+        "http_builder.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        ":context_proto_cc",
+        "//include/istio/control/http:headers_lib",
+        "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/src/istio/context/BUILD
+++ b/src/istio/context/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2019 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_proto_library",
+)
+
+envoy_proto_library(
+    name = "context_proto",
+    srcs = ["context.proto"],
+    external_deps = [
+        "@mixerapi_git//:policy_cc_proto",
+        "well_known_protos",
+    ],
+)

--- a/src/istio/context/BUILD
+++ b/src/istio/context/BUILD
@@ -26,7 +26,6 @@ envoy_proto_library(
     name = "context_proto",
     srcs = ["context.proto"],
     external_deps = [
-        "@mixerapi_git//:policy_cc_proto",
         "well_known_protos",
     ],
 )

--- a/src/istio/context/context.proto
+++ b/src/istio/context/context.proto
@@ -1,0 +1,136 @@
+// Copyright 2019 Istio Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+syntax = "proto3";
+
+package istio.context;
+
+option cc_enable_arenas = true;
+
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+message Request {
+  map<string, string> headers = 1;
+  google.protobuf.StringValue id = 2;
+  google.protobuf.StringValue host = 3;
+  google.protobuf.StringValue method = 4;
+  google.protobuf.StringValue path = 5;
+  google.protobuf.StringValue url_path = 6;
+  map<string, string> query_params = 7;
+  google.protobuf.StringValue reason = 8;
+  google.protobuf.StringValue referer = 9;
+  google.protobuf.StringValue scheme = 10;
+  google.protobuf.Int64Value total_size = 11;
+  google.protobuf.Int64Value size = 12;
+  google.protobuf.Timestamp time = 13;
+  google.protobuf.StringValue useragent = 14;
+  google.protobuf.StringValue api_key = 15;
+}
+
+message RequestAuth {
+  google.protobuf.StringValue principal = 1;
+  google.protobuf.StringValue audiences = 2;
+  google.protobuf.StringValue presenter = 3;
+  map<string, string> claims = 4;
+  google.protobuf.StringValue raw_claims = 5;
+}
+
+message Response {
+  google.protobuf.Int64Value code = 1;
+  google.protobuf.Duration duration = 2;
+  map<string, string> headers = 3;
+  google.protobuf.Int64Value total_size = 4;
+  google.protobuf.Int64Value size = 5;
+  google.protobuf.Timestamp time = 6;
+  google.protobuf.StringValue grpc_status = 7;
+  google.protobuf.StringValue grpc_message = 8;
+}
+
+message Origin {
+  google.protobuf.BytesValue ip = 1;
+  google.protobuf.StringValue uid = 2;
+  google.protobuf.StringValue user = 3;
+}
+
+message Source {
+  google.protobuf.StringValue uid = 1;
+  google.protobuf.StringValue principal = 2;
+}
+
+message Destination {
+  google.protobuf.StringValue uid = 1;
+  google.protobuf.StringValue principal = 2;
+  google.protobuf.Int64Value port = 3;
+}
+
+message Connection {
+  google.protobuf.StringValue event = 1;
+  google.protobuf.StringValue id = 2;
+  ConnectionReceived received = 3;
+  ConnectionSent sent = 4;
+  google.protobuf.Duration duration = 5;
+  google.protobuf.BoolValue mtls = 6;
+  google.protobuf.StringValue requested_server_name = 7;
+}
+
+message ConnectionReceived {
+  google.protobuf.Int64Value bytes = 1;
+  google.protobuf.Int64Value bytes_total = 2;
+}
+
+message ConnectionSent {
+  google.protobuf.Int64Value bytes = 1;
+  google.protobuf.Int64Value bytes_total = 2;
+}
+
+message Context {
+  google.protobuf.StringValue protocol = 1;
+  google.protobuf.StringValue proxy_error_code = 2;
+  google.protobuf.Timestamp timestamp = 3;
+  google.protobuf.Timestamp time = 4;
+  ContextReporter reporter = 5;
+}
+
+message ContextReporter {
+  google.protobuf.StringValue kind = 1;
+  google.protobuf.StringValue uid = 2;
+}
+
+message Api {
+  google.protobuf.StringValue service = 1;
+  google.protobuf.StringValue version = 2;
+  google.protobuf.StringValue operation = 3;
+  google.protobuf.StringValue protocol = 4;
+}
+
+message Rbac {
+  RbacPermissive permissive = 1;
+}
+
+message RbacPermissive {
+  google.protobuf.StringValue response_code = 1;
+  google.protobuf.StringValue effective_policy_id = 2;
+}
+
+message Check {
+  google.protobuf.BoolValue cache_hit = 1;
+  google.protobuf.Int64Value error_code = 2;
+  google.protobuf.StringValue error_message = 3;
+}
+
+message Quota {
+  google.protobuf.BoolValue cache_hit = 1;
+}

--- a/src/istio/context/http_builder.cc
+++ b/src/istio/context/http_builder.cc
@@ -17,8 +17,8 @@
 
 #include "common/http/utility.h"
 
-using ::google::protobuf::StringValue;
 using ::Envoy::Http::HeaderMap;
+using ::google::protobuf::StringValue;
 
 namespace istio {
 namespace context {
@@ -28,15 +28,15 @@ namespace {
 const ::Envoy::Http::LowerCaseString kRefererHeaderKey("referer");
 
 // Set of headers excluded from request.headers attribute.
-const std::set<std::string> kRequestHeaderExclusives = { "x-istio-attributes" };
+const std::set<std::string> kRequestHeaderExclusives = {"x-istio-attributes"};
 
 // The gRPC content types.
 const std::set<std::string> kGrpcContentTypes{
     "application/grpc", "application/grpc+proto", "application/grpc+json"};
 
 void extractTimestamp(
-      ::google::protobuf::Timestamp *time_stamp,
-      const std::chrono::time_point<std::chrono::system_clock> &value) {
+    ::google::protobuf::Timestamp* time_stamp,
+    const std::chrono::time_point<std::chrono::system_clock>& value) {
   long long nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
                         value.time_since_epoch())
                         .count();
@@ -44,47 +44,53 @@ void extractTimestamp(
   time_stamp->set_nanos(nanos % 1000000000);
 }
 
-} // namespace
+}  // namespace
 
 void ExtractHeaders(Request& request, const HeaderMap& headers) {
   if (headers.Path()) {
     const ::Envoy::Http::HeaderString& path = headers.Path()->value();
-    *request.mutable_path()->mutable_value() = std::string(path.c_str(), path.size());
-    const char* query_start = ::Envoy::Http::Utility::findQueryStringStart(path);
+    *request.mutable_path()->mutable_value() =
+        std::string(path.c_str(), path.size());
+    const char* query_start =
+        ::Envoy::Http::Utility::findQueryStringStart(path);
     if (query_start != nullptr) {
-      *request.mutable_url_path()->mutable_value() = std::string(path.c_str(), query_start - path.c_str());
+      *request.mutable_url_path()->mutable_value() =
+          std::string(path.c_str(), query_start - path.c_str());
     } else {
-      *request.mutable_url_path()->mutable_value() = std::string(path.c_str(), path.size());
+      *request.mutable_url_path()->mutable_value() =
+          std::string(path.c_str(), path.size());
     }
-    for (const auto &kv : ::Envoy::Http::Utility::parseQueryString(path.c_str())) {
+    for (const auto& kv :
+         ::Envoy::Http::Utility::parseQueryString(path.c_str())) {
       (*request.mutable_query_params())[kv.first] = kv.second;
     }
   }
   if (headers.Host()) {
-    *request.mutable_host()->mutable_value() = std::string(headers.Host()->value().c_str(),
-                         headers.Host()->value().size());
+    *request.mutable_host()->mutable_value() = std::string(
+        headers.Host()->value().c_str(), headers.Host()->value().size());
   }
   if (headers.Scheme()) {
-    *request.mutable_scheme()->mutable_value() = std::string(headers.Scheme()->value().c_str(),
-                         headers.Scheme()->value().size());
+    *request.mutable_scheme()->mutable_value() = std::string(
+        headers.Scheme()->value().c_str(), headers.Scheme()->value().size());
   }
   if (headers.UserAgent()) {
-    *request.mutable_useragent()->mutable_value() = std::string(headers.UserAgent()->value().c_str(),
-                         headers.UserAgent()->value().size());
+    *request.mutable_useragent()->mutable_value() =
+        std::string(headers.UserAgent()->value().c_str(),
+                    headers.UserAgent()->value().size());
   }
   if (headers.Method()) {
-    *request.mutable_method()->mutable_value() = std::string(headers.Method()->value().c_str(),
-                         headers.Method()->value().size());
+    *request.mutable_method()->mutable_value() = std::string(
+        headers.Method()->value().c_str(), headers.Method()->value().size());
   }
 
   const ::Envoy::Http::HeaderEntry* referer = headers.get(kRefererHeaderKey);
   if (referer) {
-    *request.mutable_referer()->mutable_value() = std::string(referer->value().c_str(), referer->value().size());
+    *request.mutable_referer()->mutable_value() =
+        std::string(referer->value().c_str(), referer->value().size());
   }
 
   struct Context {
-    Context(const std::set<std::string>& exclusives,
-            Request& request)
+    Context(const std::set<std::string>& exclusives, Request& request)
         : exclusives(exclusives), request(request) {}
     const std::set<std::string>& exclusives;
     Request& request;
@@ -95,7 +101,8 @@ void ExtractHeaders(Request& request, const HeaderMap& headers) {
          void* context) -> ::Envoy::Http::HeaderMap::Iterate {
         Context* ctx = static_cast<Context*>(context);
         if (ctx->exclusives.count(header.key().c_str()) == 0) {
-          (*ctx->request.mutable_headers())[header.key().c_str()] = header.value().c_str();
+          (*ctx->request.mutable_headers())[header.key().c_str()] =
+              header.value().c_str();
         }
         return ::Envoy::Http::HeaderMap::Iterate::Continue;
       },
@@ -106,31 +113,38 @@ void ExtractHeaders(Request& request, const HeaderMap& headers) {
 }
 
 void ExtractContext(Context& context, const HeaderMap& headers) {
-  if (headers.ContentType() && kGrpcContentTypes.count(headers.ContentType()->value().c_str()) != 0) {
-    *context.mutable_protocol() -> mutable_value() = "grpc";
+  if (headers.ContentType() &&
+      kGrpcContentTypes.count(headers.ContentType()->value().c_str()) != 0) {
+    *context.mutable_protocol()->mutable_value() = "grpc";
   } else {
-    *context.mutable_protocol() -> mutable_value() = "http";
+    *context.mutable_protocol()->mutable_value() = "http";
   }
 }
 
-void ExtractConnection(Connection& connection, const ::Envoy::Network::Connection& downstream) {
+void ExtractConnection(Connection& connection,
+                       const ::Envoy::Network::Connection& downstream) {
   if (!downstream.requestedServerName().empty()) {
-    *connection.mutable_requested_server_name()->mutable_value() = std::string(downstream.requestedServerName());
+    *connection.mutable_requested_server_name()->mutable_value() =
+        std::string(downstream.requestedServerName());
   }
-  if (downstream.ssl() != nullptr && downstream.ssl()->peerCertificatePresented()) {
+  if (downstream.ssl() != nullptr &&
+      downstream.ssl()->peerCertificatePresented()) {
     connection.mutable_mtls()->set_value(true);
   }
 }
 
-void ExtractOrigin(Origin& origin, const ::Envoy::Network::Connection& downstream) {
+void ExtractOrigin(Origin& origin,
+                   const ::Envoy::Network::Connection& downstream) {
   auto ip = downstream.remoteAddress()->ip();
   if (ip) {
     if (ip->ipv4()) {
       uint32_t ipv4 = ip->ipv4()->address();
-      *origin.mutable_ip()->mutable_value() = std::string(reinterpret_cast<const char*>(&ipv4), sizeof(ipv4));
+      *origin.mutable_ip()->mutable_value() =
+          std::string(reinterpret_cast<const char*>(&ipv4), sizeof(ipv4));
     } else if (ip->ipv6()) {
       absl::uint128 ipv6 = ip->ipv6()->address();
-      *origin.mutable_ip()->mutable_value() = std::string(reinterpret_cast<const char*>(&ipv6), 16);
+      *origin.mutable_ip()->mutable_value() =
+          std::string(reinterpret_cast<const char*>(&ipv6), 16);
     }
   }
 }

--- a/src/istio/context/http_builder.cc
+++ b/src/istio/context/http_builder.cc
@@ -1,0 +1,139 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/istio/context/http_builder.h"
+
+#include "common/http/utility.h"
+
+using ::google::protobuf::StringValue;
+using ::Envoy::Http::HeaderMap;
+
+namespace istio {
+namespace context {
+
+namespace {
+// Referer header
+const ::Envoy::Http::LowerCaseString kRefererHeaderKey("referer");
+
+// Set of headers excluded from request.headers attribute.
+const std::set<std::string> kRequestHeaderExclusives = { "x-istio-attributes" };
+
+// The gRPC content types.
+const std::set<std::string> kGrpcContentTypes{
+    "application/grpc", "application/grpc+proto", "application/grpc+json"};
+
+void extractTimestamp(
+      ::google::protobuf::Timestamp *time_stamp,
+      const std::chrono::time_point<std::chrono::system_clock> &value) {
+  long long nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        value.time_since_epoch())
+                        .count();
+  time_stamp->set_seconds(nanos / 1000000000);
+  time_stamp->set_nanos(nanos % 1000000000);
+}
+
+} // namespace
+
+void ExtractHeaders(Request& request, const HeaderMap& headers) {
+  if (headers.Path()) {
+    const ::Envoy::Http::HeaderString& path = headers.Path()->value();
+    *request.mutable_path()->mutable_value() = std::string(path.c_str(), path.size());
+    const char* query_start = ::Envoy::Http::Utility::findQueryStringStart(path);
+    if (query_start != nullptr) {
+      *request.mutable_url_path()->mutable_value() = std::string(path.c_str(), query_start - path.c_str());
+    } else {
+      *request.mutable_url_path()->mutable_value() = std::string(path.c_str(), path.size());
+    }
+    for (const auto &kv : ::Envoy::Http::Utility::parseQueryString(path.c_str())) {
+      (*request.mutable_query_params())[kv.first] = kv.second;
+    }
+  }
+  if (headers.Host()) {
+    *request.mutable_host()->mutable_value() = std::string(headers.Host()->value().c_str(),
+                         headers.Host()->value().size());
+  }
+  if (headers.Scheme()) {
+    *request.mutable_scheme()->mutable_value() = std::string(headers.Scheme()->value().c_str(),
+                         headers.Scheme()->value().size());
+  }
+  if (headers.UserAgent()) {
+    *request.mutable_useragent()->mutable_value() = std::string(headers.UserAgent()->value().c_str(),
+                         headers.UserAgent()->value().size());
+  }
+  if (headers.Method()) {
+    *request.mutable_method()->mutable_value() = std::string(headers.Method()->value().c_str(),
+                         headers.Method()->value().size());
+  }
+
+  const ::Envoy::Http::HeaderEntry* referer = headers.get(kRefererHeaderKey);
+  if (referer) {
+    *request.mutable_referer()->mutable_value() = std::string(referer->value().c_str(), referer->value().size());
+  }
+
+  struct Context {
+    Context(const std::set<std::string>& exclusives,
+            Request& request)
+        : exclusives(exclusives), request(request) {}
+    const std::set<std::string>& exclusives;
+    Request& request;
+  };
+  Context ctx(kRequestHeaderExclusives, request);
+  headers.iterate(
+      [](const ::Envoy::Http::HeaderEntry& header,
+         void* context) -> ::Envoy::Http::HeaderMap::Iterate {
+        Context* ctx = static_cast<Context*>(context);
+        if (ctx->exclusives.count(header.key().c_str()) == 0) {
+          (*ctx->request.mutable_headers())[header.key().c_str()] = header.value().c_str();
+        }
+        return ::Envoy::Http::HeaderMap::Iterate::Continue;
+      },
+      &ctx);
+
+  // Populate request.time
+  extractTimestamp(request.mutable_time(), std::chrono::system_clock::now());
+}
+
+void ExtractContext(Context& context, const HeaderMap& headers) {
+  if (headers.ContentType() && kGrpcContentTypes.count(headers.ContentType()->value().c_str()) != 0) {
+    *context.mutable_protocol() -> mutable_value() = "grpc";
+  } else {
+    *context.mutable_protocol() -> mutable_value() = "http";
+  }
+}
+
+void ExtractConnection(Connection& connection, const ::Envoy::Network::Connection& downstream) {
+  if (!downstream.requestedServerName().empty()) {
+    *connection.mutable_requested_server_name()->mutable_value() = std::string(downstream.requestedServerName());
+  }
+  if (downstream.ssl() != nullptr && downstream.ssl()->peerCertificatePresented()) {
+    connection.mutable_mtls()->set_value(true);
+  }
+}
+
+void ExtractOrigin(Origin& origin, const ::Envoy::Network::Connection& downstream) {
+  auto ip = downstream.remoteAddress()->ip();
+  if (ip) {
+    if (ip->ipv4()) {
+      uint32_t ipv4 = ip->ipv4()->address();
+      *origin.mutable_ip()->mutable_value() = std::string(reinterpret_cast<const char*>(&ipv4), sizeof(ipv4));
+    } else if (ip->ipv6()) {
+      absl::uint128 ipv6 = ip->ipv6()->address();
+      *origin.mutable_ip()->mutable_value() = std::string(reinterpret_cast<const char*>(&ipv6), 16);
+    }
+  }
+}
+
+}  // namespace context
+}  // namespace istio

--- a/src/istio/context/http_builder.h
+++ b/src/istio/context/http_builder.h
@@ -29,9 +29,11 @@ void ExtractHeaders(Request& request, const ::Envoy::Http::HeaderMap& headers);
 
 void ExtractContext(Context& context, const ::Envoy::Http::HeaderMap& headers);
 
-void ExtractConnection(Connection& connection, const ::Envoy::Network::Connection& downstream);
+void ExtractConnection(Connection& connection,
+                       const ::Envoy::Network::Connection& downstream);
 
-void ExtractOrigin(Origin& origin, const ::Envoy::Network::Connection& downstream);
+void ExtractOrigin(Origin& origin,
+                   const ::Envoy::Network::Connection& downstream);
 
 }  // namespace context
 }  // namespace istio

--- a/src/istio/context/http_builder.h
+++ b/src/istio/context/http_builder.h
@@ -20,12 +20,13 @@
 
 #include "envoy/http/header_map.h"
 #include "envoy/network/connection.h"
+#include "envoy/stream_info/stream_info.h"
 #include "src/istio/context/context.pb.h"
 
 namespace istio {
 namespace context {
 
-void ExtractHeaders(Request& request, const ::Envoy::Http::HeaderMap& headers);
+void ExtractRequest(Request& request, const ::Envoy::Http::HeaderMap& headers);
 
 void ExtractContext(Context& context, const ::Envoy::Http::HeaderMap& headers);
 
@@ -34,6 +35,11 @@ void ExtractConnection(Connection& connection,
 
 void ExtractOrigin(Origin& origin,
                    const ::Envoy::Network::Connection& downstream);
+
+void ExtractReportData(Request& request, Response& response, Context& context,
+                       const ::Envoy::Http::HeaderMap& response_headers,
+                       const ::Envoy::Http::HeaderMap& response_trailers,
+                       const ::Envoy::StreamInfo::StreamInfo& info);
 
 }  // namespace context
 }  // namespace istio

--- a/src/istio/context/http_builder.h
+++ b/src/istio/context/http_builder.h
@@ -1,0 +1,37 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "envoy/http/header_map.h"
+#include "envoy/network/connection.h"
+#include "src/istio/context/context.pb.h"
+
+namespace istio {
+namespace context {
+
+void ExtractHeaders(Request& request, const ::Envoy::Http::HeaderMap& headers);
+
+void ExtractContext(Context& context, const ::Envoy::Http::HeaderMap& headers);
+
+void ExtractConnection(Connection& connection, const ::Envoy::Network::Connection& downstream);
+
+void ExtractOrigin(Origin& origin, const ::Envoy::Network::Connection& downstream);
+
+}  // namespace context
+}  // namespace istio


### PR DESCRIPTION
Introduce context proto for exchanging data between embedded CEL and envoy.

The context is derived from the istio proxy attribute manifest using wrappers for presence detection.

Populate the initial set of values.

/assign @mandarjog 
/assign @PiotrSikora 
