### PR TITLE
allow batch report to be tuned by either max_entries or max_time

### DIFF
--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -52,13 +52,13 @@ struct CheckOptions {
   uint32_t max_retry_ms{1000};
 };
 
-// Default to batch up to 100 reports or 1000 milliseconds (1 second).
 const int DEFAULT_BATCH_REPORT_MAX_ENTRIES = 100;
 const int DEFAULT_BATCH_REPORT_MAX_TIME_MS = 1000;
 
 // Options controlling report batch.
 struct ReportOptions {
   // Default constructor.
+  // Default to batch up to 100 reports or 1000 milliseconds (1 second).
   ReportOptions()
       : max_batch_entries(DEFAULT_BATCH_REPORT_MAX_ENTRIES),
         max_batch_time_ms(DEFAULT_BATCH_REPORT_MAX_TIME_MS) {}

--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -59,8 +59,8 @@ struct CheckOptions {
 struct ReportOptions {
   // Default constructor.
   // Default to batch up to 100 reports or 1000 milliseconds (1 second).
-  ReportOptions() 
-      : max_batch_entries(DEFAULT_BATCH_REPORT_MAX_ENTRIES), 
+  ReportOptions()
+      : max_batch_entries(DEFAULT_BATCH_REPORT_MAX_ENTRIES),
         max_batch_time_ms(DEFAULT_BATCH_REPORT_MAX_TIME_MS) {}
 
   // Constructor.

--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -23,9 +23,6 @@
 namespace istio {
 namespace mixerclient {
 
-const int DEFAULT_BATCH_REPORT_MAX_ENTRIES = 100;
-const int DEFAULT_BATCH_REPORT_MAX_TIME_MS = 1000;
-
 // Options controlling check behavior.
 struct CheckOptions {
   // Default constructor.
@@ -55,10 +52,13 @@ struct CheckOptions {
   uint32_t max_retry_ms{1000};
 };
 
+// Default to batch up to 100 reports or 1000 milliseconds (1 second).
+const int DEFAULT_BATCH_REPORT_MAX_ENTRIES = 100;
+const int DEFAULT_BATCH_REPORT_MAX_TIME_MS = 1000;
+
 // Options controlling report batch.
 struct ReportOptions {
   // Default constructor.
-  // Default to batch up to 100 reports or 1000 milliseconds (1 second).
   ReportOptions()
       : max_batch_entries(DEFAULT_BATCH_REPORT_MAX_ENTRIES),
         max_batch_time_ms(DEFAULT_BATCH_REPORT_MAX_TIME_MS) {}

--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -23,8 +23,8 @@
 namespace istio {
 namespace mixerclient {
 
-const int DEFAULT_BATCH_REPORT_MAX_ENTRIES=100;
-const int DEFAULT_BATCH_REPORT_MAX_TIME_MS=1000;
+const int DEFAULT_BATCH_REPORT_MAX_ENTRIES = 100;
+const int DEFAULT_BATCH_REPORT_MAX_TIME_MS = 1000;
 
 // Options controlling check behavior.
 struct CheckOptions {

--- a/include/istio/mixerclient/options.h
+++ b/include/istio/mixerclient/options.h
@@ -23,6 +23,9 @@
 namespace istio {
 namespace mixerclient {
 
+const int DEFAULT_BATCH_REPORT_MAX_ENTRIES=100;
+const int DEFAULT_BATCH_REPORT_MAX_TIME_MS=1000;
+
 // Options controlling check behavior.
 struct CheckOptions {
   // Default constructor.
@@ -56,7 +59,9 @@ struct CheckOptions {
 struct ReportOptions {
   // Default constructor.
   // Default to batch up to 100 reports or 1000 milliseconds (1 second).
-  ReportOptions() : max_batch_entries(100), max_batch_time_ms(1000) {}
+  ReportOptions() 
+      : max_batch_entries(DEFAULT_BATCH_REPORT_MAX_ENTRIES), 
+        max_batch_time_ms(DEFAULT_BATCH_REPORT_MAX_TIME_MS) {}
 
   // Constructor.
   ReportOptions(int max_batch_entries, int max_batch_time_ms)

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -95,15 +95,15 @@ ReportOptions GetReportOptions(const TransportConfig& config) {
   }
 
   // When batch reporting is enabled, if report_batch_max_entries or
-  // report_batch_max_time is set to a non-positive number, set them
-  // to their default value in ReportOptions' constructor
+  // report_batch_max_time is set to 0 (default if not specified), set
+  // them to their default value defined in the ReportOptions constructor
   uint32_t max_entries = config.report_batch_max_entries();
   uint32_t max_time_ms = DurationToMsec(config.report_batch_max_time());
 
-  if (max_entries <= 0)
+  if (max_entries == 0)
     max_entries = ::istio::mixerclient::DEFAULT_BATCH_REPORT_MAX_ENTRIES;
 
-  if (max_time_ms <= 0)
+  if (max_time_ms == 0)
     max_time_ms = ::istio::mixerclient::DEFAULT_BATCH_REPORT_MAX_TIME_MS;
 
   return ReportOptions(max_entries, max_time_ms);

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -93,7 +93,20 @@ ReportOptions GetReportOptions(const TransportConfig& config) {
   if (config.disable_report_batch()) {
     return ReportOptions(0, 1000);
   }
-  return ReportOptions();
+
+  // When batch reporting is enabled, if report_batch_max_entries or
+  // report_batch_max_time is set to a non-positive number, set them
+  // to their default value in ReportOptions' constructor
+  uint32_t max_entries = config.report_batch_max_entries();
+  uint32_t max_time_ms = DurationToMsec(config.report_batch_max_time());
+
+  if (max_entries <= 0)
+    max_entries = ::istio::mixerclient::DEFAULT_BATCH_REPORT_MAX_ENTRIES;
+
+  if (max_time_ms <= 0)
+    max_time_ms = ::istio::mixerclient::DEFAULT_BATCH_REPORT_MAX_TIME_MS;
+
+  return ReportOptions(max_entries, max_time_ms);
 }
 
 }  // namespace

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -100,11 +100,13 @@ ReportOptions GetReportOptions(const TransportConfig& config) {
   uint32_t max_entries = config.report_batch_max_entries();
   uint32_t max_time_ms = DurationToMsec(config.report_batch_max_time());
 
-  if (max_entries == 0)
+  if (max_entries == 0) {
     max_entries = ::istio::mixerclient::DEFAULT_BATCH_REPORT_MAX_ENTRIES;
+  }
 
-  if (max_time_ms == 0)
+  if (max_time_ms == 0) {
     max_time_ms = ::istio::mixerclient::DEFAULT_BATCH_REPORT_MAX_TIME_MS;
+  }
 
   return ReportOptions(max_entries, max_time_ms);
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows mixer filter's batch reporting capability to be parameterized, e.g., by Pilot. 

**Special notes for your reviewer**:

- Depends on https://github.com/istio/api/pull/914 (merged)
- Depends on https://github.com/istio/proxy/pull/2217 (merged)