### PR TITLE
Retrieve tracing header from request headers during report

### DIFF
--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -35,7 +35,8 @@ class ReportData {
   virtual std::map<std::string, std::string> GetResponseHeaders() const = 0;
 
   // Get tracing headers from HTTP request headers.
-  virtual void GetTracingHeaders(std::map<std::string, std::string> &) const = 0;
+  virtual void GetTracingHeaders(
+      std::map<std::string, std::string> &) const = 0;
 
   // Get additional report info.
   struct ReportInfo {

--- a/include/istio/control/http/report_data.h
+++ b/include/istio/control/http/report_data.h
@@ -34,6 +34,9 @@ class ReportData {
   // Get response HTTP headers.
   virtual std::map<std::string, std::string> GetResponseHeaders() const = 0;
 
+  // Get tracing headers from HTTP request headers.
+  virtual void GetTracingHeaders(std::map<std::string, std::string> &) const = 0;
+
   // Get additional report info.
   struct ReportInfo {
     uint64_t response_total_size;

--- a/include/istio/utils/attributes_builder.h
+++ b/include/istio/utils/attributes_builder.h
@@ -91,6 +91,19 @@ class AttributesBuilder {
     }
   }
 
+  void InsertStringMap(const std::string &key,
+                       const std::map<std::string, std::string> &string_map) {
+    if (string_map.size() == 0) {
+      return;
+    }
+    auto entries = (*attributes_->mutable_attributes())[key]
+                       .mutable_string_map_value()
+                       ->mutable_entries();
+    for (const auto &map_it : string_map) {
+      (*entries)[map_it.first] = map_it.second;
+    }
+  }
+
   void AddProtoStructStringMap(const std::string &key,
                                const google::protobuf::Struct &struct_map) {
     if (struct_map.fields().empty()) {

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -232,8 +232,8 @@ void Filter::log(const HeaderMap* request_headers,
   CheckData check_data(*request_headers, stream_info.dynamicMetadata(),
                        decoder_callbacks_->connection());
   // response trailer header is not counted to response total size.
-  ReportData report_data(response_headers, response_trailers, stream_info,
-                         request_total_size_);
+  ReportData report_data(request_headers, response_headers, response_trailers,
+                         stream_info, request_total_size_);
   handler_->Report(&check_data, &report_data);
 }
 

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -61,7 +61,8 @@ class ReportData : public ::istio::control::http::ReportData,
   uint64_t request_total_size_;
 
  public:
-  ReportData(const HeaderMap *request_headers, const HeaderMap *response_headers,
+  ReportData(const HeaderMap *request_headers,
+             const HeaderMap *response_headers,
              const HeaderMap *response_trailers,
              const StreamInfo::StreamInfo &info, uint64_t request_total_size)
       : request_headers_(request_headers),
@@ -81,7 +82,8 @@ class ReportData : public ::istio::control::http::ReportData,
   std::map<std::string, std::string> GetResponseHeaders() const override {
     std::map<std::string, std::string> header_map;
     if (response_headers_) {
-      Utils::ExtractHeaders(*response_headers_, ResponseHeaderExclusives, header_map);
+      Utils::ExtractHeaders(*response_headers_, ResponseHeaderExclusives,
+                            header_map);
     }
     if (trailers_) {
       Utils::ExtractHeaders(*trailers_, ResponseHeaderExclusives, header_map);
@@ -89,8 +91,10 @@ class ReportData : public ::istio::control::http::ReportData,
     return header_map;
   }
 
-  void GetTracingHeaders(std::map<std::string, std::string>& tracing_headers) const override {
-    Utils::FindHeaders(*request_headers_, Utils::TracingHeaderSet, tracing_headers);
+  void GetTracingHeaders(
+      std::map<std::string, std::string> &tracing_headers) const override {
+    Utils::FindHeaders(*request_headers_, Utils::TracingHeaderSet,
+                       tracing_headers);
   }
 
   void GetReportInfo(

--- a/src/envoy/utils/BUILD
+++ b/src/envoy/utils/BUILD
@@ -57,6 +57,7 @@ envoy_cc_library(
         "header_update.h",
         "mixer_control.h",
         "stats.h",
+        "trace_headers.h",
         "utils.h",
     ],
     repository = "@envoy",

--- a/src/envoy/utils/trace_headers.h
+++ b/src/envoy/utils/trace_headers.h
@@ -1,3 +1,18 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <string>

--- a/src/envoy/utils/trace_headers.h
+++ b/src/envoy/utils/trace_headers.h
@@ -27,7 +27,10 @@ const std::string kParentSpanID = "x-b3-parentspanid";
 const std::string kSampled = "x-b3-sampled";
 
 const std::set<std::string> TracingHeaderSet = {
-    kTraceID, kSpanID, kParentSpanID, kSampled,
+    kTraceID,
+    kSpanID,
+    kParentSpanID,
+    kSampled,
 };
 
 }  // namespace Utils

--- a/src/envoy/utils/trace_headers.h
+++ b/src/envoy/utils/trace_headers.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace Envoy {
+namespace Utils {
+
+// Zipkin B3 headers
+const std::string kTraceID = "x-b3-traceid";
+const std::string kSpanID = "x-b3-spanid";
+const std::string kParentSpanID = "x-b3-parentspanid";
+const std::string kSampled = "x-b3-sampled";
+
+const std::set<std::string> TracingHeaderSet = {
+    kTraceID, kSpanID, kParentSpanID, kSampled,
+};
+
+}  // namespace Utils
+}  // namespace Envoy

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -60,8 +60,8 @@ void ExtractHeaders(const Http::HeaderMap& header_map,
 }
 
 void FindHeaders(const Http::HeaderMap& header_map,
-                      const std::set<std::string>& inclusives,
-                      std::map<std::string, std::string>& headers) {
+                 const std::set<std::string>& inclusives,
+                 std::map<std::string, std::string>& headers) {
   struct Context {
     Context(const std::set<std::string>& inclusives,
             std::map<std::string, std::string>& headers)

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -31,6 +31,11 @@ void ExtractHeaders(const Http::HeaderMap& header_map,
                     const std::set<std::string>& exclusives,
                     std::map<std::string, std::string>& headers);
 
+// Find the given headers from the header map and extract them out to the string map.
+void FindHeaders(const Http::HeaderMap& header_map,
+                    const std::set<std::string>& inclusives,
+                    std::map<std::string, std::string>& headers);
+
 // Get ip and port from Envoy ip.
 bool GetIpPort(const Network::Address::Ip* ip, std::string* str_ip, int* port);
 

--- a/src/envoy/utils/utils.h
+++ b/src/envoy/utils/utils.h
@@ -31,10 +31,11 @@ void ExtractHeaders(const Http::HeaderMap& header_map,
                     const std::set<std::string>& exclusives,
                     std::map<std::string, std::string>& headers);
 
-// Find the given headers from the header map and extract them out to the string map.
+// Find the given headers from the header map and extract them out to the string
+// map.
 void FindHeaders(const Http::HeaderMap& header_map,
-                    const std::set<std::string>& inclusives,
-                    std::map<std::string, std::string>& headers);
+                 const std::set<std::string>& inclusives,
+                 std::map<std::string, std::string>& headers);
 
 // Get ip and port from Envoy ip.
 bool GetIpPort(const Network::Address::Ip* ip, std::string* str_ip, int* port);

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -228,7 +228,8 @@ void AttributesBuilder::ExtractReportAttributes(
 
   std::map<std::string, std::string> tracing_headers;
   report_data->GetTracingHeaders(tracing_headers);
-  builder.InsertStringMap(utils::AttributeName::kRequestHeaders, tracing_headers);
+  builder.InsertStringMap(utils::AttributeName::kRequestHeaders,
+                          tracing_headers);
 
   builder.AddTimestamp(utils::AttributeName::kResponseTime,
                        std::chrono::system_clock::now());

--- a/src/istio/control/http/attributes_builder.cc
+++ b/src/istio/control/http/attributes_builder.cc
@@ -226,6 +226,10 @@ void AttributesBuilder::ExtractReportAttributes(
       report_data->GetResponseHeaders();
   builder.AddStringMap(utils::AttributeName::kResponseHeaders, headers);
 
+  std::map<std::string, std::string> tracing_headers;
+  report_data->GetTracingHeaders(tracing_headers);
+  builder.InsertStringMap(utils::AttributeName::kRequestHeaders, tracing_headers);
+
   builder.AddTimestamp(utils::AttributeName::kResponseTime,
                        std::chrono::system_clock::now());
 

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -15,15 +15,15 @@
 
 #include "src/istio/control/http/attributes_builder.h"
 
+#include "gmock/gmock.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "src/istio/control/http/mock_check_data.h"
 #include "src/istio/control/http/mock_report_data.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using ::google::protobuf::TextFormat;
 using ::google::protobuf::util::MessageDifferencer;

--- a/src/istio/control/http/attributes_builder_test.cc
+++ b/src/istio/control/http/attributes_builder_test.cc
@@ -15,15 +15,15 @@
 
 #include "src/istio/control/http/attributes_builder.h"
 
-#include "gmock/gmock.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"
-#include "gtest/gtest.h"
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "src/istio/control/http/mock_check_data.h"
 #include "src/istio/control/http/mock_report_data.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 using ::google::protobuf::TextFormat;
 using ::google::protobuf::util::MessageDifferencer;
@@ -348,6 +348,21 @@ attributes {
   key: "destination.port"
   value {
     int64_value: 8080
+  }
+}
+attributes {
+  key: "request.headers"
+  value {
+    string_map_value {
+      entries {
+        key: "x-b3-traceid"
+        value: "abc"
+      }
+      entries {
+        key: "x-b3-spanid"
+        value: "def"
+      }
+    }
   }
 }
 attributes {
@@ -765,6 +780,11 @@ TEST(AttributesBuilderTest, TestReportAttributes) {
         map["server"] = "my-server";
         return map;
       }));
+  EXPECT_CALL(mock_data, GetTracingHeaders(_))
+      .WillOnce(Invoke([](std::map<std::string, std::string> &m) {
+        m["x-b3-traceid"] = "abc";
+        m["x-b3-spanid"] = "def";
+      }));
   EXPECT_CALL(mock_data, GetReportInfo(_))
       .WillOnce(Invoke([](ReportData::ReportInfo *info) {
         info->request_body_size = 100;
@@ -844,6 +864,11 @@ TEST(AttributesBuilderTest, TestReportAttributesWithDestIP) {
         map["content-length"] = "123456";
         map["server"] = "my-server";
         return map;
+      }));
+  EXPECT_CALL(mock_data, GetTracingHeaders(_))
+      .WillOnce(Invoke([](std::map<std::string, std::string> &m) {
+        m["x-b3-traceid"] = "abc";
+        m["x-b3-spanid"] = "def";
       }));
   EXPECT_CALL(mock_data, GetReportInfo(_))
       .WillOnce(Invoke([](ReportData::ReportInfo *info) {

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -27,6 +27,7 @@ namespace http {
 class MockReportData : public ReportData {
  public:
   MOCK_CONST_METHOD0(GetResponseHeaders, std::map<std::string, std::string>());
+  MOCK_CONST_METHOD1(GetTracingHeaders, void(std::map<std::string, std::string>&));
   MOCK_CONST_METHOD1(GetReportInfo, void(ReportInfo *info));
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string *ip, int *port));
   MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string *ip));

--- a/src/istio/control/http/mock_report_data.h
+++ b/src/istio/control/http/mock_report_data.h
@@ -27,7 +27,8 @@ namespace http {
 class MockReportData : public ReportData {
  public:
   MOCK_CONST_METHOD0(GetResponseHeaders, std::map<std::string, std::string>());
-  MOCK_CONST_METHOD1(GetTracingHeaders, void(std::map<std::string, std::string>&));
+  MOCK_CONST_METHOD1(GetTracingHeaders,
+                     void(std::map<std::string, std::string> &));
   MOCK_CONST_METHOD1(GetReportInfo, void(ReportInfo *info));
   MOCK_CONST_METHOD2(GetDestinationIpPort, bool(std::string *ip, int *port));
   MOCK_CONST_METHOD1(GetDestinationUID, bool(std::string *ip));

--- a/test/integration/istio_http_integration_test.cc
+++ b/test/integration/istio_http_integration_test.cc
@@ -506,7 +506,7 @@ TEST_P(IstioHttpIntegrationTest, TracingHeader) {
   EXPECT_TRUE(upstream_headers.has(Envoy::Utils::kSpanID));
   EXPECT_TRUE(upstream_headers.has(Envoy::Utils::kSampled));
 
-  // trace id should be included in default words of report request
+  // span id should be included in default words of report request
   EXPECT_THAT(
       report_request.default_words(),
       ::testing::AllOf(Contains(upstream_headers.get_(Envoy::Utils::kSpanID))));

--- a/test/integration/istio_http_integration_test.cc
+++ b/test/integration/istio_http_integration_test.cc
@@ -279,17 +279,23 @@ class IstioHttpIntegrationTest : public HttpProtocolIntegrationTest {
     return [](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
       auto* http_tracing = bootstrap.mutable_tracing()->mutable_http();
       http_tracing->set_name("envoy.zipkin");
-      auto* tracer_config_fields = http_tracing->mutable_config()->mutable_fields();
-      (*tracer_config_fields)["collector_cluster"].set_string_value(kZipkinBackend);
-      (*tracer_config_fields)["collector_endpoint"].set_string_value("/api/v1/spans");
+      auto* tracer_config_fields =
+          http_tracing->mutable_config()->mutable_fields();
+      (*tracer_config_fields)["collector_cluster"].set_string_value(
+          kZipkinBackend);
+      (*tracer_config_fields)["collector_endpoint"].set_string_value(
+          "/api/v1/spans");
     };
   }
 
   ConfigHelper::HttpModifierFunction addTracingRate() {
-    return [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm) {
+    return [](envoy::config::filter::network::http_connection_manager::v2::
+                  HttpConnectionManager& hcm) {
       auto* tracing = hcm.mutable_tracing();
       tracing->set_operation_name(
-        envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager_Tracing_OperationName::HttpConnectionManager_Tracing_OperationName_EGRESS);
+          envoy::config::filter::network::http_connection_manager::v2::
+              HttpConnectionManager_Tracing_OperationName::
+                  HttpConnectionManager_Tracing_OperationName_EGRESS);
       tracing->mutable_client_sampling()->set_value(100.0);
       tracing->mutable_random_sampling()->set_value(100.0);
       tracing->mutable_overall_sampling()->set_value(100.0);
@@ -501,7 +507,9 @@ TEST_P(IstioHttpIntegrationTest, TracingHeader) {
   EXPECT_TRUE(upstream_headers.has(Envoy::Utils::kSampled));
 
   // trace id should be included in default words of report request
-  EXPECT_THAT(report_request.default_words(), ::testing::AllOf(Contains(upstream_headers.get_(Envoy::Utils::kSpanID))));
+  EXPECT_THAT(
+      report_request.default_words(),
+      ::testing::AllOf(Contains(upstream_headers.get_(Envoy::Utils::kSpanID))));
 }
 
 }  // namespace

--- a/test/integration/istio_http_integration_test.cc
+++ b/test/integration/istio_http_integration_test.cc
@@ -24,6 +24,7 @@
 #include "include/istio/utils/attribute_names.h"
 #include "mixer/v1/mixer.pb.h"
 #include "src/envoy/utils/filter_names.h"
+#include "src/envoy/utils/trace_headers.h"
 #include "test/integration/http_protocol_integration.h"
 
 using ::google::protobuf::util::error::Code;
@@ -102,6 +103,7 @@ constexpr char kDestinationUID[] = "kubernetes://dest.pod";
 constexpr char kSourceUID[] = "kubernetes://src.pod";
 constexpr char kTelemetryBackend[] = "telemetry-backend";
 constexpr char kPolicyBackend[] = "policy-backend";
+constexpr char kZipkinBackend[] = "zipkin-backend";
 
 // Generates basic test request header.
 Http::TestHeaderMapImpl BaseRequestHeaders() {
@@ -227,6 +229,10 @@ class IstioHttpIntegrationTest : public HttpProtocolIntegrationTest {
     fake_upstreams_.emplace_back(new FakeUpstream(
         0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
     policy_upstream_ = fake_upstreams_.back().get();
+
+    fake_upstreams_.emplace_back(new FakeUpstream(
+        0, FakeHttpConnection::Type::HTTP2, version_, timeSystem()));
+    zipkin_upstream_ = fake_upstreams_.back().get();
   }
 
   void SetUp() override {
@@ -239,6 +245,10 @@ class IstioHttpIntegrationTest : public HttpProtocolIntegrationTest {
 
     config_helper_.addConfigModifier(addCluster(kTelemetryBackend));
     config_helper_.addConfigModifier(addCluster(kPolicyBackend));
+    config_helper_.addConfigModifier(addCluster(kZipkinBackend));
+
+    config_helper_.addConfigModifier(addTracer());
+    config_helper_.addConfigModifier(addTracingRate());
 
     HttpProtocolIntegrationTest::initialize();
   }
@@ -247,6 +257,7 @@ class IstioHttpIntegrationTest : public HttpProtocolIntegrationTest {
     cleanupConnection(fake_upstream_connection_);
     cleanupConnection(telemetry_connection_);
     cleanupConnection(policy_connection_);
+    cleanupConnection(zipkin_connection_);
   }
 
   ConfigHelper::ConfigModifierFunction addNodeMetadata() {
@@ -261,6 +272,27 @@ class IstioHttpIntegrationTest : public HttpProtocolIntegrationTest {
                        kDestinationUID, kDestinationNamespace),
           meta);
       bootstrap.mutable_node()->mutable_metadata()->MergeFrom(meta);
+    };
+  }
+
+  ConfigHelper::ConfigModifierFunction addTracer() {
+    return [](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+      auto* http_tracing = bootstrap.mutable_tracing()->mutable_http();
+      http_tracing->set_name("envoy.zipkin");
+      auto* tracer_config_fields = http_tracing->mutable_config()->mutable_fields();
+      (*tracer_config_fields)["collector_cluster"].set_string_value(kZipkinBackend);
+      (*tracer_config_fields)["collector_endpoint"].set_string_value("/api/v1/spans");
+    };
+  }
+
+  ConfigHelper::HttpModifierFunction addTracingRate() {
+    return [](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm) {
+      auto* tracing = hcm.mutable_tracing();
+      tracing->set_operation_name(
+        envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager_Tracing_OperationName::HttpConnectionManager_Tracing_OperationName_EGRESS);
+      tracing->mutable_client_sampling()->set_value(100.0);
+      tracing->mutable_random_sampling()->set_value(100.0);
+      tracing->mutable_overall_sampling()->set_value(100.0);
     };
   }
 
@@ -329,6 +361,10 @@ class IstioHttpIntegrationTest : public HttpProtocolIntegrationTest {
   FakeUpstream* policy_upstream_{};
   FakeHttpConnectionPtr policy_connection_{};
   FakeStreamPtr policy_request_{};
+
+  FakeUpstream* zipkin_upstream_{};
+  FakeHttpConnectionPtr zipkin_connection_{};
+  FakeStreamPtr zipkin_request_{};
 };
 
 INSTANTIATE_TEST_CASE_P(
@@ -433,6 +469,39 @@ TEST_P(IstioHttpIntegrationTest, GoodJwt) {
 
   EXPECT_TRUE(response->complete());
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+}
+
+TEST_P(IstioHttpIntegrationTest, TracingHeader) {
+  codec_client_ =
+      makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  auto response =
+      codec_client_->makeHeaderOnlyRequest(HeadersWithToken(kGoodToken));
+
+  ::istio::mixer::v1::CheckRequest check_request;
+  waitForPolicyRequest(&check_request);
+  sendPolicyResponse();
+
+  waitForNextUpstreamRequest(0);
+  // Send backend response.
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}},
+                                   true);
+  response->waitForEndStream();
+
+  ::istio::mixer::v1::ReportRequest report_request;
+  waitForTelemetryRequest(&report_request);
+  sendTelemetryResponse();
+
+  response->waitForEndStream();
+
+  EXPECT_TRUE(response->complete());
+  Http::TestHeaderMapImpl upstream_headers(upstream_request_->headers());
+  // Trace headers should be added into upstream request
+  EXPECT_TRUE(upstream_headers.has(Envoy::Utils::kTraceID));
+  EXPECT_TRUE(upstream_headers.has(Envoy::Utils::kSpanID));
+  EXPECT_TRUE(upstream_headers.has(Envoy::Utils::kSampled));
+
+  // trace id should be included in default words of report request
+  EXPECT_THAT(report_request.default_words(), ::testing::AllOf(Contains(upstream_headers.get_(Envoy::Utils::kSpanID))));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/13391

Even though tracing happens before all filters inside envoy (https://github.com/envoyproxy/envoy/blob/master/source/common/http/conn_manager_impl.cc#L735), the tracing header injection actually happens at envoy.router filter (https://github.com/envoyproxy/envoy/blob/master/source/common/router/router.cc#L1218).

The current behavior of mixer filter is that it extracts request headers once at `decodeHeaders` callback during check time. However request header is not yet ready by that time. This PR extracts b3 tracing headers at report time and add them into request.header attribute.