### PR TITLE
Always use Bazel-0.22 for macOS on CircleCI (release-1.1).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,16 @@ jobs:
       - BAZEL_STARTUP_ARGS: "--output_base /Users/distiller/.cache/bazel"
       - BAZEL_BUILD_ARGS: "--local_resources=12288,5,1"
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all --local_resources=12288,5,1 --local_test_jobs=8"
+      - BAZEL_VERSION: "0.22.0"
       - CC: clang
       - CXX: clang++
     steps:
       - run: sudo ntpdate -vu time.apple.com
-      - run: brew install bazel cmake coreutils go libtool ninja wget
+      - run: brew install cmake coreutils go libtool ninja wget
       - checkout
+      - run: wget https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh
+      - run: chmod +x bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh
+      - run: sudo ./bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh
       - restore_cache:
           keys:
             - macos_fastbuild-bazel-cache-{{ checksum "WORKSPACE" }}


### PR DESCRIPTION
Backported from #2252.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>