### PR TITLE
Fix root context

### DIFF
--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -387,6 +387,18 @@ class PluginRootContext : public RootContext {
   std::vector<StatGen> stats_;
 };
 
+class PluginRootContextOutbound : public PluginRootContext {
+ public:
+  PluginRootContextOutbound(uint32_t id, StringView root_id)
+      : PluginRootContext(id, root_id){};
+};
+
+class PluginRootContextInbound : public PluginRootContext {
+ public:
+  PluginRootContextInbound(uint32_t id, StringView root_id)
+      : PluginRootContext(id, root_id){};
+};
+
 // Per-stream context.
 class PluginContext : public Context {
  public:
@@ -431,6 +443,14 @@ NULL_PLUGIN_ROOT_REGISTRY;
 static RegisterContextFactory register_Stats(
     CONTEXT_FACTORY(Stats::PluginContext),
     ROOT_FACTORY(Stats::PluginRootContext));
+
+static RegisterContextFactory register_StatsOutbound(
+    CONTEXT_FACTORY(Stats::PluginContext),
+    ROOT_FACTORY(Stats::PluginRootContextOutbound), "stats_outbound");
+
+static RegisterContextFactory register_StatsInbound(
+    CONTEXT_FACTORY(Stats::PluginContext),
+    ROOT_FACTORY(Stats::PluginRootContextInbound), "stats_inbound");
 
 }  // namespace Stats
 

--- a/extensions/stats/testdata/client.yaml
+++ b/extensions/stats/testdata/client.yaml
@@ -100,6 +100,7 @@ static_resources:
           - name: envoy.filters.http.wasm
             config:
               config:
+                root_id: "stats_outbound"
                 vm_config:
                   runtime: envoy.wasm.runtime.null
                   code:

--- a/extensions/stats/testdata/istio/stats_filter.yaml
+++ b/extensions/stats/testdata/istio/stats_filter.yaml
@@ -6,7 +6,57 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: ANY # inbound, outbound, and gateway
+        context: SIDECAR_OUTBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_outbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+              subFilter:
+                name: "envoy.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.wasm
+          config:
+            config:
+              root_id: stats_inbound
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                }
+              vm_config:
+                runtime: envoy.wasm.runtime.null
+                code:
+                  inline_string: envoy.wasm.stats
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
         listener:
           filterChain:
             filter:

--- a/extensions/stats/testdata/server.yaml
+++ b/extensions/stats/testdata/server.yaml
@@ -100,6 +100,7 @@ static_resources:
           - name: envoy.filters.http.wasm
             config:
               config:
+                root_id: "stats_inbound"
                 vm_config:
                   runtime: envoy.wasm.runtime.null
                   code:


### PR DESCRIPTION
Fix root context by adding 3 different context_ids.

1. inbound
2. outbound
3. unspecified, or blank.

This is needed to fix the stats filter.