### PR TITLE
Remove Envoy SHA from istio.deps

### DIFF
--- a/istio.deps
+++ b/istio.deps
@@ -5,12 +5,5 @@
 		"repoName": "api",
 		"file": "repositories.bzl",
 		"lastStableSHA": "36b42252042c0e8b229a0d66059af184c3105f9d"
-	},
-	{
-		"_comment": "",
-		"name": "ENVOY_SHA",
-		"repoName": "envoyproxy/envoy-wasm",
-		"file": "WORKSPACE",
-		"lastStableSHA": "915ed46b694a611f966bed501bcc177162c2df34"
 	}
 ]


### PR DESCRIPTION
WORKSPACE is used for Envoy SHA and istio.deps is no longer kept in sync.
