### PR TITLE
using sha instead of of git_sha

### DIFF
--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -44,4 +44,4 @@ export BAZEL_BUILD_ARGS="--local_ram_resources=12288 --local_cpu_resources=8 --v
 
 echo 'Create and push artifacts'
 scripts/release-binary.sh
-ARTIFACTS_DIR="gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs" make artifacts
+ARTIFACTS_DIR="gs://istio-artifacts/proxy/${SHA}/artifacts/debs" make artifacts


### PR DESCRIPTION
**What this PR does / why we need it**:
git_sha is not set with new prow
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
