### PR TITLE
add insufficient include

### DIFF
--- a/src/istio/utils/logger.cc
+++ b/src/istio/utils/logger.cc
@@ -15,6 +15,7 @@
 
 #include "src/istio/utils/logger.h"
 #include <stdarg.h>
+#include <stdio.h>
 
 namespace istio {
 namespace utils {


### PR DESCRIPTION
Signed-off-by: Lizan Zhou <lizan@tetrate.io>

**What this PR does / why we need it**:
`vsnprintf` and `stderr` need `stdio.h`.


**Release note**:
```release-note
None
```
