### PR TITLE
feat(edges): add support for meshtelemetry edge export

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/common/context.h"
+
 #include "google/protobuf/util/json_util.h"
 
 // WASM_PROLOG
@@ -56,8 +57,13 @@ google::protobuf::util::Status extractNodeMetadata(
   }
   google::protobuf::util::JsonParseOptions json_parse_options;
   json_parse_options.ignore_unknown_fields = true;
-  return JsonStringToMessage(metadata_json_struct, node_info,
-                             json_parse_options);
+  status =
+      JsonStringToMessage(metadata_json_struct, node_info, json_parse_options);
+
+  // used to extract a node key at creation time.
+  absl::StrAppend(node_info->mutable_node_key(), node_info->name(), ".",
+                  node_info->namespace_());
+  return status;
 }
 
 google::protobuf::util::Status extractLocalNodeMetadata(

--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/common/context.h"
+
 #include "google/protobuf/util/json_util.h"
 
 // WASM_PROLOG
@@ -56,13 +57,8 @@ google::protobuf::util::Status extractNodeMetadata(
   }
   google::protobuf::util::JsonParseOptions json_parse_options;
   json_parse_options.ignore_unknown_fields = true;
-  status =
-      JsonStringToMessage(metadata_json_struct, node_info, json_parse_options);
-
-  // used to extract a node key at creation time.
-  absl::StrAppend(node_info->mutable_node_key(), node_info->name(), ".",
-                  node_info->namespace_());
-  return status;
+  return JsonStringToMessage(metadata_json_struct, node_info,
+                             json_parse_options);
 }
 
 google::protobuf::util::Status extractLocalNodeMetadata(

--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -14,7 +14,6 @@
  */
 
 #include "extensions/common/context.h"
-
 #include "google/protobuf/util/json_util.h"
 
 // WASM_PROLOG

--- a/extensions/common/node_info.proto
+++ b/extensions/common/node_info.proto
@@ -37,8 +37,4 @@ message NodeInfo {
 
   // Version identifier for the proxy.
   string istio_version = 7 [json_name = "ISTIO_VERSION"];
-
-  // Used to uniquely identify the node (in caches, etc.)
-  // This is not assigned as part of any json serialization.
-  string node_key = 9;
 }

--- a/extensions/common/node_info.proto
+++ b/extensions/common/node_info.proto
@@ -37,4 +37,8 @@ message NodeInfo {
 
   // Version identifier for the proxy.
   string istio_version = 7 [json_name = "ISTIO_VERSION"];
+
+  // Unique identifier for the mesh. Taken from global mesh id parameter (or
+  // the configured trust domain when not specified).
+  string mesh_id = 8 [json_name = "MESH_ID"];
 }

--- a/extensions/common/node_info.proto
+++ b/extensions/common/node_info.proto
@@ -37,4 +37,8 @@ message NodeInfo {
 
   // Version identifier for the proxy.
   string istio_version = 7 [json_name = "ISTIO_VERSION"];
+
+  // Used to uniquely identify the node (in caches, etc.)
+  // This is not assigned as part of any json serialization.
+  string node_key = 9;
 }

--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -24,7 +24,7 @@ cc_library(
     ],
     visibility = [
         "//extensions/stackdriver:__pkg__",
-        "//extensions/stackdriver/metric:__pkg__",
         "//extensions/stackdriver/edges:__pkg__",
+        "//extensions/stackdriver/metric:__pkg__",
     ],
 )

--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -25,5 +25,6 @@ cc_library(
     visibility = [
         "//extensions/stackdriver:__pkg__",
         "//extensions/stackdriver/metric:__pkg__",
+        "//extensions/stackdriver/edges:__pkg__",
     ],
 )

--- a/extensions/stackdriver/edges/BUILD
+++ b/extensions/stackdriver/edges/BUILD
@@ -28,7 +28,7 @@ proto_library(
     srcs = ["edges.proto"],
     deps = [
         "@com_google_protobuf//:timestamp_proto",
-    ]
+    ],
 )
 
 load(
@@ -49,9 +49,9 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":edges_cc_proto",
-        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
         "//extensions/common:context",
-    ]
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
+    ],
 )
 
 envoy_cc_library(
@@ -67,10 +67,10 @@ envoy_cc_library(
     deps = [
         ":edges_cc_proto",
         ":mesh_edges_service_client",
-        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
         "//extensions/common:context",
         "//extensions/stackdriver/common:constants",
-    ]
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
+    ],
 )
 
 envoy_cc_test(

--- a/extensions/stackdriver/edges/BUILD
+++ b/extensions/stackdriver/edges/BUILD
@@ -1,0 +1,85 @@
+# Copyright 2019 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+licenses(["notice"])
+
+cc_proto_library(
+    name = "edges_cc_proto",
+    visibility = ["//visibility:public"],
+    deps = ["edges_proto"],
+)
+
+proto_library(
+    name = "edges_proto",
+    srcs = ["edges.proto"],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ]
+)
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_cc_test",
+)
+
+envoy_cc_library(
+    name = "mesh_edges_service_client",
+    srcs = [
+        "mesh_edges_service_client.cc",
+    ],
+    hdrs = [
+        "mesh_edges_service_client.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":edges_cc_proto",
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
+        "//extensions/common:context",
+    ]
+)
+
+envoy_cc_library(
+    name = "edge_reporter",
+    srcs = [
+        "edge_reporter.cc",
+    ],
+    hdrs = [
+        "edge_reporter.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":edges_cc_proto",
+        ":mesh_edges_service_client",
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
+        "//extensions/common:context",
+        "//extensions/stackdriver/common:constants",
+    ]
+)
+
+envoy_cc_test(
+    name = "edge_reporter_test",
+    size = "small",
+    srcs = ["edge_reporter_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":edge_reporter",
+        "@envoy//source/extensions/common/wasm:wasm_lib",
+    ],
+)

