### PR TITLE
fix(metadata filter): update metadata exchange filter to new EnvoyFilter API

### DIFF
--- a/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
+++ b/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
@@ -3,43 +3,21 @@ kind: EnvoyFilter
 metadata:
   name: metadata-exchange
 spec:
-  filters:
-  - filterConfig:
-      configuration: envoy.wasm.metadata_exchange
-      vm_config:
-        code:
-          inline_string: envoy.wasm.metadata_exchange
-        vm: envoy.wasm.vm.null
-    filterName: envoy.wasm
-    filterType: HTTP
-    insertPosition:
-      index: FIRST
-    listenerMatch:
-      listenerProtocol: HTTP
-      listenerType: SIDECAR_INBOUND
-  - filterConfig:
-      configuration: envoy.wasm.metadata_exchange
-      vm_config:
-        code:
-          inline_string: envoy.wasm.metadata_exchange
-        vm: envoy.wasm.vm.null
-    filterName: envoy.wasm
-    filterType: HTTP
-    insertPosition:
-      index: FIRST
-    listenerMatch:
-      listenerProtocol: HTTP
-      listenerType: SIDECAR_OUTBOUND
-  - filterConfig:
-      configuration: envoy.wasm.metadata_exchange
-      vm_config:
-        code:
-          inline_string: envoy.wasm.metadata_exchange
-        vm: envoy.wasm.vm.null
-    filterName: envoy.wasm
-    filterType: HTTP
-    insertPosition:
-      index: FIRST
-    listenerMatch:
-      listenerProtocol: HTTP
-      listenerType: GATEWAY
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.wasm
+          config:
+            configuration: envoy.wasm.metadata_exchange
+            vm_config:
+              vm: envoy.wasm.vm.null
+              code:
+                inline_string: envoy.wasm.metadata_exchange


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the config for the metadata exchange filter from the deprecated EnvoyFilter API bits to the new EnvoyFilter API bits.

**Special notes for your reviewer**:
I have only done a single spot testing of this in action. I'm hoping the existing tests can further validate that I've done the conversion correctly.
