### PR TITLE
feat(forwarded attributes): add support for ignore_forwarded_attributes

### DIFF
--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -55,10 +55,6 @@ class ClientContext : public ClientContextBase {
   // Get the service config cache size
   int service_config_cache_size() const { return service_config_cache_size_; }
 
-  const bool IgnoreForwardedAttributes() const {
-    return config_.ignore_forwarded_attributes();
-  }
-
  private:
   // The http client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config_;

--- a/src/istio/control/http/client_context.h
+++ b/src/istio/control/http/client_context.h
@@ -55,6 +55,10 @@ class ClientContext : public ClientContextBase {
   // Get the service config cache size
   int service_config_cache_size() const { return service_config_cache_size_; }
 
+  const bool IgnoreForwardedAttributes() const {
+    return config_.ignore_forwarded_attributes();
+  }
+
  private:
   // The http client config.
   const ::istio::mixer::v1::config::client::HttpClientConfig& config_;

--- a/src/istio/control/http/request_handler_impl.cc
+++ b/src/istio/control/http/request_handler_impl.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/http/request_handler_impl.h"
+
 #include "src/istio/control/http/attributes_builder.h"
 
 using ::google::protobuf::util::Status;
@@ -42,8 +43,10 @@ void RequestHandlerImpl::AddForwardAttributes(CheckData* check_data) {
   }
   forward_attributes_added_ = true;
 
-  AttributesBuilder builder(attributes_->attributes());
-  builder.ExtractForwardedAttributes(check_data);
+  if (!service_context_->ignore_forwarded_attributes()) {
+    AttributesBuilder builder(attributes_->attributes());
+    builder.ExtractForwardedAttributes(check_data);
+  }
 }
 
 void RequestHandlerImpl::AddCheckAttributes(CheckData* check_data) {

--- a/src/istio/control/http/request_handler_impl_test.cc
+++ b/src/istio/control/http/request_handler_impl_test.cc
@@ -127,6 +127,50 @@ forward_attributes {
 }
 )";
 
+// The default client config with flag set to ignore
+// forwarded attributes
+const char kIgnoreForwardedAttributesClientConfig[] = R"(
+service_configs {
+  key: ":default"
+  value {
+    mixer_attributes {
+      attributes {
+        key: "route0-key"
+        value {
+          string_value: "route0-value"
+        }
+      }
+    }
+    forward_attributes {
+      attributes {
+        key: "source-key-override"
+        value {
+          string_value: "service-value"
+        }
+      }
+    }
+  }
+}
+default_destination_service: ":default"
+mixer_attributes {
+  attributes {
+    key: "global-key"
+    value {
+      string_value: "global-value"
+    }
+  }
+}
+forward_attributes {
+  attributes {
+    key: "source-key-override"
+    value {
+      string_value: "global-value"
+    }
+  }
+}
+ignore_forwarded_attributes: true
+)";
+
 class RequestHandlerImplTest : public ::testing::Test {
  public:
   RequestHandlerImplTest(bool outbound = false) : outbound_(outbound) {}
@@ -506,6 +550,32 @@ TEST_F(OutboundRequestHandlerImplTest, TestLocalAttributesOverride) {
                           const CheckDoneFunc &on_done) {
         auto map = context->attributes()->attributes();
         EXPECT_EQ(map["source.uid"].string_value(), "fwded");
+        EXPECT_NE(map["destination.uid"].string_value(), "ignored");
+      }));
+
+  ServiceConfig config;
+  Controller::PerRouteConfig per_route;
+  ApplyPerRouteConfig(config, &per_route);
+  auto handler = controller_->CreateRequestHandler(per_route);
+  handler->Check(&mock_data, &mock_header, nullptr, nullptr);
+}
+
+TEST_F(OutboundRequestHandlerImplTest, TestIgnoreForwardedAttributes) {
+  SetUpMockController(kIgnoreForwardedAttributesClientConfig);
+
+  ::testing::NiceMock<MockCheckData> mock_data;
+  ::testing::NiceMock<MockHeaderUpdate> mock_header;
+
+  EXPECT_CALL(mock_data, ExtractIstioAttributes(_)).Times(0);
+
+  // Check should be called.
+  EXPECT_CALL(*mock_client_, Check(_, _, _))
+      .WillOnce(Invoke([](CheckContextSharedPtr &context,
+                          const TransportCheckFunc &transport,
+                          const CheckDoneFunc &on_done) {
+        auto map = context->attributes()->attributes();
+        EXPECT_EQ(map["source.uid"].string_value(),
+                  "kubernetes://src-client-84469dc8d7-jbbxt.default");
         EXPECT_NE(map["destination.uid"].string_value(), "ignored");
       }));
 

--- a/src/istio/control/http/service_context.h
+++ b/src/istio/control/http/service_context.h
@@ -54,7 +54,7 @@ class ServiceContext {
   }
 
   bool ignore_forwarded_attributes() const {
-    return client_context_->IgnoreForwardedAttributes();
+    return client_context_->config().ignore_forwarded_attributes();
   }
 
  private:

--- a/src/istio/control/http/service_context.h
+++ b/src/istio/control/http/service_context.h
@@ -53,6 +53,10 @@ class ServiceContext {
     return service_config_ && !service_config_->disable_report_calls();
   }
 
+  bool ignore_forwarded_attributes() const {
+    return client_context_->IgnoreForwardedAttributes();
+  }
+
  private:
   // Pre-process the config data to build parser objects.
   void BuildParsers();


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds code to the http `request_handler_impl` to ignore forwarded attributes when the http client configuration specifies to ignore the attributes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

See: istio/istio#15188, istio/istio#12063