### PR TITLE
update metadata exchange for the new bootstrap format

### DIFF
--- a/src/envoy/http/metadata_exchange/config.cc
+++ b/src/envoy/http/metadata_exchange/config.cc
@@ -37,6 +37,8 @@ using Common::Wasm::Null::Plugin::replaceRequestHeader;
 using Common::Wasm::Null::Plugin::replaceResponseHeader;
 using Common::Wasm::Null::Plugin::setMetadataStringValue;
 
+namespace {
+
 bool serializeToStringDeterministic(const google::protobuf::Struct& metadata,
                                     std::string* metadata_bytes) {
   google::protobuf::io::StringOutputStream md(metadata_bytes);
@@ -44,37 +46,61 @@ bool serializeToStringDeterministic(const google::protobuf::Struct& metadata,
 
   mcs.SetSerializationDeterministic(true);
   if (!metadata.SerializeToCodedStream(&mcs)) {
-    logWarn(
-        absl::StrCat("unable to serialize Nodemetadata key=", NodeMetadataKey));
+    logWarn("unable to serialize metadata");
     return false;
   }
   return true;
 }
 
-void PluginRootContext::onConfigure(
-    std::unique_ptr<WasmData> ABSL_ATTRIBUTE_UNUSED configuration) {
-  google::protobuf::Value metadata;
-  if (getMetadataValue(Common::Wasm::MetadataType::Node, NodeMetadataKey,
-                       &metadata) != Common::Wasm::MetadataResult::Ok) {
-    logWarn(absl::StrCat("cannot get metadata for: ", NodeMetadataKey));
+}  // namespace
+
+void PluginRootContext::updateMetadataValue() {
+  google::protobuf::Value keys_value;
+  if (getMetadataValue(Common::Wasm::MetadataType::Node,
+                       NodeMetadataExchangeKeys,
+                       &keys_value) != Common::Wasm::MetadataResult::Ok) {
+    logWarn(
+        absl::StrCat("cannot get metadata key: ", NodeMetadataExchangeKeys));
     return;
   }
 
-  if (metadata.kind_case() == google::protobuf::Value::kStructValue) {
-    std::string metadata_bytes;
-    serializeToStringDeterministic(metadata.struct_value(), &metadata_bytes);
+  if (keys_value.kind_case() != google::protobuf::Value::kStringValue) {
+    logWarn(absl::StrCat("metadata key is not a string: ",
+                         NodeMetadataExchangeKeys));
+    return;
+  }
 
-    metadata_value_ =
-        Base64::encode(metadata_bytes.data(), metadata_bytes.size());
+  google::protobuf::Struct metadata;
 
-    // magic "." to get the whole node.
-    google::protobuf::Struct node;
-    if (getMetadataStruct(Common::Wasm::MetadataType::Node, WholeNodeKey,
-                          &node) != Common::Wasm::MetadataResult::Ok) {
-      logWarn(absl::StrCat("cannot get metadata for: ", WholeNodeKey));
-      return;
+  // select keys from the metadata using the keys
+  const std::set<absl::string_view> keys =
+      absl::StrSplit(keys_value.string_value(), ',', absl::SkipWhitespace());
+  for (auto key : keys) {
+    google::protobuf::Value value;
+    if (getMetadataValue(Common::Wasm::MetadataType::Node, key, &value) ==
+        Common::Wasm::MetadataResult::Ok) {
+      (*metadata.mutable_fields())[std::string(key)] = value;
+    } else {
+      logWarn(absl::StrCat("cannot get metadata key: ", key));
     }
+  }
 
+  // store serialized form
+  std::string metadata_bytes;
+  serializeToStringDeterministic(metadata, &metadata_bytes);
+  metadata_value_ =
+      Base64::encode(metadata_bytes.data(), metadata_bytes.size());
+}
+
+void PluginRootContext::onConfigure(
+    std::unique_ptr<WasmData> ABSL_ATTRIBUTE_UNUSED configuration) {
+  updateMetadataValue();
+
+  // TODO: this is really expensive since it fetches the entire metadata from
+  // before magic "." to get the whole node.
+  google::protobuf::Struct node;
+  if (getMetadataStruct(Common::Wasm::MetadataType::Node, WholeNodeKey,
+                        &node) == Common::Wasm::MetadataResult::Ok) {
     for (const auto& f : node.fields()) {
       if (f.first == NodeIdKey &&
           f.second.kind_case() == google::protobuf::Value::kStringValue) {
@@ -82,6 +108,8 @@ void PluginRootContext::onConfigure(
         break;
       }
     }
+  } else {
+    logWarn(absl::StrCat("cannot get metadata key: ", WholeNodeKey));
   }
 
   logDebug(

--- a/src/envoy/http/metadata_exchange/config.h
+++ b/src/envoy/http/metadata_exchange/config.h
@@ -23,13 +23,10 @@ namespace Wasm {
 namespace MetadataExchange {
 
 constexpr absl::string_view ExchangeMetadataHeader = "x-envoy-peer-metadata";
-
 constexpr absl::string_view ExchangeMetadataHeaderId =
     "x-envoy-peer-metadata-id";
 
-// NodeMetadata key is the key in the node metadata struct that is passed
-// between peers.
-constexpr absl::string_view NodeMetadataKey = "istio.io/metadata";
+constexpr absl::string_view NodeMetadataExchangeKeys = "EXCHANGE_KEYS";
 constexpr absl::string_view NodeIdKey = "id";
 constexpr absl::string_view WholeNodeKey = ".";
 
@@ -73,6 +70,7 @@ class PluginRootContext : public RootContext {
   StringView nodeId() { return node_id_; };
 
  private:
+  void updateMetadataValue();
   std::string metadata_value_;
   std::string node_id_;
 };

--- a/src/envoy/http/metadata_exchange/testdata/client.yaml
+++ b/src/envoy/http/metadata_exchange/testdata/client.yaml
@@ -1,10 +1,35 @@
 node:
   id: test-client-productpage
-  metadata:
-    "istio.io/metadata": {
-      namespace: default,
-      labels: { app: productpage },
-    }
+  metadata: {
+    "NAMESPACE": "default",
+    "INCLUDE_INBOUND_PORTS": "9080",
+    "app": "productpage",
+    "EXCHANGE_KEYS": "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
+    "INSTANCE_IPS": "10.52.0.34,fe80::a075:11ff:fe5e:f1cd",
+    "pod-template-hash": "84975bc778",
+    "INTERCEPTION_MODE": "REDIRECT",
+    "SERVICE_ACCOUNT": "bookinfo-productpage",
+    "CONFIG_NAMESPACE": "default",
+    "version": "v1",
+    "OWNER": "kubernetes://api/apps/v1/namespaces/default/deployment/productpage-v1",
+    "WORKLOAD_NAME": "productpage-v1",
+    "ISTIO_VERSION": "1.3-dev",
+    "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container productpage",
+    "POD_NAME": "productpage-v1-84975bc778-pxz2w",
+    "istio": "sidecar",
+    "PLATFORM_METADATA": {
+     "gcp_cluster_name": "/redacted/",
+     "gcp_project": "/redacted/",
+     "gcp_cluster_location": "us-east4-b"
+    },
+    "LABELS": {
+     "app": "productpage",
+     "version": "v1",
+     "pod-template-hash": "84975bc778"
+    },
+    "ISTIO_PROXY_SHA": "istio-proxy:47e4559b8e4f0d516c0d17b233d127a3deb3d7ce",
+    "NAME": "productpage-v1-84975bc778-pxz2w",
+  }
 static_resources:
   listeners:
   - name: client

--- a/src/envoy/http/metadata_exchange/testdata/server.yaml
+++ b/src/envoy/http/metadata_exchange/testdata/server.yaml
@@ -1,10 +1,35 @@
 node:
   id: test-server-ratings
-  metadata:
-    "istio.io/metadata": {
-      namespace: default,
-      labels: { app: ratings },
-    }
+  metadata: {
+    "NAMESPACE": "default",
+    "INCLUDE_INBOUND_PORTS": "9080",
+    "app": "ratings",
+    "EXCHANGE_KEYS": "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
+    "INSTANCE_IPS": "10.52.0.34,fe80::a075:11ff:fe5e:f1cd",
+    "pod-template-hash": "84975bc778",
+    "INTERCEPTION_MODE": "REDIRECT",
+    "SERVICE_ACCOUNT": "bookinfo-ratings",
+    "CONFIG_NAMESPACE": "default",
+    "version": "v1",
+    "OWNER": "kubernetes://api/apps/v1/namespaces/default/deployment/ratings-v1",
+    "WORKLOAD_NAME": "ratings-v1",
+    "ISTIO_VERSION": "1.3-dev",
+    "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container ratings",
+    "POD_NAME": "ratings-v1-84975bc778-pxz2w",
+    "istio": "sidecar",
+    "PLATFORM_METADATA": {
+     "gcp_cluster_name": "/redacted/",
+     "gcp_project": "/redacted/",
+     "gcp_cluster_location": "us-east4-b"
+    },
+    "LABELS": {
+     "app": "ratings",
+     "version": "v1",
+     "pod-template-hash": "84975bc778"
+    },
+    "ISTIO_PROXY_SHA": "istio-proxy:47e4559b8e4f0d516c0d17b233d127a3deb3d7ce",
+    "NAME": "ratings-v1-84975bc778-pxz2w",
+  }
 static_resources:
   listeners:
   - name: server


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Manual test:
```
client 200 downstream_id:- downstream:- upstream_id:- upstream:{"SERVICE_ACCOUNT":"bookinfo-ratings","PLATFORM_METADATA":{"gcp_cluster_location":"us-east4-b","gcp_cluster_name":"/redacted/","gcp_project":"/redacted/"},"OWNER":"kubernetes://api/apps/v1/namespaces/default/deployment/ratings-v1","WORKLOAD_NAME":"ratings-v1","LABELS":{"app":"ratings","version":"v1","pod-template-hash":"84975bc778"},"NAME":"ratings-v1-84975bc778-pxz2w","NAMESPACE":"default","INSTANCE_IPS":"10.52.0.34,fe80::a075:11ff:fe5e:f1cd"}

server 200 downstream_id:- downstream:{"SERVICE_ACCOUNT":"bookinfo-productpage","PLATFORM_METADATA":{"gcp_cluster_name":"/redacted/","gcp_project":"/redacted/","gcp_cluster_location":"us-east4-b"},"OWNER":"kubernetes://api/apps/v1/namespaces/default/deployment/productpage-v1","WORKLOAD_NAME":"productpage-v1","LABELS":{"pod-template-hash":"84975bc778","app":"productpage","version":"v1"},"NAME":"productpage-v1-84975bc778-pxz2w","NAMESPACE":"default","INSTANCE_IPS":"10.52.0.34,fe80::a075:11ff:fe5e:f1cd"} upstream_id:- upstream:-
```

/assign @mandarjog 
/assign @douglas-reid 