### PR TITLE
Add trust domain and trust domain aliases to mTLS API

### DIFF
--- a/src/istio/authn/context.proto
+++ b/src/istio/authn/context.proto
@@ -51,6 +51,22 @@ message X509Payload {
   // Identity carries by X509 certification. This is extracted from SAN field
   // for Istio provided certificate.
   string user = 1;
+
+  // The trust domain corresponds to the trust root of a system.
+  // Refer to
+  // [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
+  string trust_domain = 2;
+
+  // The trust domain aliases represent the aliases of `trust_domain`.
+  // For example, if we have
+  // ```yaml
+  // trustDomain: td1
+  // trustDomainAliases: [“td2”, "td3"]
+  // ```
+  // Any service with the identity `td1/ns/foo/sa/a-service-account`,
+  // `td2/ns/foo/sa/a-service-account`, or `td3/ns/foo/sa/a-service-account`
+  // will be treated the same in the Istio mesh.
+  repeated string trust_domain_aliases = 3;
 };
 
 message Payload {

--- a/src/istio/authn/context.proto
+++ b/src/istio/authn/context.proto
@@ -58,6 +58,8 @@ message X509Payload {
   // The `trust_domains` field contains a list of trust domains. A request from
   // `serviceA` to `serviceB` is accepted at `serviceB` if `serviceA` carries a
   // valid x509 cerficicate with the trust domain from the trust_domains list.
+  // The `trust_domains` field should not be empty. It should contain at least
+  // one trust domain.
   repeated string trust_domains = 2;
 };
 

--- a/src/istio/authn/context.proto
+++ b/src/istio/authn/context.proto
@@ -55,18 +55,10 @@ message X509Payload {
   // The trust domain corresponds to the trust root of a system.
   // Refer to
   // [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)
-  string trust_domain = 2;
-
-  // The trust domain aliases represent the aliases of `trust_domain`.
-  // For example, if we have
-  // ```yaml
-  // trustDomain: td1
-  // trustDomainAliases: [“td2”, "td3"]
-  // ```
-  // Any service with the identity `td1/ns/foo/sa/a-service-account`,
-  // `td2/ns/foo/sa/a-service-account`, or `td3/ns/foo/sa/a-service-account`
-  // will be treated the same in the Istio mesh.
-  repeated string trust_domain_aliases = 3;
+  // The `trust_domains` field contains a list of trust domains. A request from
+  // `serviceA` to `serviceB` is accepted at `serviceB` if `serviceA` carries a
+  // valid x509 cerficicate with the trust domain from the trust_domains list.
+  repeated string trust_domains = 2;
 };
 
 message Payload {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add trust domain and trust domain aliases information, so that the authn filter can use this information.