--- a/extensions/stackdriver/edges/TODO
+++ b/extensions/stackdriver/edges/TODO
@@ -1,6 +1,5 @@
 (P0) Figure out mesh_uid data source
 (P0) Integration test for grpc endpoint
-(P1) Caching / don't report the same edge repeatedly
 (P1) Retries
 (P1) Better debugging / monitoring (exported metrics)
 (P1) WASM bits

--- a/extensions/stackdriver/edges/TODO
+++ b/extensions/stackdriver/edges/TODO
@@ -1,0 +1,8 @@
+(P0) Figure out mesh_uid data source
+(P0) Integration test for grpc endpoint
+(P1) Caching / don't report the same edge repeatedly
+(P1) Retries
+(P1) Better debugging / monitoring (exported metrics)
+(P1) WASM bits
+(P2) Support for other platforms / error handling when not on GCP
+(P3) Refactoring / alignment with other Stackdriver extension components

--- a/extensions/stackdriver/edges/TODO
+++ b/extensions/stackdriver/edges/TODO
@@ -1,4 +1,3 @@
-(P0) Figure out mesh_uid data source
 (P0) Integration test for grpc endpoint
 (P1) Destination service shortname (as opposed to host)
 (P1) Retries

--- a/extensions/stackdriver/edges/TODO
+++ b/extensions/stackdriver/edges/TODO
@@ -1,5 +1,6 @@
 (P0) Figure out mesh_uid data source
 (P0) Integration test for grpc endpoint
