### PR TITLE
Always use Bazel-0.25 for macOS on CircleCI (release-1.2).

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -14,13 +14,13 @@ RUN sudo sh -c 'echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 
 
 RUN sudo apt-get update && \
     sudo apt-get -y install \
-    wget software-properties-common make cmake python python-pip pkg-config \
+    wget software-properties-common make python python-pip pkg-config \
     zlib1g-dev bash-completion bc libtool automake zip time g++-6 gcc-6 \
     clang-7 clang-format-7 clang-tidy-7 lld-7 libc++-7-dev libc++abi-7-dev \
     rsync ninja-build
 
 # ~100M, depends on g++, zlib1g-dev, bash-completions
-RUN curl -Lo /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel_0.22.0-linux-x86_64.deb && \
+RUN curl -Lo /tmp/bazel.deb https://github.com/bazelbuild/bazel/releases/download/0.25.0/bazel_0.25.0-linux-x86_64.deb && \
     sudo dpkg -i /tmp/bazel.deb && rm /tmp/bazel.deb
 
 
@@ -31,6 +31,13 @@ RUN cd /tmp && \
     sudo tar -C /usr/local -xzf go1.11.5.linux-amd64.tar.gz && \
     sudo chown -R circleci /usr/local/go && \
     sudo ln -s /usr/local/go/bin/go /usr/local/bin
+
+# instead of "apt-get -y install cmake", pin cmake version to 3.8.0
+RUN cd /tmp && \
+    wget https://github.com/Kitware/CMake/releases/download/v3.8.0/cmake-3.8.0-Linux-x86_64.tar.gz && \
+    sudo tar -C /usr/local/ -xzf cmake-3.8.0-Linux-x86_64.tar.gz && \
+    sudo chown -R circleci /usr/local/cmake-3.8.0-Linux-x86_64 && \
+    sudo ln -s /usr/local/cmake-3.8.0-Linux-x86_64/bin/cmake /usr/local/bin
 
 RUN bazel version
 

--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -2,7 +2,7 @@ HUB ?=
 PROJECT ?= istio
 
 # Using same naming convention as istio/istio
-VERSION ?= go1.11-bazel0.22-clang7
+VERSION ?= go1.11-bazel0.25-clang7-cmake3.8.0
 IMG ?= ci
 
 # Build a local image, can be used for testing with circleci command line.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: istio/ci:go1.11-bazel0.22-clang7
+      - image: istio/ci:go1.11-bazel0.25-clang7-cmake3.8.0
     environment:
       - BAZEL_BUILD_ARGS: "--local_resources=12288,5,1"
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all --local_resources=12288,5,1 --local_test_jobs=8"
@@ -31,7 +31,7 @@ jobs:
           destination: /proxy/bin
   linux_asan:
     docker:
-      - image: istio/ci:go1.11-bazel0.22-clang7
+      - image: istio/ci:go1.11-bazel0.25-clang7-cmake3.8.0
     environment:
       - BAZEL_BUILD_ARGS: "--local_resources=12288,5,1"
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all --local_resources=12288,5,1 --local_test_jobs=8"
@@ -51,7 +51,7 @@ jobs:
             - /home/circleci/.cache/bazel
   linux_tsan:
     docker:
-      - image: istio/ci:go1.11-bazel0.22-clang7
+      - image: istio/ci:go1.11-bazel0.25-clang7-cmake3.8.0
     environment:
       - BAZEL_BUILD_ARGS: "--local_resources=12288,5,1"
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all --local_resources=12288,5,1 --local_test_jobs=8"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,16 @@ jobs:
       - BAZEL_STARTUP_ARGS: "--output_base /Users/distiller/.cache/bazel"
       - BAZEL_BUILD_ARGS: "--local_resources=12288,5,1"
       - BAZEL_TEST_ARGS: "--test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=all --local_resources=12288,5,1 --local_test_jobs=8"
+      - BAZEL_VERSION: "0.25.0"
       - CC: clang
       - CXX: clang++
     steps:
       - run: sudo ntpdate -vu time.apple.com
-      - run: brew install bazel cmake coreutils go libtool ninja wget
+      - run: brew install cmake coreutils go libtool ninja wget
       - checkout
+      - run: wget https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh
+      - run: chmod +x bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh
+      - run: sudo ./bazel-$BAZEL_VERSION-installer-darwin-x86_64.sh
       - restore_cache:
           keys:
             - macos_fastbuild-bazel-cache-{{ checksum "WORKSPACE" }}


### PR DESCRIPTION
Backported from #2252.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>