### PR TITLE
Use per filter config in route instead of route entry

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -63,7 +63,8 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
   ::istio::control::http::Controller::PerRouteConfig config;
   auto route = decoder_callbacks_->route();
   if (route) {
-    auto route_cfg = route->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
+    auto route_cfg =
+        route->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
     if (route_cfg) {
       ReadPerRouteConfig(*route_cfg, &config);
     }
@@ -227,7 +228,8 @@ void Filter::log(const HeaderMap* request_headers,
     // Here Request is rejected by other filters, Mixer filter is not called.
     ::istio::control::http::Controller::PerRouteConfig config;
     auto route_entry = stream_info.routeEntry();
-    auto route_cfg = route_entry->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
+    auto route_cfg =
+        route_entry->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
     if (route_cfg) {
       ReadPerRouteConfig(*route_cfg, &config);
     }

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -48,22 +48,15 @@ Filter::Filter(Control& control)
 }
 
 void Filter::ReadPerRouteConfig(
-    const Router::RouteEntry* entry,
+    const PerRouteServiceConfig* route_cfg,
     ::istio::control::http::Controller::PerRouteConfig* config) {
-  if (entry == nullptr) {
+  if (!route_cfg) {
     return;
   }
-
-  // Check v2 per-route config.
-  auto route_cfg = entry->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
-  if (route_cfg) {
-    if (!control_.controller()->LookupServiceConfig(route_cfg->hash)) {
-      control_.controller()->AddServiceConfig(route_cfg->hash,
-                                              route_cfg->config);
-    }
-    config->service_config_id = route_cfg->hash;
-    return;
+  if (!control_.controller()->LookupServiceConfig(route_cfg->hash)) {
+    control_.controller()->AddServiceConfig(route_cfg->hash, route_cfg->config);
   }
+  config->service_config_id = route_cfg->hash;
 }
 
 FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
@@ -73,7 +66,8 @@ FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
   ::istio::control::http::Controller::PerRouteConfig config;
   auto route = decoder_callbacks_->route();
   if (route) {
-    ReadPerRouteConfig(route->routeEntry(), &config);
+    ReadPerRouteConfig(
+        route->perFilterConfigTyped<PerRouteServiceConfig>("mixer"), &config);
   }
   handler_ = control_.controller()->CreateRequestHandler(config);
 
@@ -233,7 +227,10 @@ void Filter::log(const HeaderMap* request_headers,
 
     // Here Request is rejected by other filters, Mixer filter is not called.
     ::istio::control::http::Controller::PerRouteConfig config;
-    ReadPerRouteConfig(stream_info.routeEntry(), &config);
+    auto route_entry = stream_info.routeEntry();
+    ReadPerRouteConfig(
+        route_entry->perFilterConfigTyped<PerRouteServiceConfig>("mixer"),
+        &config);
     handler_ = control_.controller()->CreateRequestHandler(config);
   }
 

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -228,10 +228,12 @@ void Filter::log(const HeaderMap* request_headers,
     // Here Request is rejected by other filters, Mixer filter is not called.
     ::istio::control::http::Controller::PerRouteConfig config;
     auto route_entry = stream_info.routeEntry();
-    auto route_cfg =
-        route_entry->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
-    if (route_cfg) {
-      ReadPerRouteConfig(*route_cfg, &config);
+    if (route_entry) {
+      auto route_cfg =
+          route_entry->perFilterConfigTyped<PerRouteServiceConfig>("mixer");
+      if (route_cfg) {
+        ReadPerRouteConfig(*route_cfg, &config);
+      }
     }
     handler_ = control_.controller()->CreateRequestHandler(config);
   }

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -77,7 +77,7 @@ class Filter : public StreamFilter,
  private:
   // Read per-route config.
   void ReadPerRouteConfig(
-      const Router::RouteEntry* entry,
+      const PerRouteServiceConfig* route_cfg,
       ::istio::control::http::Controller::PerRouteConfig* config);
 
   // Update header maps

--- a/src/envoy/http/mixer/filter.h
+++ b/src/envoy/http/mixer/filter.h
@@ -77,7 +77,7 @@ class Filter : public StreamFilter,
  private:
   // Read per-route config.
   void ReadPerRouteConfig(
-      const PerRouteServiceConfig* route_cfg,
+      const PerRouteServiceConfig& route_cfg,
       ::istio::control::http::Controller::PerRouteConfig* config);
 
   // Update header maps


### PR DESCRIPTION
When blackhole route is matched, routeEntry will be null in `route` and instead the directResponseEntry will be populated. The original logic uses per filter config from routeEntry, which does not work for blackhole case. After this change, the attributes mixer receives are:
```
...
context.reporter.kind         : outbound
context.reporter.uid          : kubernetes://sleep-596b545f8d-sqhdj.default
destination.service.host      : BlackHoleCluster
destination.service.name      : BlackHoleCluster
origin.ip                     : [10 24 0 11]
...
request.host                  : httpbin.org
request.method                : GET
request.path                  : /
request.scheme                : http
request.size                  : 0
request.total_size            : 788
request.url_path              : /
...
```

@douglas-reid @nrjpoddar @mandarjog Should we consider leaving `destination.service.host` unset for `BlackHoleCluster` cluster? So that metric could fall back to `request.host`. It does not seem to be very informative if both service host and name are `BlackHoleCluster`.

fix https://github.com/istio/istio/issues/16629