### PR TITLE
fixing a comment that is out of sync with the code

### DIFF
--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -55,7 +55,7 @@ struct CheckOptions {
 // Options controlling report batch.
 struct ReportOptions {
   // Default constructor.
-  // Default to batch up to 500 reports or 1 seconds.
+  // Default to batch up to 100 reports or 1 seconds.
   ReportOptions() : max_batch_entries(100), max_batch_time_ms(1000) {}
 
   // Constructor.


### PR DESCRIPTION
Comment is out of sync with the code. Fixing the comment to be not confusing