+(P1) Destination service shortname (as opposed to host)
 (P1) Retries
 (P1) Better debugging / monitoring (exported metrics)
 (P1) WASM bits

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -56,7 +56,7 @@ std::unique_ptr<WorkloadInstance> instanceFromMetadata(
   instance->set_owner_uid(node_info.owner());
   instance->set_workload_name(node_info.workload_name());
   instance->set_workload_namespace(node_info.namespace_());
-  return std::move(instance);
+  return instance;
 };
 
 EdgeReporter::EdgeReporter(

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -42,9 +42,8 @@ using google::cloud::meshtelemetry::v1alpha1::
 using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 using google::protobuf::util::TimeUtil;
 
-std::unique_ptr<WorkloadInstance> instanceFromMetadata(
-    const ::wasm::common::NodeInfo& node_info) {
-  auto instance = std::make_unique<WorkloadInstance>();
+void instanceFromMetadata(const ::wasm::common::NodeInfo& node_info,
+                          WorkloadInstance* instance) {
   // TODO(douglas-reid): support more than just kubernetes instances
   instance->set_uid("kubernetes://" + node_info.name() + "." +
                     node_info.namespace_());
@@ -56,7 +55,7 @@ std::unique_ptr<WorkloadInstance> instanceFromMetadata(
   instance->set_owner_uid(node_info.owner());
   instance->set_workload_name(node_info.workload_name());
   instance->set_workload_namespace(node_info.namespace_());
-  return instance;
+  return;
 };
 
 EdgeReporter::EdgeReporter(
@@ -80,20 +79,34 @@ EdgeReporter::EdgeReporter(
       "//cloudresourcemanager.googleapis.com/projects/" + project_id + "/" +
       location + "/meshes/" + cluster);
 
-  node_instance_ = instanceFromMetadata(local_node_info);
+  node_instance_ = std::make_unique<WorkloadInstance>();
+  instanceFromMetadata(local_node_info, node_instance_.get());
 
   edges_client_ = std::move(edges_client);
 };
 
+std::string nodeKey(const ::wasm::common::NodeInfo& node_info) {
+  return node_info.name() + "." + node_info.namespace_();
+}
+
 // ONLY inbound
 void EdgeReporter::addEdge(const ::Wasm::Common::RequestInfo& request_info,
                            const ::wasm::common::NodeInfo& peer_node_info) {
+  std::string key = nodeKey(peer_node_info);
+  {
+    std::lock_guard<std::mutex> lock(request_mutex_);
+    auto peer = current_peers_.find(key);
+    if (peer != current_peers_.end()) {
+      return;
+    }
+    current_peers_.emplace(key, true);
+  }
   auto* traffic_assertions = current_request_->mutable_traffic_assertions();
   auto* edge = traffic_assertions->Add();
 
   edge->set_destination_service_name(request_info.destination_service_host);
   edge->set_destination_service_namespace(node_instance_->workload_namespace());
-  edge->mutable_source()->CopyFrom(*instanceFromMetadata(peer_node_info).get());
+  instanceFromMetadata(peer_node_info, edge->mutable_source());
   edge->mutable_destination()->CopyFrom(*node_instance_.get());
 
   auto protocol = request_info.request_protocol;
@@ -111,7 +124,7 @@ void EdgeReporter::addEdge(const ::Wasm::Common::RequestInfo& request_info,
       max_assertions_per_request_) {
     flush();
   }
-};
+};  // namespace Edges
 
 void EdgeReporter::reportEdges() {
   flush();
@@ -131,6 +144,8 @@ void EdgeReporter::flush() {
   next->set_parent(current_request_->parent());
   next->set_mesh_uid(current_request_->mesh_uid());
 
+  std::lock_guard<std::mutex> lock(request_mutex_);
+  current_peers_.clear();
   current_request_.swap(next);
   *next->mutable_timestamp() = TimeUtil::GetCurrentTime();
   request_queue_.emplace_back(std::move(next));

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -68,16 +68,13 @@ EdgeReporter::EdgeReporter(const ::wasm::common::NodeInfo& local_node_info,
       local_node_info.platform_metadata().at(Common::kGCPProjectKey);
   current_request_->set_parent("projects/" + project_id);
 
-  // TODO(dougreid): figure out how to get the real mesh uid here.
-  // Using: //.../projects/<project_id>/<location>/meshes/<cluster> as a
-  // placeholder.
-  std::string location =
-      local_node_info.platform_metadata().at(Common::kGCPClusterLocationKey);
-  std::string cluster =
-      local_node_info.platform_metadata().at(Common::kGCPClusterNameKey);
+  std::string mesh_id = local_node_info.mesh_id();
+  if (mesh_id.empty()) {
+    mesh_id = "unknown";
+  }
   absl::StrAppend(current_request_->mutable_mesh_uid(),
                   "//cloudresourcemanager.googleapis.com/projects/", project_id,
-                  "/", location, "/meshes/", cluster);
+                  "/meshes/", mesh_id);
 
   instanceFromMetadata(local_node_info, &node_instance_);
 };

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -1,0 +1,141 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/stackdriver/edges/edge_reporter.h"
+
+#include "extensions/stackdriver/common/constants.h"
+#include "extensions/stackdriver/edges/edges.pb.h"
+#include "google/protobuf/util/time_util.h"
+
+#ifndef NULL_PLUGIN
+#include "api/wasm/cpp/proxy_wasm_intrinsics.h"
+#else
+#include "extensions/common/wasm/null/null_plugin.h"
+#endif
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Edges {
+
+using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
+using google::cloud::meshtelemetry::v1alpha1::TrafficAssertion;
+using google::cloud::meshtelemetry::v1alpha1::
+    TrafficAssertion_Protocol_PROTOCOL_GRPC;
+using google::cloud::meshtelemetry::v1alpha1::
+    TrafficAssertion_Protocol_PROTOCOL_HTTP;
+using google::cloud::meshtelemetry::v1alpha1::
+    TrafficAssertion_Protocol_PROTOCOL_HTTPS;
+using google::cloud::meshtelemetry::v1alpha1::
+    TrafficAssertion_Protocol_PROTOCOL_TCP;
+using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
+using google::protobuf::util::TimeUtil;
+
+std::unique_ptr<WorkloadInstance> instanceFromMetadata(
+    const ::wasm::common::NodeInfo& node_info) {
+  auto instance = std::make_unique<WorkloadInstance>();
+  // TODO(douglas-reid): support more than just kubernetes instances
+  instance->set_uid("kubernetes://" + node_info.name() + "." +
+                    node_info.namespace_());
+  // TODO(douglas-reid): support more than just GCP ?
+  instance->set_location(
+      node_info.platform_metadata().at(Common::kGCPClusterLocationKey));
+  instance->set_cluster_name(
+      node_info.platform_metadata().at(Common::kGCPClusterNameKey));
+  instance->set_owner_uid(node_info.owner());
+  instance->set_workload_name(node_info.workload_name());
+  instance->set_workload_namespace(node_info.namespace_());
+  return std::move(instance);
+};
+
+EdgeReporter::EdgeReporter(
+    const ::wasm::common::NodeInfo& local_node_info,
+    std::unique_ptr<MeshEdgesServiceClient> edges_client) {
+  current_request_ = std::make_unique<ReportTrafficAssertionsRequest>();
+
+  const auto& project_id =
+      local_node_info.platform_metadata().at(Common::kGCPProjectKey);
+  current_request_->set_parent("projects/" + project_id);
+
+  // TODO(dougreid): figure out how to get the real mesh uid here.
+  // Using: //.../projects/<project_id>/<location>/meshes/<cluster> as a
+  // placeholder.
+  std::string location =
+      local_node_info.platform_metadata().at(Common::kGCPClusterLocationKey);
+  std::string cluster =
+      local_node_info.platform_metadata().at(Common::kGCPClusterNameKey);
+  std::string mesh_uid = "unknown";
+  current_request_->set_mesh_uid(
+      "//cloudresourcemanager.googleapis.com/projects/" + project_id + "/" +
+      location + "/meshes/" + cluster);
+
+  node_instance_ = instanceFromMetadata(local_node_info);
+
+  edges_client_ = std::move(edges_client);
+};
+
+// ONLY inbound
+void EdgeReporter::addEdge(const ::Wasm::Common::RequestInfo& request_info,
+                           const ::wasm::common::NodeInfo& peer_node_info) {
+  auto* traffic_assertions = current_request_->mutable_traffic_assertions();
+  auto* edge = traffic_assertions->Add();
+
+  edge->set_destination_service_name(request_info.destination_service_host);
+  edge->set_destination_service_namespace(node_instance_->workload_namespace());
+  edge->mutable_source()->CopyFrom(*instanceFromMetadata(peer_node_info).get());
+  edge->mutable_destination()->CopyFrom(*node_instance_.get());
+
+  auto protocol = request_info.request_protocol;
+  if (protocol == "http" || protocol == "HTTP") {
+    edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_HTTP);
+  } else if (protocol == "https" || protocol == "HTTPS") {
+    edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_HTTPS);
+  } else if (protocol == "grpc" || protocol == "GRPC") {
+    edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_GRPC);
+  } else {
+    edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_TCP);
+  }
+
+  if (current_request_->traffic_assertions_size() >
+      max_assertions_per_request_) {
+    flush();
+  }
+};
+
+void EdgeReporter::reportEdges() {
+  flush();
+  for (auto& req : request_queue_) {
+    edges_client_->reportTrafficAssertions(std::move(req));
+  }
+  request_queue_.clear();
+}
+
+void EdgeReporter::flush() {
+  if (current_request_->traffic_assertions_size() == 0) {
+    return;
+  }
+
+  std::unique_ptr<ReportTrafficAssertionsRequest> next =
+      std::make_unique<ReportTrafficAssertionsRequest>();
+  next->set_parent(current_request_->parent());
+  next->set_mesh_uid(current_request_->mesh_uid());
+
+  current_request_.swap(next);
+  *next->mutable_timestamp() = TimeUtil::GetCurrentTime();
+  request_queue_.emplace_back(std::move(next));
+}
+
+}  // namespace Edges
+}  // namespace Stackdriver
+}  // namespace Extensions

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -38,6 +38,8 @@ using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 // "edges" for a mesh. It should be used **only** to document incoming edges for
 // a proxy. This means that the proxy in which this reporter is running should
 // be the destination workload instance for all reported traffic.
