### PR TITLE
Use FilterState instead  of  DynamicMetadata  in  Metadata Exchange Filter

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -163,8 +163,8 @@ void populateHTTPRequestInfo(bool outbound, RequestInfo* request_info) {
 }
 
 google::protobuf::util::Status extractNodeMetadataValue(
-    const google::protobuf::Struct &node_metadata,
-    google::protobuf::Struct *metadata) {
+    const google::protobuf::Struct& node_metadata,
+    google::protobuf::Struct* metadata) {
   if (metadata == nullptr) {
     return google::protobuf::util::Status(
         google::protobuf::util::error::INVALID_ARGUMENT,
@@ -177,7 +177,7 @@ google::protobuf::util::Status extractNodeMetadataValue(
         "metadata exchange key is missing");
   }
 
-  const auto &keys_value = key_it->second;
+  const auto& keys_value = key_it->second;
   if (keys_value.kind_case() != google::protobuf::Value::kStringValue) {
     return google::protobuf::util::Status(
         google::protobuf::util::error::INVALID_ARGUMENT,

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -131,5 +131,12 @@ google::protobuf::util::Status extractLocalNodeMetadata(
 // the request context.
 void populateHTTPRequestInfo(bool outbound, RequestInfo* request_info);
 
+// Extracts node metadata value. It looks for values of all the keys
+// corresponding to EXCHANGE_KEYS in node_metadata and populates it in
+// google::protobuf::Value pointer that is passed in.
+google::protobuf::util::Status extractNodeMetadataValue(
+    const google::protobuf::Struct& node_metadata,
+    google::protobuf::Struct* metadata);
+
 }  // namespace Common
 }  // namespace Wasm

--- a/extensions/common/context_test.cc
+++ b/extensions/common/context_test.cc
@@ -136,11 +136,9 @@ TEST(ContextTest, extractNodeMetadataValue) {
   (*node_metadata_map)["EXCHANGE_KEYS"].set_string_value("namespace,labels");
   (*node_metadata_map)["namespace"].set_string_value("default");
   (*node_metadata_map)["labels"].set_string_value("{app, details}");
-  google::protobuf::Value value;
-  const auto status = extractNodeMetadataValue(metadata_struct, &value);
+  google::protobuf::Struct value_struct;
+  const auto status = extractNodeMetadataValue(metadata_struct, &value_struct);
   EXPECT_EQ(status, Status::OK);
-  ASSERT_TRUE(value.has_struct_value());
-  google::protobuf::Struct value_struct = value.struct_value();
   auto namespace_iter = value_struct.fields().find("namespace");
   EXPECT_TRUE(namespace_iter != value_struct.fields().end());
   EXPECT_EQ(namespace_iter->second.string_value(), "default");

--- a/extensions/common/context_test.cc
+++ b/extensions/common/context_test.cc
@@ -129,6 +129,26 @@ TEST(ContextTest, extractNodeMetadataUnknownField) {
   EXPECT_EQ(status, Status::OK);
 }
 
+// Test extractNodeMetadataValue.
+TEST(ContextTest, extractNodeMetadataValue) {
+  google::protobuf::Struct metadata_struct;
+  auto node_metadata_map = metadata_struct.mutable_fields();
+  (*node_metadata_map)["EXCHANGE_KEYS"].set_string_value("namespace,labels");
+  (*node_metadata_map)["namespace"].set_string_value("default");
+  (*node_metadata_map)["labels"].set_string_value("{app, details}");
+  google::protobuf::Value value;
+  const auto status = extractNodeMetadataValue(metadata_struct, &value);
+  EXPECT_EQ(status, Status::OK);
+  ASSERT_TRUE(value.has_struct_value());
+  google::protobuf::Struct value_struct = value.struct_value();
+  auto namespace_iter = value_struct.fields().find("namespace");
+  EXPECT_TRUE(namespace_iter != value_struct.fields().end());
+  EXPECT_EQ(namespace_iter->second.string_value(), "default");
+  auto label_iter = value_struct.fields().find("labels");
+  EXPECT_TRUE(label_iter != value_struct.fields().end());
+  EXPECT_EQ(label_iter->second.string_value(), "{app, details}");
+}
+
 }  // namespace Common
 
 // WASM_EPILOG

--- a/extensions/metadata_exchange/BUILD
+++ b/extensions/metadata_exchange/BUILD
@@ -20,6 +20,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        "//extensions/common:context",
         "@envoy//source/common/common:base64_lib",
         "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
     ],

--- a/src/envoy/tcp/metadata_exchange/BUILD
+++ b/src/envoy/tcp/metadata_exchange/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
     ],
     repository = "@envoy",
     deps = [
+        "//extensions/common:context",
         "//src/envoy/tcp/metadata_exchange/config:metadata_exchange_cc_proto",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/base:endian",
@@ -47,10 +48,12 @@ envoy_cc_library(
         "@envoy//include/envoy/network:filter_interface",
         "@envoy//include/envoy/runtime:runtime_interface",
         "@envoy//include/envoy/stats:stats_macros",
+        "@envoy//include/envoy/stream_info:filter_state_interface",
         "@envoy//source/common/http:utility_lib",
         "@envoy//source/common/network:utility_lib",
         "@envoy//source/common/protobuf",
         "@envoy//source/common/protobuf:utility_lib",
+        "@envoy//source/extensions/common/wasm:wasm_interoperation_lib",
         "@envoy//source/extensions/filters/network:well_known_names",
     ],
 )

--- a/src/envoy/tcp/metadata_exchange/config.cc
+++ b/src/envoy/tcp/metadata_exchange/config.cc
@@ -34,8 +34,8 @@ Network::FilterFactoryCb createFilterFactoryHelper(
 
   MetadataExchangeConfigSharedPtr filter_config(
       std::make_shared<MetadataExchangeConfig>(
-          StatPrefix, proto_config.protocol(), proto_config.node_metadata_id(),
-          filter_direction, context.scope()));
+          StatPrefix, proto_config.protocol(), filter_direction,
+          context.scope()));
   return [filter_config,
           &context](Network::FilterManager& filter_manager) -> void {
     filter_manager.addFilter(std::make_shared<MetadataExchangeFilter>(

--- a/src/envoy/tcp/metadata_exchange/config/metadata_exchange.proto
+++ b/src/envoy/tcp/metadata_exchange/config/metadata_exchange.proto
@@ -28,8 +28,4 @@ message MetadataExchange {
   // Protocol that Alpn should support on the server.
   // [#comment:TODO(GargNupur): Make it a list.]
   string protocol = 1;
-
-  // The node metadata id whose data will be written to connection data.
-  // [#comment: TODO(GargNupur): Remove this and use bootstrap node.id]
-  string node_metadata_id = 2;
 }

--- a/test/envoye2e/env/setup.go
+++ b/test/envoye2e/env/setup.go
@@ -100,8 +100,11 @@ type TestSetup struct {
 	// Whether Tls is Enabled or not.
 	EnableTls bool
 
-	// Format for accesslog
+	// Format for client accesslog
 	AccesslogFormat string
+
+	// Format for server accesslog
+	ServerAccesslogFormat string
 
 	// TlsContext to be used.
 	TlsContext string
@@ -210,6 +213,11 @@ func (s *TestSetup) SetClientNodeMetadata(metadata string) {
 // SetAccessLogFormat sets the accesslogformat.
 func (s *TestSetup) SetAccessLogFormat(accesslogformat string) {
 	s.AccesslogFormat = accesslogformat
+}
+
+// SetServerAccessLogFormat sets the serverAccesslogformat.
+func (s *TestSetup) SetServerAccessLogFormat(serverAccesslogformat string) {
+	s.ServerAccesslogFormat = serverAccesslogformat
 }
 
 // SetUpstreamFiltersInClient sets upstream filters chain in client envoy..

--- a/test/envoye2e/env/tcp_envoy_conf.go
+++ b/test/envoye2e/env/tcp_envoy_conf.go
@@ -64,7 +64,7 @@ static_resources:
           - name: envoy.file_access_log
             config:
               path: {{.ClientAccessLogPath}}
-{{.AccesslogFormat | indent 14 }}
+              format: {{.AccesslogFormat}}
 {{.TlsContext | indent 6 }}
 `
 
@@ -117,6 +117,7 @@ static_resources:
           - name: envoy.file_access_log
             config:
               path: {{.ServerAccessLogPath}}
+              format: {{.ServerAccesslogFormat}}
 {{.TlsContext | indent 6 }}
 `
 

--- a/test/envoye2e/tcp_metadata_exchange/tcp_metadata_exchange_test.go
+++ b/test/envoye2e/tcp_metadata_exchange/tcp_metadata_exchange_test.go
@@ -31,7 +31,6 @@ const metadataExchangeIstioConfigFilter = `
 - name: envoy.filters.network.metadata_exchange
   config:
     protocol: istio2
-    node_metadata_id: istio.io/metadata
 `
 
 const metadataExchangeIstioUpstreamConfigFilterChain = `
@@ -40,7 +39,6 @@ filters:
   typed_config: 
     "@type": type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
     protocol: istio2
-    node_metadata_id: istio.io/metadata
 `
 
 const tlsContext = `
@@ -74,19 +72,63 @@ tls_context:
         inline_string: "-----BEGIN CERTIFICATE-----\nMIIFFDCCAvygAwIBAgIUZqU0Sviq/wULK6UV7PoAZ7B+nqAwDQYJKoZIhvcNAQEL\nBQAwIjEOMAwGA1UECgwFSXN0aW8xEDAOBgNVBAMMB1Jvb3QgQ0EwHhcNMTkwNzIy\nMjEzMDA0WhcNMjkwNzE5MjEzMDA0WjAiMQ4wDAYDVQQKDAVJc3RpbzEQMA4GA1UE\nAwwHUm9vdCBDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANNl5/pH\n/ktdqEsb83cqHrYJCyzbvWce6k/iud4Czu6FClFX8b+n/Rv9GrZFxJwKAFlUx3iA\nBGlSn/1XYpnhudQhgVGvyuWNO5kX4BfrAJwfWt+7Mn6NcWvunDqwqUPxI07sgCJW\nAYBAwkZH/Nhn6tj571XWNPziUtCwlPNkFMiRu/2nI/tq12IgwimFjVgiCuprNfyX\ntQz/DMVTWpCRQLK5ptlYMfk0P25UKyJdKHnr1MPQBJmPXMfSSqpGjksikV4QnYc7\nCXB3ucq7ty0IWA8QXH+86WqMTh22mosWVXHe0OGbzYtuyVnXc1G7YRv4D87G3Ves\nG4n/8e+RaDTacvwOsYEkuQGk+s8pggPkIqydGy02JNZ4cSRpXJRTzME2BgBZxT8S\nEw1Omr5+iuLNRAKEYRM/eWI7qrs5fxpD6K9JELHS41hWHGdW94PP0wKz70trx5pM\nfLpcVm7BQ5ppgf+t4vgKnrNiACQpfyZbInCBU0doaZaqVMnKH0vgyM7xrC43fsOP\ny5URy3tEH8Uk7Dbvsmj7AXR7IPKlYtgcqcJXmeWa+kLOpx3G55hgJL1ySrxXg/qz\nAobgmV0IycH2ntn5lXvjbwe0cfXAnZgGoALZjJVuEazyBmmVzjBjG2Qcq35nHfp8\nRm6WnCZIaGsZqgoDuSJD280ZLWW7R0PMcnypAgMBAAGjQjBAMB0GA1UdDgQWBBQZ\nh3/ckcK23ZYKO+JsZowd3dIobDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQE\nAwIC5DANBgkqhkiG9w0BAQsFAAOCAgEAjh4CdrwnLsqwVxyVSgxd7TfSHtKE/J2Y\n2IZ4fJYXGkq3McPk2e9u0zjCH0buvfDwyAItLIacD+YwIP+OC2WxLe+YMZ5KkXl3\nLuhQ2TOoRlrbp5tYLQITZIIl9+vNkgnn1DkdxkLm9cDDag19LSxa9Rjrnb3wwFAT\nIzEhy+d18FpQtdMMhmonU/L8Oy5LqjT5BR3T8VrXYUsaAkcUs/yHNTFAY3iJFBWL\nZ8dFa5v0A1Ryi8quSNo7lK/hSEZvvV9k4XfFAolXSUqe8BCuXe0rbAq3Jq9HgDww\noImGM0uz4Zf89uhTk1O7UOUfQoSTmA0yZICtQkCiOC0J4AlAOTmiEXUC9gicV3R8\ndvVOqNBOcBELglZ+NIMm6FQQqPh1nZ6A3Bh+JRTPerAF12725RZZE6XMxq2MSr3G\nk5yH10QPMH7/DJRQUhRHAhbge+jk2csa7EGSxABcbsPLSV+cEzXRO4cJeItoZQLh\nsaFhIn9lGukXG6lgiperOqZl6DFVcUG6/nogK7KOTAnV9zjR/7vNwvYzPI9iOR3V\n6dbG38KnipcfL885VLJVTnfhvYHlxFklCKTEnOHnmKsM0qjQuky3DBzmDA6iqeOM\nSHRje5LKxi7mllJfu/X0MxYJWiu6i4gMCWZsC3UtAJQ09x7iwcNr/1bl9ApGszOy\nUff0OxD2hzk=\n-----END CERTIFICATE-----\n"
 `
 
-const clientNodeMetadata = `
-"istio.io/metadata": {
-      namespace: default,
-      labels: { app: productpage },
-    }
-`
+const clientNodeMetadata = `"NAMESPACE": "default",
+"INCLUDE_INBOUND_PORTS": "9080",
+"app": "productpage",
+"EXCHANGE_KEYS": "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
+"INSTANCE_IPS": "10.52.0.34,fe80::a075:11ff:fe5e:f1cd",
+"pod-template-hash": "84975bc778",
+"INTERCEPTION_MODE": "REDIRECT",
+"SERVICE_ACCOUNT": "bookinfo-productpage",
+"CONFIG_NAMESPACE": "default",
+"version": "v1",
+"OWNER": "kubernetes://api/apps/v1/namespaces/default/deployment/productpage-v1",
+"WORKLOAD_NAME": "productpage-v1",
+"ISTIO_VERSION": "1.3-dev",
+"kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container productpage",
+"POD_NAME": "productpage-v1-84975bc778-pxz2w",
+"istio": "sidecar",
+"PLATFORM_METADATA": {
+ "gcp_cluster_name": "test-cluster",
+ "gcp_project": "test-project",
+ "gcp_cluster_location": "us-east4-b"
+},
+"LABELS": {
+ "app": "productpage",
+ "version": "v1",
+ "pod-template-hash": "84975bc778"
+},
+"ISTIO_PROXY_SHA": "istio-proxy:47e4559b8e4f0d516c0d17b233d127a3deb3d7ce",
+"NAME": "productpage-v1-84975bc778-pxz2w",`
 
-const serverNodeMetadata = `
-"istio.io/metadata": {
-      namespace: default,
-      labels: { app: details },
-    }
-`
+const serverNodeMetadata = `"NAMESPACE": "default",
+"INCLUDE_INBOUND_PORTS": "9080",
+"app": "ratings",
+"EXCHANGE_KEYS": "NAME,NAMESPACE,INSTANCE_IPS,LABELS,OWNER,PLATFORM_METADATA,WORKLOAD_NAME,CANONICAL_TELEMETRY_SERVICE,MESH_ID,SERVICE_ACCOUNT",
+"INSTANCE_IPS": "10.52.0.34,fe80::a075:11ff:fe5e:f1cd",
+"pod-template-hash": "84975bc778",
+"INTERCEPTION_MODE": "REDIRECT",
+"SERVICE_ACCOUNT": "bookinfo-ratings",
+"CONFIG_NAMESPACE": "default",
+"version": "v1",
+"OWNER": "kubernetes://api/apps/v1/namespaces/default/deployment/ratings-v1",
+"WORKLOAD_NAME": "ratings-v1",
+"ISTIO_VERSION": "1.3-dev",
+"kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container ratings",
+"POD_NAME": "ratings-v1-84975bc778-pxz2w",
+"istio": "sidecar",
+"PLATFORM_METADATA": {
+ "gcp_cluster_name": "test-cluster",
+ "gcp_project": "test-project",
+ "gcp_cluster_location": "us-east4-b"
+},
+"LABELS": {
+ "app": "ratings",
+ "version": "v1",
+ "pod-template-hash": "84975bc778"
+},
+"ISTIO_PROXY_SHA": "istio-proxy:47e4559b8e4f0d516c0d17b233d127a3deb3d7ce",
+"NAME": "ratings-v1-84975bc778-pxz2w",`
 
 // Stats in Client Envoy proxy.
 var expectedClientStats = map[string]int{
@@ -140,7 +182,7 @@ func TestTcpMetadataExchange(t *testing.T) {
 	}
 	config := &tls.Config{Certificates: []tls.Certificate{certificate}, ServerName: "localhost", NextProtos: []string{"istio2"}, RootCAs: certPool}
 
-	conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", s.Ports().AppToClientProxyPort /*s.Ports().ProxyToServerProxyPort*/), config)
+	conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", s.Ports().AppToClientProxyPort), config)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use FilterState instead  of  DynamicMetadata  in  Metadata Exchange Filter

Also made  the filter  in sync with existing HTTP Metadata Exchange Wasm Plugin,  so that stats(prometheus)  plugin  can use this easily.

