### PR TITLE
fix(stats filter): update stats filter config to new EnvoyFilter API

### DIFF
--- a/extensions/stats/testdata/istio/stats_filter.yaml
+++ b/extensions/stats/testdata/istio/stats_filter.yaml
@@ -3,58 +3,27 @@ kind: EnvoyFilter
 metadata:
   name: stats-filter
 spec:
-  filters:
-  - filterConfig:
-      configuration: |
-        {
-          "debug": "false",
-          "stat_prefix": "istio",
-        }
-      vm_config:
-        code:
-          inline_string: envoy.wasm.stats
-        vm: envoy.wasm.vm.null
-    filterName: envoy.wasm
-    filterType: HTTP
-    insertPosition:
-      index: BEFORE
-      relativeTo: envoy.router
-    listenerMatch:
-      listenerProtocol: HTTP
-      listenerType: GATEWAY
-  - filterConfig:
-      configuration: |
-        {
-          "debug": "false",
-          "stat_prefix": "istio",
-        }
-      vm_config:
-        code:
-          inline_string: envoy.wasm.stats
-        vm: envoy.wasm.vm.null
-    filterName: envoy.wasm
-    filterType: HTTP
-    insertPosition:
-      index: BEFORE
-      relativeTo: envoy.router
-    listenerMatch:
-      listenerProtocol: HTTP
-      listenerType: SIDECAR_INBOUND
-  - filterConfig:
-      configuration: |
-        {
-          "debug": "false",
-          "stat_prefix": "istio",
-        }
-      vm_config:
-        code:
-          inline_string: envoy.wasm.stats
-        vm: envoy.wasm.vm.null
-    filterName: envoy.wasm
-    filterType: HTTP
-    insertPosition:
-      index: BEFORE
-      relativeTo: envoy.router
-    listenerMatch:
-      listenerProtocol: HTTP
-      listenerType: SIDECAR_OUTBOUND
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY # inbound, outbound, and gateway
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.wasm
+          config:
+            configuration: |
+              {
+                "debug": "false",
+                "stat_prefix": "istio",
+              }
+            vm_config:
+              vm: envoy.wasm.vm.null
+              code:
+                inline_string: envoy.wasm.stats


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the experimental stats filter config to the latest EnvoyFilter API. The existing config uses deprecated config options.

**Special notes for your reviewer**:
Beyond initial spot-checking, I have not thoroughly vetted this config change. I'm hoping our testing is robust enough to capture any issues that aren't immediately obvious.
