### PR TITLE
release 1.1: Update envoy to enable path normalization

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,12 +1,15 @@
 # Copied from https://github.com/envoyproxy/envoy/blob/master/tools/bazel.rc
 # Envoy specific Bazel build/test options.
 
-build --workspace_status_command=tools/bazel_get_workspace_status
 # Bazel doesn't need more than 200MB of memory based on memory profiling:
 # https://docs.bazel.build/versions/master/skylark/performance.html#memory-profiling
 # Limiting JVM heapsize here to let it do GC more when approaching the limit to
 # leave room for compiler/linker.
 startup --host_jvm_args=-Xmx512m
+
+build --workspace_status_command=tools/bazel_get_workspace_status
+# enable path normalization by default. See https://github.com/envoyproxy/envoy/pull/6519
+build --define path_normalization_by_default=true
 
 # Basic ASAN/UBSAN that works for gcc
 build:asan --define ENVOY_CONFIG_ASAN=1
@@ -54,6 +57,8 @@ build:clang-msan --copt -fsanitize-memory-track-origins=2
 
 # Test options
 test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
+# enable path normalization by default. See https://github.com/envoyproxy/envoy/pull/6519
+test --define path_normalization_by_default=true
 
 # Release builds without debug symbols.
 build:release -c opt

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,11 +32,15 @@ bind(
     actual = "//external:ssl",
 )
 
+# envoy commit date 04/10/2019
+# bazel version: 0.22.0
+
 # When updating envoy sha manually please update the sha in istio.deps file also
 #
 # Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/COMMIT.tar.gz && sha256sum COMMIT.tar.gz`
-ENVOY_SHA = "805683f835bd63e4b7b9d89059aa0d3783924a93"
-ENVOY_SHA256 = "75a029fb3904c17f47c7f723e2a04468bfc007bb4cfc74fe21f82cf799d8a904"
+ENVOY_SHA = "ac7aa5ac8a815e5277b4d4659c5c02145fa1d56f"
+ENVOY_SHA256 = "3f13facc893ef0c5063c7391a1ffca8de0f52425c8a7a49ef45e69dbb5e7304b"
+LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
 
 http_archive(
     name = "envoy",
@@ -45,8 +49,15 @@ http_archive(
     sha256 = ENVOY_SHA256,
 )
 
-load("@envoy//bazel:repositories.bzl", "GO_VERSION", "envoy_dependencies")
+#local_repository(
+#     name = "envoy",
+#     path = LOCAL_ENVOY_PROJECT
+#)
 
+load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")
+envoy_api_dependencies()
+
+load("@envoy//bazel:repositories.bzl", "GO_VERSION", "envoy_dependencies")
 envoy_dependencies()
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,9 +49,11 @@ http_archive(
     sha256 = ENVOY_SHA256,
 )
 
+# TODO(silentdai) Use bazel args to select envoy between local or http
+# Uncomment below and comment above http_archive to depends on local envoy.
 #local_repository(
 #     name = "envoy",
-#     path = LOCAL_ENVOY_PROJECT
+#     path = LOCAL_ENVOY_PROJECT,
 #)
 
 load("@envoy//bazel:api_repositories.bzl", "envoy_api_dependencies")

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "envoyproxy/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "805683f835bd63e4b7b9d89059aa0d3783924a93"
+		"lastStableSHA": "ac7aa5ac8a815e5277b4d4659c5c02145fa1d56f"
 	}
 ]


### PR DESCRIPTION
On top of #2158 

And introduce the path normalization.

- Update envoy dependency to 1.10  at 04/10/2019
- Update .bazelrc to adopt the compilation option to enable the path normalization by default
- Update WORKSPACE so that it support envoy build from http github repo and local envoy. The latter is heavily used by debugging.

Q: How to build or test the path normalization?
A: Any make/bazel command should pickup the compilation option automatically. See .bazelrc