### PR TITLE
[1.2] mixer: calculate header size if cache invalidated

### DIFF
--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -68,7 +68,7 @@ void Filter::ReadPerRouteConfig(
 
 FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
-  request_total_size_ += headers.byteSize().value_or(0);
+  request_total_size_ += headers.refreshByteSize();
 
   ::istio::control::http::Controller::PerRouteConfig config;
   auto route = decoder_callbacks_->route();
@@ -109,7 +109,7 @@ FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
 
 FilterTrailersStatus Filter::decodeTrailers(HeaderMap& trailers) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
-  request_total_size_ += trailers.byteSize().value_or(0);
+  request_total_size_ += trailers.refreshByteSize();
   if (state_ == Calling) {
     return FilterTrailersStatus::StopIteration;
   }

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -72,10 +72,14 @@ class ReportData : public ::istio::control::http::ReportData,
         response_total_size_(info.bytesSent()),
         request_total_size_(request_total_size) {
     if (response_headers != nullptr) {
-      response_total_size_ += response_headers->byteSize().value_or(0);
+      response_total_size_ += (response_headers->byteSize().has_value()
+                                   ? response_headers->byteSize().value()
+                                   : response_headers->byteSizeInternal());
     }
     if (response_trailers != nullptr) {
-      response_total_size_ += response_trailers->byteSize().value_or(0);
+      response_total_size_ += (response_trailers->byteSize().has_value()
+                                   ? response_trailers->byteSize().value()
+                                   : response_trailers->byteSizeInternal());
     }
   }
 

--- a/test/integration/int_client.cc
+++ b/test/integration/int_client.cc
@@ -253,7 +253,8 @@ class Http1ClientConnection : public ClientConnection {
       : ClientConnection(client, id, connect_callback, close_callback,
                          dispatcher),
         network_connection_(std::move(network_connection)),
-        http_connection_(*network_connection_, *this, Envoy::Http::DEFAULT_MAX_HEADERS_COUNT),
+        http_connection_(*network_connection_, *this,
+                         Envoy::Http::DEFAULT_MAX_HEADERS_COUNT),
         read_filter_{std::make_shared<HttpClientReadFilter>(client.name(), id,
                                                             http_connection_)} {
     network_connection_->addReadFilter(read_filter_);
@@ -295,7 +296,8 @@ class Http2ClientConnection : public ClientConnection {
         settings_(),
         network_connection_(std::move(network_connection)),
         http_connection_(*network_connection_, *this, stats_, settings_,
-                         max_request_headers_kb, Envoy::Http::DEFAULT_MAX_HEADERS_COUNT),
+                         max_request_headers_kb,
+                         Envoy::Http::DEFAULT_MAX_HEADERS_COUNT),
         read_filter_{std::make_shared<HttpClientReadFilter>(client.name(), id,
                                                             http_connection_)} {
     network_connection_->addReadFilter(read_filter_);


### PR DESCRIPTION
Enforce header byte size calculation when header size cache is in validated.
It should not very expensive: at most 2 (mixer filter + report data) * 2 (req + response) * 2(header + trailer) per http transaction

Fix https://github.com/istio/istio/issues/17735