### PR TITLE
jwt: extract claim with whitespce as list

### DIFF
--- a/src/envoy/http/authn/authn_utils.cc
+++ b/src/envoy/http/authn/authn_utils.cc
@@ -16,6 +16,7 @@
 #include <regex>
 
 #include "absl/strings/match.h"
+#include "absl/strings/str_split.h"
 #include "authn_utils.h"
 #include "common/json/json_loader.h"
 #include "google/protobuf/struct.pb.h"
@@ -36,12 +37,18 @@ static const std::string kExchangedTokenOriginalPayload = "original_claims";
 // Extract JWT claim as a string list.
 // This function only extracts string and string list claims.
 // A string claim is extracted as a string list of 1 item.
+// A string claim with whitespace is extracted as a string list with each
+// sub-string delimited with the whitespace.
 void ExtractStringList(const std::string& key, const Envoy::Json::Object& obj,
                        std::vector<std::string>* list) {
   // First, try as string
   try {
     // Try as string, will throw execption if object type is not string.
-    list->push_back(obj.getString(key));
+    const std::vector<std::string> keys = absl::StrSplit(obj.getString(key), ' ',
+        absl::SkipEmpty());
+    for (auto key : keys) {
+      list->push_back(key);
+    }
   } catch (Json::Exception& e) {
     // Not convertable to string
   }

--- a/src/envoy/http/authn/authn_utils.cc
+++ b/src/envoy/http/authn/authn_utils.cc
@@ -44,8 +44,8 @@ void ExtractStringList(const std::string& key, const Envoy::Json::Object& obj,
   // First, try as string
   try {
     // Try as string, will throw execption if object type is not string.
-    const std::vector<std::string> keys = absl::StrSplit(obj.getString(key), ' ',
-        absl::SkipEmpty());
+    const std::vector<std::string> keys =
+        absl::StrSplit(obj.getString(key), ' ', absl::SkipEmpty());
     for (auto key : keys) {
       list->push_back(key);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
If a claim in the JWT token includes spaces, extract it as a list of string delimited with spaces. For example, `"aud": "aud1   aud2"` will be extracted as `"aud": ["aud1", "aud2"]`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes https://github.com/istio/istio/issues/13565

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
