### PR TITLE
Add ability to fail_open (allow) when quota backend is unavailable

### DIFF
--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -13,9 +13,12 @@
  * limitations under the License.
  */
 #include "src/istio/mixerclient/client_impl.h"
+
 #include <google/protobuf/arena.h>
+
 #include <algorithm>
 #include <cmath>
+
 #include "include/istio/mixerclient/check_response.h"
 #include "include/istio/utils/protobuf.h"
 #include "src/istio/mixerclient/status_util.h"
@@ -284,19 +287,21 @@ void MixerClientImpl::RemoteCheck(CheckContextSharedPtr context,
         } else if (!context->policyStatus().ok()) {
           context->setFinalStatus(context->policyStatus());
         } else {
-          // if the quota backend is unavailable and we want to fail open in network failure cases
-          // then just say OK.
-          // NOTE: this does not include INTERNAL errors as fail-open worthy. The
-          // mixer handler code for redisquota can return UNAVAILABLE, INTERNAL, or OK.
+          // if the quota backend is unavailable and we want to fail open in
+          // network failure cases then just say OK. NOTE: this does not include
+          // INTERNAL errors as fail-open worthy. The mixer handler code for
+          // redisquota can return UNAVAILABLE, INTERNAL, or OK.
 
-          // we need to check quota statuses from the response individually, as context->quotaStatus() overrides
-          // the individual responses based on other factors. For all unavailable, the code would be 8 (resource exhausted).
-          // because we want to tease out a special case, we must look at the responses directly.
+          // we need to check quota statuses from the response individually, as
+          // context->quotaStatus() overrides the individual responses based on
+          // other factors. For all unavailable, the code would be 8 (resource
+          // exhausted). because we want to tease out a special case, we must
+          // look at the responses directly.
           bool all_unavailable = context->response()->quotas().size() > 0;
-          for (auto & pair : context->response()->quotas())
-          {
+          for (auto &pair : context->response()->quotas()) {
             auto quota = pair.second;
-            all_unavailable = all_unavailable && (quota.status().code() == Code::UNAVAILABLE);
+            all_unavailable =
+                all_unavailable && (quota.status().code() == Code::UNAVAILABLE);
           }
 
           if (all_unavailable && context->networkFailOpen()) {

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -287,28 +287,7 @@ void MixerClientImpl::RemoteCheck(CheckContextSharedPtr context,
         } else if (!context->policyStatus().ok()) {
           context->setFinalStatus(context->policyStatus());
         } else {
-          // if the quota backend is unavailable and we want to fail open in
-          // network failure cases then just say OK. NOTE: this does not include
-          // INTERNAL errors as fail-open worthy. The mixer handler code for
-          // redisquota can return UNAVAILABLE, INTERNAL, or OK.
-
-          // we need to check quota statuses from the response individually, as
-          // context->quotaStatus() overrides the individual responses based on
-          // other factors. For all unavailable, the code would be 8 (resource
-          // exhausted). because we want to tease out a special case, we must
-          // look at the responses directly.
-          bool all_unavailable = context->response()->quotas().size() > 0;
-          for (auto &pair : context->response()->quotas()) {
-            auto quota = pair.second;
-            all_unavailable =
-                all_unavailable && (quota.status().code() == Code::UNAVAILABLE);
-          }
-
-          if (all_unavailable && context->networkFailOpen()) {
-            context->setFinalStatus(Status::OK);
-          } else {
-            context->setFinalStatus(context->quotaStatus());
-          }
+          context->setFinalStatus(context->quotaStatus());
         }
 
         if (on_done) {

--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -284,7 +284,26 @@ void MixerClientImpl::RemoteCheck(CheckContextSharedPtr context,
         } else if (!context->policyStatus().ok()) {
           context->setFinalStatus(context->policyStatus());
         } else {
-          context->setFinalStatus(context->quotaStatus());
+          // if the quota backend is unavailable and we want to fail open in network failure cases
+          // then just say OK.
+          // NOTE: this does not include INTERNAL errors as fail-open worthy. The
+          // mixer handler code for redisquota can return UNAVAILABLE, INTERNAL, or OK.
+
+          // we need to check quota statuses from the response individually, as context->quotaStatus() overrides
+          // the individual responses based on other factors. For all unavailable, the code would be 8 (resource exhausted).
+          // because we want to tease out a special case, we must look at the responses directly.
+          bool all_unavailable = context->response()->quotas().size() > 0;
+          for (auto & pair : context->response()->quotas())
+          {
+            auto quota = pair.second;
+            all_unavailable = all_unavailable && (quota.status().code() == Code::UNAVAILABLE);
+          }
+
+          if (all_unavailable && context->networkFailOpen()) {
+            context->setFinalStatus(Status::OK);
+          } else {
+            context->setFinalStatus(context->quotaStatus());
+          }
         }
 
         if (on_done) {

--- a/src/istio/mixerclient/client_impl_test.cc
+++ b/src/istio/mixerclient/client_impl_test.cc
@@ -59,15 +59,11 @@ class MixerClientImplTest : public ::testing::Test {
 
  protected:
   void CreateClient(bool check_cache, bool quota_cache) {
-    CreateClient(check_cache, quota_cache, true);
-  }
-
-  void CreateClient(bool check_cache, bool quota_cache, bool fail_open) {
     MixerClientOptions options(CheckOptions(check_cache ? 1 : 0 /*entries */),
                                ReportOptions(1, 1000),
                                QuotaOptions(quota_cache ? 1 : 0 /* entries */,
                                             600000 /* expiration_ms */));
-    options.check_options.network_fail_open = fail_open;
+    options.check_options.network_fail_open = false;
     options.env.check_transport = mock_check_transport_.GetFunc();
     client_ = CreateMixerClient(options);
   }
@@ -133,11 +129,8 @@ class MixerClientImplTest : public ::testing::Test {
   }
 
   CheckContextSharedPtr CreateContext(int quota_request) {
-    return CreateContext(quota_request, false /* fail_open */);
-  }
-
-  CheckContextSharedPtr CreateContext(int quota_request, bool fail_open) {
     uint32_t retries{0};
+    bool fail_open{false};
     istio::mixerclient::SharedAttributesSharedPtr attributes{
         new SharedAttributes()};
     istio::mixerclient::CheckContextSharedPtr context{
@@ -549,10 +542,7 @@ TEST_F(MixerClientImplTest, TestFailedCheckAndQuota) {
   EXPECT_EQ(stat.total_remote_call_other_errors_, 0);
 }
 
-TEST_F(MixerClientImplTest, TestUnavailableQuotaBackendFailClosed) {
-  CreateClient(true /* check_cache */, true /* quota_cache */,
-               false /* fail_open */);
-
+TEST_F(MixerClientImplTest, TestUnavailableQuotaBackend) {
   EXPECT_CALL(mock_check_transport_, Check(_, _, _))
       .WillOnce(Invoke([](const CheckRequest& request, CheckResponse* response,
                           DoneFunc on_done) {
@@ -566,31 +556,6 @@ TEST_F(MixerClientImplTest, TestUnavailableQuotaBackendFailClosed) {
 
   {
     CheckContextSharedPtr context = CreateContext(1);
-    Status status;
-    client_->Check(
-        context, empty_transport_,
-        [&status](const CheckResponseInfo& info) { status = info.status(); });
-    EXPECT_ERROR_CODE(Code::RESOURCE_EXHAUSTED, status);
-  }
-}
-
-TEST_F(MixerClientImplTest, TestUnavailableQuotaBackendFailOpen) {
-  CreateClient(true /* check_cache */, true /* quota_cache */,
-               true /* fail_open */);
-
-  EXPECT_CALL(mock_check_transport_, Check(_, _, _))
-      .WillOnce(Invoke([](const CheckRequest& request, CheckResponse* response,
-                          DoneFunc on_done) {
-        response->mutable_precondition()->set_valid_use_count(100);
-        CheckResponse::QuotaResult quota_result;
-        quota_result.mutable_status()->set_code(Code::UNAVAILABLE);
-        // explicitly do not set granted amounts.
-        (*response->mutable_quotas())[kRequestCount] = quota_result;
-        on_done(Status::OK);
-      }));
-
-  {
-    CheckContextSharedPtr context = CreateContext(1, true /* fail_open */);
     Status status;
     client_->Check(
         context, empty_transport_,

--- a/src/istio/mixerclient/client_impl_test.cc
+++ b/src/istio/mixerclient/client_impl_test.cc
@@ -549,9 +549,9 @@ TEST_F(MixerClientImplTest, TestFailedCheckAndQuota) {
   EXPECT_EQ(stat.total_remote_call_other_errors_, 0);
 }
 
-
 TEST_F(MixerClientImplTest, TestUnavailableQuotaBackendFailClosed) {
-  CreateClient(true /* check_cache */, true /* quota_cache */, false /* fail_open */);
+  CreateClient(true /* check_cache */, true /* quota_cache */,
+               false /* fail_open */);
 
   EXPECT_CALL(mock_check_transport_, Check(_, _, _))
       .WillOnce(Invoke([](const CheckRequest& request, CheckResponse* response,
@@ -575,7 +575,8 @@ TEST_F(MixerClientImplTest, TestUnavailableQuotaBackendFailClosed) {
 }
 
 TEST_F(MixerClientImplTest, TestUnavailableQuotaBackendFailOpen) {
-  CreateClient(true /* check_cache */, true /* quota_cache */, true /* fail_open */);
+  CreateClient(true /* check_cache */, true /* quota_cache */,
+               true /* fail_open */);
 
   EXPECT_CALL(mock_check_transport_, Check(_, _, _))
       .WillOnce(Invoke([](const CheckRequest& request, CheckResponse* response,

--- a/src/istio/mixerclient/quota_cache.cc
+++ b/src/istio/mixerclient/quota_cache.cc
@@ -168,6 +168,7 @@ void QuotaCache::CheckCache(const Attributes& request, bool check_use_cache,
            const CheckResponse::QuotaResult* result) -> bool {
       // nullptr means connection error, for quota, it is fail open for
       // connection error.
+      // TODO: determine if fail open for connection error is really appropriate.
       return result == nullptr || result->granted_amount() > 0;
     };
     return;

--- a/src/istio/mixerclient/quota_cache.cc
+++ b/src/istio/mixerclient/quota_cache.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/quota_cache.h"
+
 #include "include/istio/utils/protobuf.h"
 #include "src/istio/utils/logger.h"
 
@@ -168,7 +169,8 @@ void QuotaCache::CheckCache(const Attributes& request, bool check_use_cache,
            const CheckResponse::QuotaResult* result) -> bool {
       // nullptr means connection error, for quota, it is fail open for
       // connection error.
-      // TODO: determine if fail open for connection error is really appropriate.
+      // TODO: determine if fail open for connection error is really
+      // appropriate.
       return result == nullptr || result->granted_amount() > 0;
     };
     return;

--- a/src/istio/mixerclient/quota_cache.cc
+++ b/src/istio/mixerclient/quota_cache.cc
@@ -169,9 +169,9 @@ void QuotaCache::CheckCache(const Attributes& request, bool check_use_cache,
            const CheckResponse::QuotaResult* result) -> bool {
       // nullptr means connection error, for quota, it is fail open for
       // connection error.
-      // TODO: determine if fail open for connection error is really
-      // appropriate.
-      return result == nullptr || result->granted_amount() > 0;
+      return result == nullptr ||
+             result->status().code() == Code::UNAVAILABLE ||
+             result->granted_amount() > 0;
     };
     return;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
Users reported being surprised at the `429` responses received when a quota backend (redis, in particular) was unavailable. This PR attempts to provide a mechanism to enable operators to ignore failed quota checks that result from an unavailable quota backend. This is the client-side PR companion to istio/istio#16583.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
- https://github.com/istio/istio/issues/12115

**Special notes for your reviewer**:
I'm not entirely certain that this is the desired behavior, but I _think_ it is a reasonable change. I'm very interested in reviewer feedback on the approach.

In summary: with istio/istio#16583, Mixer will return `UNAVAILABLE` **with 0 granted quota tokens** in the `QuotaResult`s for a `CheckResponse` when a quota backend is unreachable/down (redis). This PR alters the mixerclient behavior to look through all the returned quota responses, check if they **all** include a status of `UNAVAILABLE`, and if that is the case, allow the request if a "fail open" transport policy has been set.  Otherwise, the request will fail (as is current behavior).

This allows for operator control over sensitivity to quota enforcement when the quota system is unreachable -- without introducing further API changes, etc.

It seems like a decent compromise, but I'm very much open to other approaches.

Please take a close and considered look.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow network transport policy to override rate limit enforcement when quota backend is unavailable (allow on unavailable).
```
