### PR TITLE
feat(stats): add istio_build metric to prom extension

### DIFF
--- a/extensions/common/node_info.proto
+++ b/extensions/common/node_info.proto
@@ -34,4 +34,7 @@ message NodeInfo {
   // Platform metadata uses prefixed keys
   // GCP uses gcp_* keys
   map<string, string> platform_metadata = 6 [json_name = "PLATFORM_METADATA"];
+
+  // Version identifier for the proxy.
+  string istio_version = 7 [json_name = "ISTIO_VERSION"];
 }

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -81,6 +81,11 @@ void PluginRootContext::onConfigure(std::unique_ptr<WasmData> configuration) {
   // scraper"
   stat_prefix = absl::StrCat("_", stat_prefix, "_");
 
+  Metric build(MetricType::Gauge, absl::StrCat(stat_prefix, "build"),
+               {MetricTag{"component", MetricTag::TagType::String},
+                MetricTag{"tag", MetricTag::TagType::String}});
+  build.record(1, "proxy", absl::StrCat(local_node_info_.istio_version(), ";"));
+
   stats_ = std::vector<StatGen>{
       StatGen(
           absl::StrCat(stat_prefix, "requests_total"), MetricType::Counter,

--- a/extensions/stats/testdata/client.yaml
+++ b/extensions/stats/testdata/client.yaml
@@ -1,6 +1,7 @@
 node:
   id: test-client-productpage
   metadata:
+    ISTIO_VERSION: "1.4-dev"
     EXCHANGE_KEYS: "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME"
     NAME: productpage-v11-84975bc778-pxz2w
     NAMESPACE: default
@@ -58,6 +59,10 @@ stats_config:
     regex: "(connection_security_policy=\\.=(.+?);\\.;)"
   - tag_name: "cache"
     regex: "(cache\\.(.+?)\\.)"
+  - tag_name: "component"
+    regex: "(component\\.(.+?)\\.)"
+  - tag_name: "tag"
+    regex: "(tag\\.(.+?);\\.)"
 static_resources:
   listeners:
   - name: client

--- a/extensions/stats/testdata/server.yaml
+++ b/extensions/stats/testdata/server.yaml
@@ -1,6 +1,7 @@
 node:
   id: test-server-ratings
   metadata:
+    ISTIO_VERSION: "1.4-dev"
     EXCHANGE_KEYS: "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME"
     NAME: ratings-v22-84975bc778-pxz2w
     NAMESPACE: default
@@ -58,6 +59,10 @@ stats_config:
     regex: "(connection_security_policy=\\.=(.+?);\\.;)"
   - tag_name: "cache"
     regex: "(cache\\.(.+?)\\.)"
+  - tag_name: "component"
+    regex: "(component\\.(.+?)\\.)"
+  - tag_name: "tag"
+    regex: "(tag\\.(.+?);\\.)"
 static_resources:
   listeners:
   - name: server


### PR DESCRIPTION
This PR adds a Gauge that records the `istio_build` metric when the `stats` extension is loaded in the proxy.

This will allow tracking of proxy version updates/rollouts across a large mesh.

See also: https://github.com/istio/istio/issues/17173, https://github.com/istio/istio/issues/16555

For the example config, here is prometheus output:

```
# TYPE istio_build gauge
istio_build{component="proxy",tag="1.4-dev"} 1
```

And here is the statstd:

```
component.proxy.tag.1.4-dev;._istio_build: 1
```

This metric is meant to match (with available information) the `istio_build` metric defined in [istio/pkg/version](https://github.com/istio/pkg/blob/master/version/stats_linux.go#L35).

Reviewers:
I'm looking for feedback on the use of the Metrics API, as well as if `PluginRootContext::onConfigure` is the appropriate location for this contribution.