### PR TITLE
Fix missing GIT_SHA from post submit

### DIFF
--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -38,6 +38,7 @@ fi
 GOPATH=/go
 ROOT=/go/src
 rm -f "${HOME}/.bazelrc"
+GIT_SHA="$(git rev-parse --verify HEAD)"
 
 export BAZEL_BUILD_ARGS="--local_ram_resources=12288 --local_cpu_resources=8 --verbose_failures"
 


### PR DESCRIPTION
This fix *only* affects Post submit so should not need to be tested with *any pre submits*

Fixes `./prow/proxy-postsubmit.sh: line 46: GIT_SHA: unbound variable`