### PR TITLE
Update Envoy SHA to latest with option to select WASM runtimes.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,11 +35,11 @@ bind(
 # When updating envoy sha manually please update the sha in istio.deps file also
 #
 # Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/COMMIT.tar.gz && sha256sum COMMIT.tar.gz`
-# envoy-wasm commit date  05/30/2019
+# envoy-wasm commit date  06/12/2019
 # bazel version: 0.25.0
-ENVOY_SHA = "81b3ee8bf4ff343e376ed290c07a95b708af707c"
+ENVOY_SHA = "72ac3212de661d2ef7c9210e78fedf76d5cbe9f0"
 
-ENVOY_SHA256 = "2888f5be49aa4e9681a3497e5c617d655a04ed4e3707ff10b78eec826f4e8649"
+ENVOY_SHA256 = "cdf7e17398f8767b9fe63538129ac8b5231e7a017cd478a4642205575522cd47"
 
 LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
 

--- a/istio.deps
+++ b/istio.deps
@@ -9,8 +9,8 @@
 	{
 		"_comment": "",
 		"name": "ENVOY_SHA",
-		"repoName": "envoyproxy/envoy",
+		"repoName": "envoyproxy/envoy-wasm",
 		"file": "WORKSPACE",
-		"lastStableSHA": "829b905ca0fdc85233c3969247e53a62a52ac627"
+		"lastStableSHA": "72ac3212de661d2ef7c9210e78fedf76d5cbe9f0"
 	}
 ]


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>