### PR TITLE
Remove strip for release build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,12 +60,13 @@ test --test_env=HEAPCHECK=normal --test_env=PPROF_PATH
 # enable path normalization by default. See https://github.com/envoyproxy/envoy/pull/6519
 test --define path_normalization_by_default=true
 
-# Release builds without debug symbols.
+# Release builds with debug symbols
 build:release -c opt
-build:release --strip=always
+build:release --copt -g
 
 # Release builds with debug symbols
 build:release-symbol -c opt
+build:release-symbol --copt -g
 
 # Add compile option for all C++ files
 build --cxxopt -Wnon-virtual-dtor


### PR DESCRIPTION
**What this PR does / why we need it**: Improve ability to debug Envoy in prod and compile release Envoy with symbols
