### PR TITLE
envoy: proxy release 1.0 should use the istio/envoy with cve fix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -30,7 +30,7 @@ bind(
 )
 
 # When updating envoy sha manually please update the sha in istio.deps file also
-ENVOY_SHA = "2d8386532f68899ca1fe6476dc458b0df1260b29"
+ENVOY_SHA = "fb9e49cbc9f136f3c49a5daa8fcdc96b2f245a51"
 
 http_archive(
     name = "envoy",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,9 @@ bind(
     actual = "//external:ssl",
 )
 
+# envoy commit date 04/09/2019
+# bazel version: 0.15.0
+
 # When updating envoy sha manually please update the sha in istio.deps file also
 ENVOY_SHA = "fb9e49cbc9f136f3c49a5daa8fcdc96b2f245a51"
 

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "istio/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "2d8386532f68899ca1fe6476dc458b0df1260b29"
+		"lastStableSHA": "fb9e49cbc9f136f3c49a5daa8fcdc96b2f245a51"
 	}
 ]


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

**What this PR does / why we need it**:
Use the istio/envoy with the cve fix for future proxy release

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
CVE-2019-9900
CVE-2019-9901

**Special notes for your reviewer**:
Please confirm your bazel version is 0.15

**Release note**:
```
Should borrow the existing announced 1.0.7 release notes.  TBD
```
