### PR TITLE
Sync .bazelrc with upstream.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,29 +19,34 @@ build --experimental_local_memory_estimate
 build --experimental_strict_action_env=true
 build --host_force_python=PY2
 build --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build --action_env=BAZEL_LINKOPTS=-lm:-static-libgcc
+build --action_env=BAZEL_LINKOPTS=-lm
 build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
+
+# We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
+build --define absl=1
 
 # Pass PATH, CC and CXX variables from the environment.
 build --action_env=CC
 build --action_env=CXX
 build --action_env=PATH
 
+# Common flags for sanitizers
+build:sanitizer --define tcmalloc=disabled
+build:sanitizer --linkopt -ldl
+build:sanitizer --build_tag_filters=-no_san
+build:sanitizer --test_tag_filters=-no_san
+
 # Basic ASAN/UBSAN that works for gcc
-build:asan --action_env=BAZEL_LINKLIBS=
-build:asan --action_env=BAZEL_LINKOPTS=-lstdc++:-lm
 build:asan --action_env=ENVOY_ASAN=1
+build:asan --config=sanitizer
+# ASAN install its signal handler, disable ours so the stacktrace will be printed by ASAN
+build:asan --define signal_trace=disabled
 build:asan --define ENVOY_CONFIG_ASAN=1
 build:asan --copt -fsanitize=address,undefined
 build:asan --linkopt -fsanitize=address,undefined
 build:asan --copt -fno-sanitize=vptr
 build:asan --linkopt -fno-sanitize=vptr
-build:asan --linkopt -ldl
-build:asan --define tcmalloc=disabled
-build:asan --build_tag_filters=-no_asan
-build:asan --test_tag_filters=-no_asan
-build:asan --define signal_trace=disabled
 build:asan --copt -DADDRESS_SANITIZER=1
 build:asan --copt -D__SANITIZE_ADDRESS__
 build:asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true:detect_odr_violation=1
@@ -64,12 +69,11 @@ build:macos-asan --dynamic_mode=off
 
 # Clang TSAN
 build:clang-tsan --action_env=ENVOY_TSAN=1
+build:clang-tsan --config=sanitizer
 build:clang-tsan --define ENVOY_CONFIG_TSAN=1
 build:clang-tsan --copt -fsanitize=thread
 build:clang-tsan --linkopt -fsanitize=thread
 build:clang-tsan --linkopt -fuse-ld=lld
-build:clang-tsan --linkopt -static-libsan
-build:clang-tsan --define tcmalloc=disabled
 # Needed due to https://github.com/libevent/libevent/issues/777
 build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 
@@ -77,8 +81,7 @@ build:clang-tsan --copt -DEVENT__DISABLE_DEBUG_MODE
 build:libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:libc++ --action_env=LDFLAGS=-stdlib=libc++
 build:libc++ --action_env=BAZEL_CXXOPTS=-stdlib=libc++
-build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
-build:libc++ --action_env=BAZEL_LINKOPTS=-lm:-static-libgcc
+build:libc++ --action_env=BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a:-lm
 build:libc++ --linkopt=-fuse-ld=lld
 build:libc++ --host_linkopt=-fuse-ld=lld
 build:libc++ --define force_libcpp=enabled
@@ -105,6 +108,7 @@ build:rbe-toolchain-clang-libc++ --extra_toolchains=@rbe_ubuntu_clang_libcxx//co
 build:rbe-toolchain-clang-libc++ --action_env=CC=clang --action_env=CXX=clang++ --action_env=PATH=/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/llvm-8/bin
 build:rbe-toolchain-clang-libc++ --action_env=CXXFLAGS=-stdlib=libc++
 build:rbe-toolchain-clang-libc++ --action_env=LDFLAGS=-stdlib=libc++
+build:rbe-toolchain-clang-libc++ --define force_libcpp=enabled
 
 build:rbe-toolchain-gcc --config=rbe-toolchain
 build:rbe-toolchain-gcc --crosstool_top=@rbe_ubuntu_gcc//cc:toolchain

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ UNAME := $(shell uname)
 ifeq ($(UNAME),Linux)
 BAZEL_CONFIG_DEV  = --config=libc++
 BAZEL_CONFIG_REL  = --config=libc++ --config=release
-BAZEL_CONFIG_ASAN = --config=clang-asan --config=libc++
-BAZEL_CONFIG_TSAN = --config=clang-tsan --config=libc++
+BAZEL_CONFIG_ASAN = --config=libc++ --config=clang-asan
+BAZEL_CONFIG_TSAN = --config=libc++ --config=clang-tsan
 endif
 ifeq ($(UNAME),Darwin)
 BAZEL_CONFIG_DEV  = # macOS always links against libc++

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,9 +32,10 @@ bind(
     actual = "//external:ssl",
 )
 
-# Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
+# 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
+# 2. Update .bazelrc and .bazelversion files.
+#
 # envoy-wasm commit date: 10/09/2019
-# bazel version: 0.29.1
 ENVOY_SHA = "ec03328688895d99c9f5ae4fd7f8459ef3e95212"
 
 ENVOY_SHA256 = "4abf05fd040b56af630b624068d462035bd986bccf775f821b755fd3c0df8083"


### PR DESCRIPTION
This file is often skipped when updating Envoy SHA in WORKSPACE.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>