### PR TITLE
[WIP] Add support for RS384 and RS512 algorithms in JWT filter

### DIFF
--- a/src/envoy/http/jwt_auth/jwt.cc
+++ b/src/envoy/http/jwt_auth/jwt.cc
@@ -273,7 +273,8 @@ Jwt::Jwt(const std::string &jwt) {
     return;
   }
 
-  if (alg_ != "RS256" && alg_ != "ES256") {
+  if (alg_ != "RS256" && alg_ != "ES256" &&
+      alg_ != "RS384" && alg_ != "RS512") {
     UpdateStatus(Status::ALG_NOT_IMPLEMENTED);
     return;
   }
@@ -409,14 +410,23 @@ bool Verifier::Verify(const Jwt &jwt, const Pubkeys &pubkeys) {
         VerifySignatureEC(pubkey->ec_key_.get(), jwt.signature_, signed_data)) {
       // Verification succeeded.
       return true;
-    } else if ((pubkey->pem_format_ || pubkey->kty_ == "RSA") &&
-               VerifySignatureRSA(pubkey->evp_pkey_.get(), EVP_sha256(),
-                                  jwt.signature_, signed_data)) {
-      // Verification succeeded.
-      return true;
+    } else if (pubkey->pem_format_ || pubkey->kty_ == "RSA") {
+      const EVP_MD* md;
+      if (jwt.alg_ == "RS384") {
+        md = EVP_sha384();
+      } else if (jwt.alg_ == "RS512") {
+        md = EVP_sha512();
+      } else {
+        // default to SHA256
+        md = EVP_sha256();
+      }
+      if (VerifySignatureRSA(pubkey->evp_pkey_.get(), md,
+                             jwt.signature_, signed_data)) {
+        // Verification succeeded.
+        return true;
+      }
     }
   }