+// This should only be used in a single-threaded context. No support for
+// threading is currently provided.
 class EdgeReporter {
  public:
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
@@ -60,7 +62,7 @@ class EdgeReporter {
   void flush();
 
   // represents the workload instance for the current proxy
-  std::unique_ptr<WorkloadInstance> node_instance_;
+  WorkloadInstance node_instance_;
 
   // the active pending request to which edges are being added
   std::unique_ptr<ReportTrafficAssertionsRequest> current_request_;
@@ -71,11 +73,8 @@ class EdgeReporter {
   // client used to send requests to the edges service
   std::unique_ptr<MeshEdgesServiceClient> edges_client_;
 
-  // map of current peers for which edges have been created in the
-  // current_request_;
-  std::map<std::string, bool> current_peers_;
-
-  std::mutex request_mutex_;
+  // current peers for which edges have been created in current_request_;
+  std::set<std::string> current_peers_;
 
   // TODO(douglas-reid): make adjustable.
   const int max_assertions_per_request_ = 1000;

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -1,0 +1,80 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "extensions/common/context.h"
+#include "extensions/stackdriver/edges/edges.pb.h"
+#include "extensions/stackdriver/edges/mesh_edges_service_client.h"
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Edges {
+
+#ifdef NULL_PLUGIN
+using Envoy::Extensions::Common::Wasm::Null::Plugin::Extensions::Stackdriver::
+    Edges::MeshEdgesServiceClient;
+#endif
+
+using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
+using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
+
+// EdgeReporter provides a mechanism for generating information on traffic
+// "edges" for a mesh. It should be used **only** to document incoming edges for
+// a proxy. This means that the proxy in which this reporter is running should
+// be the destination workload instance for all reported traffic.
+class EdgeReporter {
+ public:
+  EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
+               std::unique_ptr<MeshEdgesServiceClient> edges_client);
+
+  // addEdge creates a traffic assertion (aka an edge) based on the
+  // the supplied request / peer info. The new edge is added to the
+  // pending request that will be sent with all generated edges.
+  void addEdge(const ::Wasm::Common::RequestInfo &request_info,
+               const ::wasm::common::NodeInfo &peer_node_info);
+
+  // reportEdges sends the buffered requests to the configured edges
+  // service via the supplied client.
+  void reportEdges();
+
+ private:
+  // flush pushes the current pending request (iff there have been
+  // edges added) into the request buffer, and swaps in a new request
+  // to gather additional edges.
+  void flush();
+
+  // represents the workload instance for the current proxy
+  std::unique_ptr<WorkloadInstance> node_instance_;
+
+  // the active pending request to which edges are being added
+  std::unique_ptr<ReportTrafficAssertionsRequest> current_request_;
+
+  // the buffer of pending requests, awaiting transmission to the edges service
+  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> request_queue_;
+
+  // client used to send requests to the edges service
+  std::unique_ptr<MeshEdgesServiceClient> edges_client_;
+
+  // TODO(douglas-reid): make adjustable.
+  const int max_assertions_per_request_ = 1000;
+};
+
+}  // namespace Edges
+}  // namespace Stackdriver
+}  // namespace Extensions

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -37,12 +37,6 @@ using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
 using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 using google::protobuf::util::TimeUtil;
 
-namespace {
-static inline google::protobuf::Timestamp wasmTimestamp() {
-  return TimeUtil::NanosecondsToTimestamp(getCurrentTimeNanoseconds());
-}
-}  // namespace
-
 // EdgeReporter provides a mechanism for generating information on traffic
 // "edges" for a mesh. It should be used **only** to document incoming edges for
 // a proxy. This means that the proxy in which this reporter is running should
@@ -54,8 +48,11 @@ class EdgeReporter {
 
  public:
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
+               std::unique_ptr<MeshEdgesServiceClient> edges_client);
+
+  EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
                std::unique_ptr<MeshEdgesServiceClient> edges_client,
-               TimestampFn now = wasmTimestamp);
+               TimestampFn now);
 
   ~EdgeReporter();  // this will call `reportEdges`
 
