### PR TITLE
Makefile: allow specify BAZEL binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 ## limitations under the License.
 
 TOP := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-
+BAZEL_BIN ?= bazel
 SHELL := /bin/bash
 LOCAL_ARTIFACTS_DIR ?= $(abspath artifacts)
 ARTIFACTS_DIR ?= $(LOCAL_ARTIFACTS_DIR)
@@ -24,23 +24,23 @@ HUB ?=
 TAG ?=
 
 build:
-	@bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) //...
+	@${BAZEL_BIN} $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) //...
 
 # Build only envoy - fast
 build_envoy:
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) //src/envoy/mixer:envoy
+	${BAZEL_BIN} $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) //src/envoy/tcp/mixer:filter_lib //src/envoy/http/mixer:filter_lib
 
 clean:
-	@bazel clean
+	@${BAZEL_BIN} clean
 
 test:
-	bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) //...
+	${BAZEL_BIN} $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) //...
 
 test_asan:
-	CC=clang-5.0 CXX=clang++-5.0 bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-asan //...
+	CC=clang-5.0 CXX=clang++-5.0 ${BAZEL_BIN} $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-asan //...
 
 test_tsan:
-	CC=clang-5.0 CXX=clang++-5.0 bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-tsan //...
+	CC=clang-5.0 CXX=clang++-5.0 ${BAZEL_BIN} $(BAZEL_STARTUP_ARGS) test $(BAZEL_TEST_ARGS) --config=clang-tsan //...
 
 check:
 	@script/check-license-headers
@@ -50,7 +50,7 @@ artifacts: build
 	@script/push-debian.sh -c opt -p $(ARTIFACTS_DIR)
 
 deb:
-	@bazel build tools/deb:istio-proxy ${BAZEL_BUILD_ARGS}
+	@${BAZEL_BIN} build tools/deb:istio-proxy ${BAZEL_BUILD_ARGS}
 
 
 .PHONY: build clean test check artifacts


### PR DESCRIPTION
Also fix the target in make targe `build_envoy`

Usage:
`BAZEL_BIN=~/bazel0.16/bin/bazel make build_envoy`

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

**What this PR does / why we need it**:

My current bazel 0.22 cannot build proxy 1.0 any more. I choose to install bazel 0.16 and fix the Makefile to opt the bazel. See the usage above. 
Also enable the `make build_envoy`

**Special notes for your reviewer**:
If you have a default old bazel, you can use it as long as you specify BAZE_BIN

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