-
   // Verification failed.
   if (kid_alg_matched) {
     UpdateStatus(Status::JWT_INVALID_SIGNATURE);

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -86,6 +86,30 @@ const std::string kPublicKey =
     "  \"e\": \"AQAB\","
     "  \"alg\": \"RS256\","
     "  \"kid\": \"b3319a147514df7ee5e4bcdee51350cc890cc89e\""
+    "},"
+    "{"
+    "  \"kty\": \"RSA\","
+    "  \"n\": "
+    "\"up97uqrF9MWOPaPkwSaBeuAPLOr9FKcaWGdVEGzQ4f3Zq5WKVZowx9TCBxmImNJ1q"
+    "mUi13pB8otwM_l5lfY1AFBMxVbQCUXntLovhDaiSvYp4wGDjFzQiYA-pUq8h6MUZBnhleYrk"
+    "U7XlCBwNVyN8qNMkpLA7KFZYz-486GnV2NIJJx_4BGa3HdKwQGxi2tjuQsQvao5W4xmSVaaE"
+    "WopBwMy2QmlhSFQuPUpTaywTqUcUq_6SfAHhZ4IDa_FxEd2c2z8gFGtfst9cY3lRYf-c_Zdb"
+    "oY3mqN9Su3-j3z5r2SHWlhB_LNAjyWlBGsvbGPlTqDziYQwZN4aGsqVKQb9Vw\","
+    "  \"e\": \"AQAB\","
+    "  \"alg\": \"RS384\","
+    "  \"kid\": \"98e3f54edc2042ed879047e9e077bb2d9824f952\""
+    "},"
+    "{"
+    "  \"kty\": \"RSA\","
+    "  \"n\": "
+    "\"up97uqrF9MWOPaPkwSaBeuAPLOr9FKcaWGdVEGzQ4f3Zq5WKVZowx9TCBxmImNJ1q"
+    "mUi13pB8otwM_l5lfY1AFBMxVbQCUXntLovhDaiSvYp4wGDjFzQiYA-pUq8h6MUZBnhleYrk"
+    "U7XlCBwNVyN8qNMkpLA7KFZYz-486GnV2NIJJx_4BGa3HdKwQGxi2tjuQsQvao5W4xmSVaaE"
+    "WopBwMy2QmlhSFQuPUpTaywTqUcUq_6SfAHhZ4IDa_FxEd2c2z8gFGtfst9cY3lRYf-c_Zdb"
+    "oY3mqN9Su3-j3z5r2SHWlhB_LNAjyWlBGsvbGPlTqDziYQwZN4aGsqVKQb9Vw\","
+    "  \"e\": \"AQAB\","
+    "  \"alg\": \"RS512\","
+    "  \"kid\": \"ba69c7f5dd954a5e89ba1a1be72c4b32a5bb6880\""
     "}]}";
 
 // Keep this same as issuer field in the config below.
@@ -205,7 +229,7 @@ const std::string kInvalidAudToken =
     "WFIPUGmPy3aM0TiF2oFOuuMxdPR3HNdSG7EWWRwoXv7n__jA";
 
 // Payload:
-// {"iss":"https://example.com","sub":"test@example.com","aud":"example_service","exp":2001001001}
+// {"iss":"https://example.com","sub":"test@example.com","exp":2001001001,"aud":"example_service"}
 const std::string kGoodToken =
     "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUu"
     "Y29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIsImV4cCI6MjAwMTAwMTAwMSwiY"
@@ -221,6 +245,32 @@ const std::string kGoodTokenPayload =
     "{\"iss\":\"https://"
     "example.com\",\"sub\":\"test@example.com\",\"exp\":2001001001,"
     "\"aud\":\"example_service\"}";
+
+// Payload:
+// {"iss":"https://example.com","sub":"test@example.com","exp":2001001001,"aud":"example_service"}
+const std::string kGoodTokenRs384 =
+    "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlL"
+    "mNvbSIsImV4cCI6MjAwMTAwMTAwMSwiYXVkIjoiZXhhbXBsZV9zZXJ2aWNlIn0.hm"
+    "qJlnvohmHI3QzO_f79Jl6Af2JNlRYILtdY4bSnhCAHBUh3dVaAlkb7GZIXsGjzMRS"
+    "dQsIp2M9lhykBy9Bz-Mt5jmcfVHLQ80kdFa9sqT427Zt1pv4cybvUp32ZHiPznlPi"
+    "rZiRibnhn4kkX4IQetbc8ch4SW-YXPxh0Biv9rxX4Kwl8KaSVxtVliCnd6AHUorJS"
+    "varIXxb0uvgum6zhtNdqpjXiNMx4EX-tRE_IzdGNcF2IVIFew3vQC_9j5iQtp3j-p"
+    "BxBW4i2S0CZXkkT70QnOJRj7viNFGn8NfZrxxym_mkcQrmYhsq2BEJskIeECawqSH"
+    "hvETurikInzh3Cg";
+
+// Payload:
+// {"iss":"https://example.com","sub":"test@example.com","exp":2001001001,"aud":"example_service"}
+const std::string kGoodTokenRs512 =
+    "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlL"
+    "mNvbSIsImV4cCI6MjAwMTAwMTAwMSwiYXVkIjoiZXhhbXBsZV9zZXJ2aWNlIn0.TP"
+    "4KzwU-V26xeGpbQ-kR0DZfFytSHFuM_anxHmoSFOy1YtU7w1sDQYS1V-dZ4R6sHvR"
+    "EbtGPzdU-Z75DXxnqyf9lY_8QQqO-ys8whInOMxJZPAV-VtX8QZWGcITGULGPCnZ3"
+    "bSGHiOKXkXFpiymcaia9wXEdl4ZIIX9KFANa-AkGExzBGR-8Xez5GoVIS6Ii8xdzH"
+    "PFplRgjmvYOt2rM4au9pP-eio04GaZVHCk0FbzXB4edGmKl359CWiBYZ2A74eWY8v"
+    "OZlE6wDqzbf4-xTHBP-d-dveWN1QSAka0mBxDgvIfTz2lxxH8cuo_O99nj4QYIR5B"
+    "Io1JSe02mS2wmnw";
 
 // Payload:
 // {"iss":"https://example.com","sub":"test@example.com","aud":"http://example_service/","exp":2001001001}
@@ -408,6 +458,40 @@ TEST_F(JwtAuthenticatorTest, TestOkJWTPubkeyNoKid) {
   EXPECT_FALSE(headers.Authorization());
 
   EXPECT_EQ(mock_pubkey.called_count(), 1);
+}
+
+// Verifies that a JWT with alg=RS384 is verified successfully
+TEST_F(JwtAuthenticatorTest, TestOKJWTAlgRs384) {
+  MockUpstream mock_pubkey(mock_cm_, kPublicKey);
+
+  auto headers = TestHeaderMapImpl{{"Authorization", "Bearer " + kGoodTokenRs384}};
+
+  MockJwtAuthenticatorCallbacks mock_cb;
+  EXPECT_CALL(mock_cb, onDone(_)).WillOnce(Invoke([](const Status &status) {
+    ASSERT_EQ(status, Status::OK);
+  }));
+  EXPECT_CALL(mock_cb, savePayload(kJwtIssuer, kGoodTokenPayload));
+  auth_->Verify(headers, &mock_cb);
+
+  // Verify the token is removed.
+  EXPECT_FALSE(headers.Authorization());
+}
+
+// Verifies that a JWT with alg=RS512 is verified successfully
+TEST_F(JwtAuthenticatorTest, TestOKJWTAlgRs512) {
+  MockUpstream mock_pubkey(mock_cm_, kPublicKey);
+
+  auto headers = TestHeaderMapImpl{{"Authorization", "Bearer " + kGoodTokenRs512}};
+
+  MockJwtAuthenticatorCallbacks mock_cb;
+  EXPECT_CALL(mock_cb, onDone(_)).WillOnce(Invoke([](const Status &status) {
+    ASSERT_EQ(status, Status::OK);
+  }));
+  EXPECT_CALL(mock_cb, savePayload(kJwtIssuer, kGoodTokenPayload));
+  auth_->Verify(headers, &mock_cb);
+
+  // Verify the token is removed.
+  EXPECT_FALSE(headers.Authorization());
 }
 
 // Verifies that a JWT with aud: http://example_service/ is matched to

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -41,6 +41,34 @@ class DatasetPem {
       "N09hdvlCtAF87Fu1qqfwEQ93A-J7m08bZJoyIPcNmTcYGHwfMR4-lcI5cC_93C_"
       "5BGE1FHPLOHpNghLuM6-rhOtgwZc9ywupn_bBK3QzuAoDnYwpqQhgQL_CdUD_bSHcmWFkw";
 
+  // JWT with
+  // Header:  {"alg":"RS384","typ":"JWT"}
+  // Payload:
+  // {"iss":"https://example.com","sub":"test@example.com","exp":1501281058}
+  const std::string kJwtRs384 =
+      "eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9."
+      "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
+      "ImV4cCI6MTUwMTI4MTA1OH0.NvinWcCVmBAmbK5FnAPt8gMBSWOU9kjTEIxcDqJBzjB6nKGj"
+      "sUYF05RC69F4POrJKLl3ak9LQUFPAwn732xEavbQunl-MreZCtRKrTX2xdwod0_u3gvSakcc"
+      "N9kEkbXMqJ5DhFUH0Viv7oVQtbRzwB7hr0ip-Yi8RAbrKfk8qDX0bT2TOlqzbLDnIp3M5btX"
+      "vO1GfOirIiz0YDfzEmSbkhZAnz4D062LWwyfIfM1ZhFusSyYBaNjib1vBfjIGsiYW-ot9dRY"
+      "X0YZP1YF-XxalyUGalD6pn-5nOkd86KL8ch0OkxBpHc1XqBrrsw0Pjax6Sv-nYYUb9qN6p69"
+      "q9YstA";
+
+  // JWT with
+  // Header:  {"alg":"RS512","typ":"JWT"}
+  // Payload:
+  // {"iss":"https://example.com","sub":"test@example.com","exp":1501281058}
+  const std::string kJwtRs512 =
+      "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9."
+      "eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoidGVzdEBleGFtcGxlLmNvbSIs"
+      "ImV4cCI6MTUwMTI4MTA1OH0.BaBGWBS5ZhOX7o0LlAYqnnS-rME0E_eAjnCzPolSY5oh-Mic"
+      "WFN3B1AW-iCeAW3fHf7GhlbshKoybLaj7Cj87m9T-w015WGyIBIwWKQVjfT62RJ1hrKzoyM5"
+      "flVbwMPG70vqV9xfOTpZ4iZ9QomAut4yMDSBTINeeQLRVckYUN-IQVLU-bMnnvabsIQeNxhs"
+      "sG6S61cOD234mGdgkxoaZhHDprvEtAaYAuuKsIlaNIbp8r5hYFv09SMjAELlneObiMI3m5IG"
+      "yx3cF3odgb8PPLRBEOxD6HwJzmvbYmkjmgLuE5vb5lLEacyn2I1ko7e-Hlzvp_ezST0wknz5"
+      "wadrCQ";
+
   // {"iss":"https://example.com","sub":"test@example.com","exp":1501281058,
   // aud: [aud1, aud2] }
   // signature part is invalid.
@@ -477,6 +505,16 @@ class JwtTestPem : public JwtTest {
 TEST_F(JwtTestPem, OK) {
   auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
   DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, payload);
+}
+
+TEST_F(JwtTestPem, OKWithAlgRs384) {
+  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
+  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, payload);
+}
+
+TEST_F(JwtTestPem, OKWithAlgRs512) {
+  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
+  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, payload);
 }
 
 TEST_F(JwtTestPem, MultiAudiences) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for RS384 and RS512 alg claims in the JWT filter

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #15380

**Special notes for your reviewer**:
The corresponding PR to `jwt_verify_lib` can be found here: https://github.com/google/jwt_verify_lib/pull/24

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