@@ -63,7 +60,7 @@ class EdgeReporter {
   // the supplied request / peer info. The new edge is added to the
   // pending request that will be sent with all generated edges.
   void addEdge(const ::Wasm::Common::RequestInfo &request_info,
-               const std::string peer_metadata_id_key,
+               const std::string &peer_metadata_id_key,
                const ::wasm::common::NodeInfo &peer_node_info);
 
   // reportEdges sends the buffered requests to the configured edges

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -38,7 +38,7 @@ using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 using google::protobuf::util::TimeUtil;
 
 namespace {
-google::protobuf::Timestamp wasmTimestamp() {
+static inline google::protobuf::Timestamp wasmTimestamp() {
   return TimeUtil::NanosecondsToTimestamp(getCurrentTimeNanoseconds());
 }
 }  // namespace

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -71,6 +71,12 @@ class EdgeReporter {
   // client used to send requests to the edges service
   std::unique_ptr<MeshEdgesServiceClient> edges_client_;
 
+  // map of current peers for which edges have been created in the
+  // current_request_;
+  std::map<std::string, bool> current_peers_;
+
+  std::mutex request_mutex_;
+
   // TODO(douglas-reid): make adjustable.
   const int max_assertions_per_request_ = 1000;
 };

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -68,6 +68,10 @@ class EdgeReporter {
   void reportEdges();
 
  private:
+  // builds a full request out of the current traffic assertions (edges),
+  // adds that request to the queue, and resets the current request and state.
+  void flush();
+
   // client used to send requests to the edges service
   std::unique_ptr<MeshEdgesServiceClient> edges_client_;
 
@@ -82,6 +86,9 @@ class EdgeReporter {
 
   // current peers for which edges have been created in current_request_;
   std::unordered_set<std::string> current_peers_;
+
+  // requests waiting to be sent to backend
+  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> queued_requests_;
 
   // TODO(douglas-reid): make adjustable.
   const int max_assertions_per_request_ = 1000;

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -1,0 +1,190 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/stackdriver/edges/edge_reporter.h"
+
+#include <memory>
+
+#include "extensions/stackdriver/common/constants.h"
+#include "google/protobuf/text_format.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Edges {
+
+using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
+using google::protobuf::util::MessageDifferencer;
+
+namespace {
+
+#define EXPECT_PROTO_EQUAL(want, got, message)   \
+  std::string diff;                              \
+  MessageDifferencer differ;                     \
+  differ.ReportDifferencesToString(&diff);       \
+  bool equal = differ.Compare(want, got);        \
+  if (!equal) {                                  \
+    std::cerr << message << " " << diff << "\n"; \
+    FAIL();                                      \
+  }                                              \
+  return
+
+std::unique_ptr<ReportTrafficAssertionsRequest> last_request_;
+
+class TestMeshEdgesServiceClient : public MeshEdgesServiceClient {
+ public:
+  typedef std::function<void(std::unique_ptr<ReportTrafficAssertionsRequest>)>
+      TestFn;
+
+  TestMeshEdgesServiceClient(TestFn test_func)
+      : request_callback_(std::move(test_func)){};
+
+  virtual void reportTrafficAssertions(
+      std::unique_ptr<ReportTrafficAssertionsRequest> request) const override {
+    request_callback_(std::move(request));
+  };
+
+ private:
+  TestFn request_callback_;
+};
+
+wasm::common::NodeInfo nodeInfo() {
+  wasm::common::NodeInfo node_info;
+  (*node_info.mutable_platform_metadata())[Common::kGCPProjectKey] =
+      "test_project";
+  (*node_info.mutable_platform_metadata())[Common::kGCPClusterNameKey] =
+      "test_cluster";
+  (*node_info.mutable_platform_metadata())[Common::kGCPClusterLocationKey] =
+      "test_location";
+  node_info.set_namespace_("test_namespace");
+  node_info.set_name("test_pod");
+  node_info.set_workload_name("test_workload");
+  node_info.set_owner("kubernetes://test_owner");
+  return node_info;
+}
+
+wasm::common::NodeInfo peerNodeInfo() {
+  wasm::common::NodeInfo node_info;
+  (*node_info.mutable_platform_metadata())[Common::kGCPProjectKey] =
+      "test_project";
+  (*node_info.mutable_platform_metadata())[Common::kGCPClusterNameKey] =
+      "test_cluster";
+  (*node_info.mutable_platform_metadata())[Common::kGCPClusterLocationKey] =
+      "test_location";
+  node_info.set_namespace_("test_peer_namespace");
+  node_info.set_name("test_peer_pod");
+  node_info.set_workload_name("test_peer_workload");
+  node_info.set_owner("kubernetes://peer_owner");
+  return node_info;
+}
+
+::Wasm::Common::RequestInfo requestInfo() {
+  ::Wasm::Common::RequestInfo request_info;
+  request_info.destination_service_host = "httpbin.org";
+  request_info.request_protocol = "HTTP";
+  return request_info;
+}
+
+std::unique_ptr<ReportTrafficAssertionsRequest> want() {
+  auto request_info = requestInfo();
+  auto peer_node_info = peerNodeInfo();
+  auto node_info = nodeInfo();
+
+  auto req = std::make_unique<ReportTrafficAssertionsRequest>();
+  req->set_parent("projects/test_project");
+  req->set_mesh_uid(
+      "//cloudresourcemanager.googleapis.com/projects/test_project/"
+      "test_location/meshes/test_cluster");
+
+  auto* ta = req->mutable_traffic_assertions()->Add();
+  ta->set_protocol(google::cloud::meshtelemetry::v1alpha1::
+                       TrafficAssertion_Protocol_PROTOCOL_HTTP);
+  ta->set_destination_service_name("httpbin.org");
+  ta->set_destination_service_namespace("test_namespace");
+
+  auto* source = ta->mutable_source();
+  source->set_workload_namespace("test_peer_namespace");
+  source->set_workload_name("test_peer_workload");
+  source->set_cluster_name("test_cluster");
+  source->set_location("test_location");
+  source->set_owner_uid("kubernetes://peer_owner");
+  source->set_uid("kubernetes://test_peer_pod.test_peer_namespace");
+
+  auto destination = ta->mutable_destination();
+  destination->set_workload_namespace("test_namespace");
+  destination->set_workload_name("test_workload");
+  destination->set_cluster_name("test_cluster");
+  destination->set_location("test_location");
+  destination->set_owner_uid("kubernetes://test_owner");
+  destination->set_uid("kubernetes://test_pod.test_namespace");
+
+  return std::move(req);
+}
+
+}  // namespace
+
+TEST(EdgesTest, TestAddEdge) {
+  int calls = 0;
+  std::unique_ptr<ReportTrafficAssertionsRequest> got;
+
+  auto test_client = std::make_unique<TestMeshEdgesServiceClient>(
+      [&calls, &got](std::unique_ptr<ReportTrafficAssertionsRequest> request) {
+        calls++;
+        got = std::move(request);
+      });
+
+  auto edges =
+      std::make_unique<EdgeReporter>(nodeInfo(), std::move(test_client));
+  edges->addEdge(requestInfo(), peerNodeInfo());
+  edges->reportEdges();
+
+  // must ensure that we used the client to report the edges
+  EXPECT_EQ(1, calls);
+
+  // ignore timestamps in proto comparisons.
+  got->set_allocated_timestamp(nullptr);
+
+  EXPECT_PROTO_EQUAL(*want().get(), *got.get(),
+                     "ERROR: addEdge() produced unexpected result.");
+}
+
+TEST(EdgeReporterTest, TestRequestQueue) {
+  int calls = 0;
+  int num_assertions = 0;
+
+  auto test_client = std::make_unique<TestMeshEdgesServiceClient>(
+      [&calls, &num_assertions](
+          std::unique_ptr<ReportTrafficAssertionsRequest> request) {
+        calls++;
+        num_assertions += request->traffic_assertions_size();
+      });
+
+  auto edges =
+      std::make_unique<EdgeReporter>(nodeInfo(), std::move(test_client));
+
+  // force at least three queued reqs + current (four total)
+  for (int i = 0; i < 3500; i++) {
+    edges->addEdge(requestInfo(), peerNodeInfo());
+  }
+  edges->reportEdges();
+
+  EXPECT_EQ(4, calls);
+  EXPECT_EQ(3500, num_assertions);
+}
+
+}  // namespace Edges
+}  // namespace Stackdriver
+}  // namespace Extensions

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -131,11 +131,9 @@ wasm::common::NodeInfo nodeInfo() {
   return node_info;
 }
 
-wasm::common::NodeInfo peerNodeInfo(std::string name_suffix = "") {
+wasm::common::NodeInfo peerNodeInfo() {
   wasm::common::NodeInfo node_info;
   TextFormat::ParseFromString(kPeerInfo, &node_info);
-  node_info.set_name(node_info.name() + name_suffix);
-  node_info.set_node_key(node_info.name() + "." + node_info.namespace_());
   return node_info;
 }
 
@@ -166,7 +164,7 @@ TEST(EdgesTest, TestAddEdge) {
 
   auto edges = std::make_unique<EdgeReporter>(
       nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
-  edges->addEdge(requestInfo(), peerNodeInfo());
+  edges->addEdge(requestInfo(), "test", peerNodeInfo());
   edges->reportEdges();
 
   // must ensure that we used the client to report the edges
@@ -194,7 +192,7 @@ TEST(EdgeReporterTest, TestRequestEdgeCache) {
 
   // force at least three queued reqs + current (four total)
   for (int i = 0; i < 3500; i++) {
-    edges->addEdge(requestInfo(), peerNodeInfo());
+    edges->addEdge(requestInfo(), "test", peerNodeInfo());
   }
   edges->reportEdges();
 
@@ -219,7 +217,7 @@ TEST(EdgeReporterTest, TestPeriodicFlushAndCacheReset) {
 
   // force at least three queued reqs + current (four total)
   for (int i = 0; i < 3500; i++) {
-    edges->addEdge(requestInfo(), peerNodeInfo());
+    edges->addEdge(requestInfo(), "test", peerNodeInfo());
     // flush on 1000, 2000, 3000
     if (i % 1000 == 0 && i > 0) {
       edges->reportEdges();
@@ -248,7 +246,7 @@ TEST(EdgeReporterTest, TestCacheMisses) {
 
   // force at least three queued reqs + current (four total)
   for (int i = 0; i < 3500; i++) {
-    edges->addEdge(requestInfo(), peerNodeInfo(std::to_string(i)));
+    edges->addEdge(requestInfo(), std::to_string(i), peerNodeInfo());
   }
   edges->reportEdges();
 

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -131,7 +131,7 @@ std::unique_ptr<ReportTrafficAssertionsRequest> want() {
   destination->set_owner_uid("kubernetes://test_owner");
   destination->set_uid("kubernetes://test_pod.test_namespace");
 
-  return std::move(req);
+  return req;
 }
 
 }  // namespace

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -78,6 +78,7 @@ const char kNodeInfo[] = R"(
     key: "gcp_cluster_location"
     value: "test_location"
   }
+  mesh_id: "test-mesh"
 )";
 
 const char kPeerInfo[] = R"(
@@ -97,11 +98,12 @@ const char kPeerInfo[] = R"(
     key: "gcp_cluster_location"
     value: "test_location"
   }
+  mesh_id: "test-mesh"
 )";
 
 const char kWantGrpcRequest[] = R"(
   parent: "projects/test_project"
-  mesh_uid: "//cloudresourcemanager.googleapis.com/projects/test_project/test_location/meshes/test_cluster"
+  mesh_uid: "//cloudresourcemanager.googleapis.com/projects/test_project/meshes/test-mesh"
   traffic_assertions: {
     protocol: PROTOCOL_HTTP
     destination_service_name: "httpbin.org"

--- a/extensions/stackdriver/edges/edges.proto
+++ b/extensions/stackdriver/edges/edges.proto
@@ -1,0 +1,122 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package google.cloud.meshtelemetry.v1alpha1;
+
+import "google/protobuf/timestamp.proto";
+
+// MeshEdgesService enables publishing information on relationships between
+// monitored resources within a mesh.
+service MeshEdgesService {
+  // ReportTrafficAssertions publishes information on the set of communications
+  // between WorkloadInstances within a service mesh.
+  rpc ReportTrafficAssertions(ReportTrafficAssertionsRequest)
+      returns (ReportTrafficAssertionsResponse) {}
+}
+
+// ReportTrafficAssertionsRequest supports sending information on observed mesh
+// traffic.
+message ReportTrafficAssertionsRequest {
+  // Full resource name for the GCP project (projects/<project number>) for the
+  // mesh in which the TrafficAssertions are being made.
+  // Example: projects/234234324
+  string parent = 1;
+
+  // Unique identifier for the mesh in which the TrafficAssertions are being
+  // made.
+  // Example:
+  // //cloudresourcemanager.googleapis.com/projects/<project>/meshes/<mesh>
+  string mesh_uid = 2;
+
+  // These represent observed traffic between two WorkloadInstances in a mesh.
+  repeated TrafficAssertion traffic_assertions = 3;
+
+  // Records the observed time of the traffic represented in this request.
+  google.protobuf.Timestamp timestamp = 4;
+}
+
+message ReportTrafficAssertionsResponse {}
+
+// A single instantiation of a workload’s binary. WorkloadInstances can expose
+// zero or more service endpoints, and can consume zero or more services.
+// A WorkloadInstance is typically a pod in a kubernetes cluster. An individual
+// virtual machine (VM) would also be represented as a WorkloadInstance.
+// See also: https://istio.io/docs/reference/glossary/#workload-instance
+message WorkloadInstance {
+  // Unique identifier for the resource.
+  // Example: kubernetes://<pod name>.<namespace>
+  string uid = 1;
+
+  // Location name for the cluster in which the resource is running.
+  // Example: us-central1
+  string location = 2;
+
+  // Name of the cluster in which the resource is running.
+  // Example: service-mesh-demo-1
+  string cluster_name = 3;
+
+  // Unique identifier for the owning resource of the monitored resource. This
+  // is typically a kubernetes deployment UID.
+  // Example: kubernetes://apis/apps/v1/namespaces/default/deployments/test
+  string owner_uid = 4;
+
+  // Name of the workload of which this resource is an instance. This is
+  // typically the short name for the owning kubernetes deployment.
+  // Example: test
+  string workload_name = 5;
+
+  // Namespace in which the monitored resource is deployed.
+  // Example: default
+  string workload_namespace = 6;
+}
+
+// Represents an observed communication between two WorkloadInstances within
+// a mesh.
+message TrafficAssertion {
+  // The WorkloadInstance that initiates the communication (sometimes referred
+  // to as a client).
+  WorkloadInstance source = 1;
+
+  // The WorkloadInstance that is the target of the communication (sometimes
+  // referred to as a server).
+  WorkloadInstance destination = 2;
+
+  // Protocol covers the set of protocols capable of being reported for
+  // mesh traffic.
+  enum Protocol {
+    // Use when protocol is unknown.
+    PROTOCOL_UNSPECIFIED = 0;
+    // HTTP communication.
+    PROTOCOL_HTTP = 1;
+    // HTTPS communication.
+    PROTOCOL_HTTPS = 2;
+    // TCP communication. A large number of protocols (mongo, etc.) are
+    // treated as TCP traffic.
+    PROTOCOL_TCP = 3;
+    // GRPC communication.
+    PROTOCOL_GRPC = 4;
+  }
+
+  // The protocol over which the communication occurred.
+  Protocol protocol = 3;
+
+  // The short name of the destination service, if known.
+  string destination_service_name = 4;
+
+  // The namespace of the destination service, if known.
+  string destination_service_namespace = 5;
+}

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -29,7 +29,7 @@ namespace Plugin {
 using envoy::api::v2::core::GrpcService;
 using Envoy::Extensions::Common::Wasm::Null::Plugin::GrpcStatus;
 using Envoy::Extensions::Common::Wasm::Null::Plugin::logDebug;
-using Envoy::Extensions::Common::Wasm::Null::Plugin::logInfo;
+using Envoy::Extensions::Common::Wasm::Null::Plugin::logWarn;
 using Envoy::Extensions::Common::Wasm::Null::Plugin::StringView;
 #endif
 

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -85,9 +85,9 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
 };
 
 void MeshEdgesServiceClientImpl::reportTrafficAssertions(
-    std::unique_ptr<ReportTrafficAssertionsRequest> request) const {
+    const ReportTrafficAssertionsRequest& request) const {
   context_->grpcSimpleCall(
-      grpc_service_, kMeshEdgesService, kReportTrafficAssertions, *request,
+      grpc_service_, kMeshEdgesService, kReportTrafficAssertions, request,
       kDefaultTimeoutMillisecond, success_callback_, failure_callback_);
 };
 

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -1,0 +1,105 @@
+
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/stackdriver/edges/mesh_edges_service_client.h"
+
+#include "google/protobuf/util/time_util.h"
+
+#ifdef NULL_PLUGIN
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace Wasm {
+namespace Null {
+namespace Plugin {
+
+using envoy::api::v2::core::GrpcService;
+using Envoy::Extensions::Common::Wasm::Null::Plugin::GrpcStatus;
+using Envoy::Extensions::Common::Wasm::Null::Plugin::logDebug;
+using Envoy::Extensions::Common::Wasm::Null::Plugin::logInfo;
+using Envoy::Extensions::Common::Wasm::Null::Plugin::StringView;
+#endif
+
+// TODO(douglas-reid): confirm values here
+constexpr char kMeshTelemetryService[] = "meshtelemetry.googleapis.com";
+constexpr char kMeshEdgesService[] =
+    "google.cloud.meshtelemetry.v1alpha1.MeshEdgesService";
+constexpr char kReportTrafficAssertions[] = "ReportTrafficAssertions";
+constexpr char kDefaultRootCertFile[] = "/etc/ssl/certs/ca-certificates.crt";
+constexpr int kDefaultTimeoutMillisecond = 10000;  // 10 seconds
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Edges {
+
+using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
+using google::protobuf::util::TimeUtil;
+
+MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
+    RootContext* root_context, std::string edges_endpoint)
+    : context_(root_context) {
+  success_callback_ = [](google::protobuf::Empty&&) {
+    // TODO(douglas-reid): improve logging message.
+    logDebug(
+        "successfully sent MeshEdgesService ReportTrafficAssertionsRequest");
+  };
+
+  failure_callback_ = [](GrpcStatus status, StringView message) {
+    // TODO(douglas-reid): add retry (and other) logic
+    logWarn("MeshEdgesService ReportTrafficAssertionsRequest failure: " +
+            std::to_string(static_cast<int>(status)) + " " +
+            std::string(message));
+  };
+
+  GrpcService grpc_service;
+  if (edges_endpoint.empty()) {
+    // use application default creds and default target
+    grpc_service.mutable_google_grpc()->set_target_uri(kMeshTelemetryService);
+    grpc_service.mutable_google_grpc()
+        ->add_call_credentials()
+        ->mutable_google_compute_engine();
+    grpc_service.mutable_google_grpc()
+        ->mutable_channel_credentials()
+        ->mutable_ssl_credentials()
+        ->mutable_root_certs()
+        ->set_filename(kDefaultRootCertFile);
+  } else {
+    // no creds attached
+    grpc_service.mutable_google_grpc()->set_target_uri(edges_endpoint);
+  }
+
+  grpc_service.SerializeToString(&grpc_service_);
+};
+
+void MeshEdgesServiceClientImpl::reportTrafficAssertions(
+    std::unique_ptr<ReportTrafficAssertionsRequest> request) const {
+  context_->grpcSimpleCall(
+      grpc_service_, kMeshEdgesService, kReportTrafficAssertions, *request,
+      kDefaultTimeoutMillisecond, success_callback_, failure_callback_);
+};
+
+}  // namespace Edges
+}  // namespace Stackdriver
+}  // namespace Extensions
+
+#ifdef NULL_PLUGIN
+}  // namespace plugin
+}  // namespace null
+}  // namespace wasm
+}  // namespace common
+}  // namespace extensions
+}  // namespace envoy
+#endif

