### PR TITLE
Fix mx filter broken in the last commit

### DIFF
--- a/src/envoy/http/metadata_exchange/config.h
+++ b/src/envoy/http/metadata_exchange/config.h
@@ -22,8 +22,6 @@ namespace Extensions {
 namespace Wasm {
 namespace MetadataExchange {
 
-using Common::Wasm::Null::Plugin::proxy_setMetadataStruct;
-
 constexpr absl::string_view ExchangeMetadataHeader = "x-envoy-peer-metadata";
 
 constexpr absl::string_view ExchangeMetadataHeaderId =
@@ -50,6 +48,7 @@ constexpr absl::string_view UpstreamMetadataIdKey =
     "envoy.wasm.metadata_exchange.upstream_id";
 
 using StringView = absl::string_view;
+using Common::Wasm::MetadataType;
 using Common::Wasm::Null::NullVmPluginRootRegistry;
 using Common::Wasm::Null::Plugin::Context;
 using Common::Wasm::Null::Plugin::ContextFactory;
@@ -70,8 +69,8 @@ class PluginRootContext : public RootContext {
   void onStart() override{};
   void onTick() override{};
 
-  std::string metadata_value() { return metadata_value_; };
-  std::string node_id() { return node_id_; };
+  StringView metadataValue() { return metadata_value_; };
+  StringView nodeId() { return node_id_; };
 
  private:
   std::string metadata_value_;
@@ -91,16 +90,23 @@ class PluginContext : public Context {
   inline PluginRootContext* rootContext() {
     return dynamic_cast<PluginRootContext*>(this->root());
   };
-  inline std::string metadata_value() {
-    return rootContext()->metadata_value();
+  inline StringView metadataValue() {
+    return rootContext()->metadataValue();
   };
-  inline std::string node_id() { return rootContext()->node_id(); }
+  inline StringView nodeId() { return rootContext()->nodeId(); }
 };
 
 // TODO(mjog) move this to proxy_wasm_impl.h
-inline void setMetadataStruct(Common::Wasm::MetadataType type, StringView key,
+inline void setMetadataStruct(MetadataType type, StringView key,
                               StringView value) {
-  proxy_setMetadataStruct(type, key.data(), key.size(), value.data(),
+  Common::Wasm::Null::Plugin::proxy_setMetadataStruct(type, key.data(), key.size(), value.data(),
+                          value.size());
+}
+
+// TODO(mjog) move this to proxy_wasm_impl.h
+inline void setMetadata(MetadataType type, StringView key,
+                              StringView value) {
+  Common::Wasm::Null::Plugin::proxy_setMetadata(type, key.data(), key.size(), value.data(),
                           value.size());
 }
 

--- a/src/envoy/http/metadata_exchange/config.h
+++ b/src/envoy/http/metadata_exchange/config.h
@@ -86,28 +86,21 @@ class PluginContext : public Context {
   Http::FilterHeadersStatus onRequestHeaders() override;
   Http::FilterHeadersStatus onResponseHeaders() override;
 
+  void onLog() override;
+
  private:
   inline PluginRootContext* rootContext() {
     return dynamic_cast<PluginRootContext*>(this->root());
   };
-  inline StringView metadataValue() {
-    return rootContext()->metadataValue();
-  };
+  inline StringView metadataValue() { return rootContext()->metadataValue(); };
   inline StringView nodeId() { return rootContext()->nodeId(); }
 };
 
 // TODO(mjog) move this to proxy_wasm_impl.h
 inline void setMetadataStruct(MetadataType type, StringView key,
                               StringView value) {
-  Common::Wasm::Null::Plugin::proxy_setMetadataStruct(type, key.data(), key.size(), value.data(),
-                          value.size());
-}
-
-// TODO(mjog) move this to proxy_wasm_impl.h
-inline void setMetadata(MetadataType type, StringView key,
-                              StringView value) {
-  Common::Wasm::Null::Plugin::proxy_setMetadata(type, key.data(), key.size(), value.data(),
-                          value.size());
+  Common::Wasm::Null::Plugin::proxy_setMetadataStruct(
+      type, key.data(), key.size(), value.data(), value.size());
 }
 
 NULL_PLUGIN_ROOT_REGISTRY;

--- a/src/envoy/http/metadata_exchange/config.h
+++ b/src/envoy/http/metadata_exchange/config.h
@@ -86,8 +86,6 @@ class PluginContext : public Context {
   Http::FilterHeadersStatus onRequestHeaders() override;
   Http::FilterHeadersStatus onResponseHeaders() override;
 
-  void onLog() override;
-
  private:
   inline PluginRootContext* rootContext() {
     return dynamic_cast<PluginRootContext*>(this->root());

--- a/src/envoy/http/metadata_exchange/testdata/client.yaml
+++ b/src/envoy/http/metadata_exchange/testdata/client.yaml
@@ -1,0 +1,62 @@
+node:
+  id: test-client-productpage
+  metadata:
+    "istio.io/metadata": {
+      namespace: default,
+      labels: { app: productpage },
+    }
+static_resources:
+  listeners:
+  - name: client
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8080
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route: 
+                  cluster: server
+          http_filters:
+          - name: envoy.wasm
+            config:
+              vm_config:
+                vm: "envoy.wasm.vm.null"
+                code:
+                  inline_string: "envoy.wasm.metadata_exchange"
+              configuration: "test"
+          - name: envoy.router
+            config: {}
+          access_log:
+          - name: envoy.file_access_log
+            config:
+              path: "/dev/stdout"
+              format: "client %RESPONSE_CODE% downstream_id:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.downstream_id)% downstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.downstream)% upstream_id:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.upstream_id)% upstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.upstream)%\n"
+  clusters:
+  - name: server
+    connect_timeout: 0.25s
+    type: static
+    lb_policy: round_robin
+    hosts:
+    - socket_address:
+        address: 127.0.0.1
+        port_value: 8081
+    http2_protocol_options: {}
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/src/envoy/http/metadata_exchange/testdata/server.yaml
+++ b/src/envoy/http/metadata_exchange/testdata/server.yaml
@@ -1,54 +1,17 @@
 node:
-  id: test
+  id: test-server-ratings
   metadata:
     "istio.io/metadata": {
       namespace: default,
-      labels: { app: productpage },
+      labels: { app: ratings },
     }
 static_resources:
   listeners:
-  - name: client
-    address:
-      socket_address:
-        address: 0.0.0.0
-        port_value: 8090
-    filter_chains:
-    - filters:
-      - name: envoy.http_connection_manager
-        config:
-          stat_prefix: ingress_http
-          codec_type: auto
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: local_service
-              domains:
-              - "*"
-              routes:
-              - match:
-                  prefix: "/"
-                route: 
-                  cluster: server
-          http_filters:
-          - name: envoy.wasm
-            config:
-              vm_config:
-                vm: "envoy.wasm.vm.null"
-                code:
-                  inline_string: "envoy.wasm.metadata_exchange"
-              configuration: "test"
-          - name: envoy.router
-            config: {}
-          access_log:
-          - name: envoy.file_access_log
-            config:
-              path: "/dev/stdout"
-              format: "client %RESPONSE_CODE% downstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.downstream:labels)% upstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.upstream:labels)%\n"
   - name: server
     address:
       socket_address:
         address: 0.0.0.0
-        port_value: 8091
+        port_value: 8081
     filter_chains:
     - filters:
       - name: envoy.http_connection_manager
@@ -80,7 +43,7 @@ static_resources:
           - name: envoy.file_access_log
             config:
               path: "/dev/stdout"
-              format: "server %RESPONSE_CODE% downstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.downstream:labels)% upstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.upstream:labels)%\n"
+              format: "server %RESPONSE_CODE% downstream_id:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.downstream_id)% downstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.downstream)% upstream_id:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.upstream_id)% upstream:%DYNAMIC_METADATA(envoy.wasm.metadata_exchange.upstream)%\n"
   - name: staticreply
     address:
       socket_address:
@@ -108,6 +71,12 @@ static_resources:
           http_filters:
           - name: envoy.router
             config: {}
+          access_log:
+          - name: envoy.file_access_log
+            config:
+              path: "/dev/stdout"
+              format: "origin %RESPONSE_CODE% downstream:%REQ(x-envoy-peer-metadata-id)% downstream:%REQ(x-envoy-peer-metadata)%\n"
+ 
   clusters:
   - name: web_service
     connect_timeout: 0.25s
@@ -117,18 +86,9 @@ static_resources:
     - socket_address:
         address: 127.0.0.1
         port_value: 8099
-  - name: server
-    connect_timeout: 0.25s
-    type: static
-    lb_policy: round_robin
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 8091
-    http2_protocol_options: {}
 admin:
   access_log_path: "/dev/null"
   address:
     socket_address:
       address: 0.0.0.0
-      port_value: 8001
+      port_value: 8002


### PR DESCRIPTION
1. Fix deterministic serialization by ensuring stream is destroyed before string is used.
2. Split testdata config in 2 parts, server.yaml and client.yaml to separate client and server.
3. Review comments from last review.