### PR TITLE
Unfold Set-Cookie header on direct response from Mixer

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -147,16 +147,18 @@ void Filter::UpdateHeaders(
   }
 }
 
-void Filter::UnfoldSetCookieHeader(HeaderMap& headers, const std::string value) {
+void Filter::UnfoldSetCookieHeader(HeaderMap& headers,
+                                   const std::string value) {
   // Folded cookie syntax can be complicated. See, for example,
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Syntax.
   // Unfortunately, the http2 library does not expose/support cookie parsing.
   // Here we handle a much simpler syntax - a comma separated list of cookies.
   // The simplification comes at the cost of preventing the use of 'Expires'
-  // cookie attribute. A more robust parser would require 100-150 LOC and could be
-  // modeled after the following JS or Java code:
+  // cookie attribute. A more robust parser would require 100-150 LOC and could
+  // be modeled after the following JS or Java code:
   // https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
-  // or https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+  // or
+  // https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
   std::istringstream iss(value);
   std::vector<std::string> cookies;
   std::string cookie;
@@ -168,7 +170,7 @@ void Filter::UnfoldSetCookieHeader(HeaderMap& headers, const std::string value) 
     for (std::string c : cookies) {
       headers.addReference(kSetCookieHeader, c);
     }
-  } else { // failure, just copy the original header value
+  } else {  // failure, just copy the original header value
     headers.addCopy(kSetCookieHeader, value);
   }
 }

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -148,7 +148,29 @@ void Filter::UpdateHeaders(
 }
 
 void Filter::UnfoldSetCookieHeader(HeaderMap& headers, const std::string value) {
-  headers.addCopy(kSetCookieHeader, value);
+  // Folded cookie syntax can be complicated. See, for example,
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Syntax.
+  // Unfortunately, the http2 library does not expose/support cookie parsing.
+  // Here we handle a much simpler syntax - a comma separated list of cookies.
+  // The simplification comes at the cost of preventing the use of 'Expires'
+  // cookie attribute. A more robust parser would require 100-150 LOC and could be
+  // modeled after the following JS or Java code:
+  // https://github.com/nfriedly/set-cookie-parser/blob/master/lib/set-cookie.js
+  // or https://github.com/google/j2objc/commit/16820fdbc8f76ca0c33472810ce0cb03d20efe25
+  std::istringstream iss(value);
+  std::vector<std::string> cookies;
+  std::string cookie;
+
+  while (std::getline(iss, cookie, ',')) {
+    cookies.push_back(cookie);
+  }
+  if (iss.eof()) {
+    for (std::string c : cookies) {
+      headers.addReference(kSetCookieHeader, c);
+    }
+  } else { // failure, just copy the original header value
+    headers.addCopy(kSetCookieHeader, value);
+  }
 }
 
 FilterHeadersStatus Filter::encodeHeaders(HeaderMap& headers, bool) {

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -85,6 +85,9 @@ class Filter : public StreamFilter,
                      const ::google::protobuf::RepeatedPtrField<
                          ::istio::mixer::v1::HeaderOperation>& operations);
 
+  // Unfold Set-Cookie into multiple header lines, if needed
+  void UnfoldSetCookieHeader(HeaderMap& headers, const std::string value);
+
   // The control object.
   Control& control_;
   // The request handler.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows setting multiple `Set-Cookie` headers from a mixer response.
Per the RFC, Set-Cookie headers should be sent on separate lines. However, the mixer response encodes headers as a map<key,value> which prevents multiple headers from being specified.
This PR's treats the returned value as a comma separated list. While incomplete in handling all possible cookie variants and attributes (e.g., `Expires` attribute may contain a comma in the date), it handles the common case of session based cookies and allows future extension based on customer feedback.

Full discussion is on [#14240](https://github.com/istio/istio/issues/14240)

**Which issue this PR fixes**:
fixes #14240

**Special notes for your reviewer**:
`Set-Cookie` is not an Envoy inline header so will not get folded by the proxy if multiple headers are added. The current "cookie cutter" is simple and works for a subset of the cookies. This is noted in the code documentation.

**Release note**:
```release-note
FIX: mixer direct response may now include multiple Set-Cookie values, by specifying a comma separated list of cookies to send. The cookies must not include other commas (e.g., in Expire attribute) 
```