--- a/extensions/stackdriver/edges/mesh_edges_service_client.h
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.h
@@ -1,0 +1,88 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "extensions/stackdriver/edges/edges.pb.h"
+
+#ifndef NULL_PLUGIN
+#include "api/wasm/cpp/proxy_wasm_intrinsics.h"
+#else
+
+#include "extensions/common/wasm/null/null_plugin.h"
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace Wasm {
+namespace Null {
+namespace Plugin {
+
+#endif
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Edges {
+
+using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
+
+// MeshEdgesServiceClient provides a client interface for comms with an edges
+// service (defined in edges.proto).
+class MeshEdgesServiceClient {
+ public:
+  virtual ~MeshEdgesServiceClient() {}
+
+  // reportTrafficAssertions handles invoking the `ReportTrafficAssertions` rpc.
+  virtual void reportTrafficAssertions(
+      std::unique_ptr<ReportTrafficAssertionsRequest> request) const = 0;
+};
+
+// MeshEdgesServiceClientImpl provides a gRPC implementation of the client
+// interface. By default, it will write the meshtelemetry backend provided
+// by Stackdriver, using application default credentials.
+class MeshEdgesServiceClientImpl : public MeshEdgesServiceClient {
+ public:
+  // root_context is the wasm runtime context
+  // edges_endpoint is an optional param used to specify alternative service
+  // address.
+  MeshEdgesServiceClientImpl(RootContext* root_context,
+                             std::string edges_endpoint);
+
+  virtual void reportTrafficAssertions(
+      std::unique_ptr<ReportTrafficAssertionsRequest> request) const override;
+
+ private:
+  // Provides the VM context for making calls.
+  RootContext* context_ = nullptr;
+
+  // edges service endpoint.
+  std::string grpc_service_;
+
+  // callbacks for the client
+  std::function<void(google::protobuf::Empty&&)> success_callback_;
+  std::function<void(GrpcStatus, StringView)> failure_callback_;
+};
+
+}  // namespace Edges
+}  // namespace Stackdriver
+}  // namespace Extensions
+
+#ifdef NULL_PLUGIN
+}  // namespace plugin
+}  // namespace null
+}  // namespace wasm
+}  // namespace common
+}  // namespace extensions
+}  // namespace envoy
+#endif

