### PR TITLE
Revert "using sha instraf of git_sha (#2338)"

### DIFF
--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -44,4 +44,4 @@ export BAZEL_BUILD_ARGS="--local_ram_resources=12288 --local_cpu_resources=8 --v
 
 echo 'Create and push artifacts'
 scripts/release-binary.sh
-ARTIFACTS_DIR="gs://istio-artifacts/proxy/${SHA}/artifacts/debs" make artifacts
+ARTIFACTS_DIR="gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs" make artifacts


### PR DESCRIPTION
This reverts commit 41943e54ea595930fdd7c2296067b58556e286f8.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>