--- a/extensions/stackdriver/edges/mesh_edges_service_client.h
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.h
@@ -45,7 +45,7 @@ class MeshEdgesServiceClient {
 
   // reportTrafficAssertions handles invoking the `ReportTrafficAssertions` rpc.
   virtual void reportTrafficAssertions(
-      std::unique_ptr<ReportTrafficAssertionsRequest> request) const = 0;
+      const ReportTrafficAssertionsRequest& request) const = 0;
 };
 
 // MeshEdgesServiceClientImpl provides a gRPC implementation of the client
@@ -59,8 +59,8 @@ class MeshEdgesServiceClientImpl : public MeshEdgesServiceClient {
   MeshEdgesServiceClientImpl(RootContext* root_context,
                              std::string edges_endpoint);
 
-  virtual void reportTrafficAssertions(
-      std::unique_ptr<ReportTrafficAssertionsRequest> request) const override;
+  void reportTrafficAssertions(
+      const ReportTrafficAssertionsRequest& request) const override;
 
  private:
   // Provides the VM context for making calls.


### PR DESCRIPTION
This PR establishes an initial set of functionality for reporting traffic edges via the Mesh Edges service (at meshtelemetry.googleapis.com). It is needed to maintain equivalent functionality with the Mixer adapter from istio/istio in the `mixer/adapter/stackdriver/contextgraph` package as we transition to the extensibility v2 architecture (aka Mixerless Istio).

This PR does not wire this functionality into any part of the larger system.

A `TODO` list is included to track the remaining work, which includes validation / integration testing.

A copy of the proto for the mesh edges service is included, as the proto is not currently published anywhere else.

**Special notes for your reviewer**:
Reviewers: Please review this with a detailed eye. I'm only barely c++ literate at this point, so I could use a solid review.

Note: most of this PR is based of the excellent examples provided by @bianpengyuan .

/cc @quentinmit
