### PR TITLE
feat(stackdriver): add support for gce_instance MR

### DIFF
--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -56,7 +56,7 @@ constexpr char kGCEInstanceIDLabel[] = "instance_id";
 constexpr char kZoneLabel[] = "zone";
 
 // GCP node metadata key
-constexpr char kGCPClusterLocationKey[] = "gcp_location";
+constexpr char kGCPLocationKey[] = "gcp_location";
 constexpr char kGCPClusterNameKey[] = "gcp_gke_cluster_name";
 constexpr char kGCPProjectKey[] = "gcp_project";
 constexpr char kGCPGCEInstanceIDKey[] = "gcp_gce_instance_id";

--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -45,17 +45,21 @@ constexpr char kIstioMetricPrefix[] = "istio.io/service/";
 // Monitored resource
 constexpr char kPodMonitoredResource[] = "k8s_pod";
 constexpr char kContainerMonitoredResource[] = "k8s_container";
+constexpr char kGCEInstanceMonitoredResource[] = "gce_instance";
 constexpr char kProjectIDLabel[] = "project_id";
 constexpr char kLocationLabel[] = "location";
 constexpr char kClusterNameLabel[] = "cluster_name";
 constexpr char kNamespaceNameLabel[] = "namespace_name";
 constexpr char kPodNameLabel[] = "pod_name";
 constexpr char kContainerNameLabel[] = "container_name";
+constexpr char kGCEInstanceIDLabel[] = "instance_id";
+constexpr char kZoneLabel[] = "zone";
 
 // GCP node metadata key
-constexpr char kGCPClusterLocationKey[] = "gcp_cluster_location";
-constexpr char kGCPClusterNameKey[] = "gcp_cluster_name";
+constexpr char kGCPClusterLocationKey[] = "gcp_location";
+constexpr char kGCPClusterNameKey[] = "gcp_gke_cluster_name";
 constexpr char kGCPProjectKey[] = "gcp_project";
+constexpr char kGCPGCEInstanceIDKey[] = "gcp_gce_instance_id";
 
 // Misc
 constexpr char kIstioProxyContainerName[] = "istio-proxy";

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -36,15 +36,14 @@ void getMonitoredResource(const std::string &monitored_resource_type,
   (*monitored_resource->mutable_labels())[kProjectIDLabel] =
       platform_metadata[kGCPProjectKey];
 
-  if (monitored_resource_type) == kGCEInstanceMonitoredResource) {
-      // gce_instance
+  if (monitored_resource_type == kGCEInstanceMonitoredResource) {
+    // gce_instance
 
-      (*monitored_resource->mutable_labels())[kGCEInstanceIDLabel] =
-          platform_metadata[kGCPGCEInstanceIDKey];
-      (*monitored_resource->mutable_labels())[kZoneLabel] =
-          platform_metadata[kGCPClusterLocationKey];
-    }
-  else {
+    (*monitored_resource->mutable_labels())[kGCEInstanceIDLabel] =
+        platform_metadata[kGCPGCEInstanceIDKey];
+    (*monitored_resource->mutable_labels())[kZoneLabel] =
+        platform_metadata[kGCPClusterLocationKey];
+  } else {
     // k8s_pod or k8s_container
 
     (*monitored_resource->mutable_labels())[kLocationLabel] =

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -42,12 +42,12 @@ void getMonitoredResource(const std::string &monitored_resource_type,
     (*monitored_resource->mutable_labels())[kGCEInstanceIDLabel] =
         platform_metadata[kGCPGCEInstanceIDKey];
     (*monitored_resource->mutable_labels())[kZoneLabel] =
-        platform_metadata[kGCPClusterLocationKey];
+        platform_metadata[kGCPLocationKey];
   } else {
     // k8s_pod or k8s_container
 
     (*monitored_resource->mutable_labels())[kLocationLabel] =
-        platform_metadata[kGCPClusterLocationKey];
+        platform_metadata[kGCPLocationKey];
     (*monitored_resource->mutable_labels())[kClusterNameLabel] =
         platform_metadata[kGCPClusterNameKey];
     (*monitored_resource->mutable_labels())[kNamespaceNameLabel] =

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/stackdriver/common/utils.h"
+
 #include "extensions/stackdriver/common/constants.h"
 
 namespace Extensions {
@@ -28,23 +29,38 @@ void getMonitoredResource(const std::string &monitored_resource_type,
   if (!monitored_resource) {
     return;
   }
+
   monitored_resource->set_type(monitored_resource_type);
   auto platform_metadata = local_node_info.platform_metadata();
+
   (*monitored_resource->mutable_labels())[kProjectIDLabel] =
       platform_metadata[kGCPProjectKey];
-  (*monitored_resource->mutable_labels())[kLocationLabel] =
-      platform_metadata[kGCPClusterLocationKey];
-  (*monitored_resource->mutable_labels())[kClusterNameLabel] =
-      platform_metadata[kGCPClusterNameKey];
-  (*monitored_resource->mutable_labels())[kNamespaceNameLabel] =
-      local_node_info.namespace_();
-  (*monitored_resource->mutable_labels())[kPodNameLabel] =
-      local_node_info.name();
 
-  if (monitored_resource_type == kContainerMonitoredResource) {
-    // Fill in container_name of k8s_container monitored resource.
-    (*monitored_resource->mutable_labels())[kContainerNameLabel] =
-        kIstioProxyContainerName;
+  if (monitored_resource_type) == kGCEInstanceMonitoredResource) {
+      // gce_instance
+
+      (*monitored_resource->mutable_labels())[kGCEInstanceIDLabel] =
+          platform_metadata[kGCPGCEInstanceIDKey];
+      (*monitored_resource->mutable_labels())[kZoneLabel] =
+          platform_metadata[kGCPClusterLocationKey];
+    }
+  else {
+    // k8s_pod or k8s_container
+
+    (*monitored_resource->mutable_labels())[kLocationLabel] =
+        platform_metadata[kGCPClusterLocationKey];
+    (*monitored_resource->mutable_labels())[kClusterNameLabel] =
+        platform_metadata[kGCPClusterNameKey];
+    (*monitored_resource->mutable_labels())[kNamespaceNameLabel] =
+        local_node_info.namespace_();
+    (*monitored_resource->mutable_labels())[kPodNameLabel] =
+        local_node_info.name();
+
+    if (monitored_resource_type == kContainerMonitoredResource) {
+      // Fill in container_name of k8s_container monitored resource.
+      (*monitored_resource->mutable_labels())[kContainerNameLabel] =
+          kIstioProxyContainerName;
+    }
   }
 }
 

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -48,7 +48,7 @@ void instanceFromMetadata(const ::wasm::common::NodeInfo& node_info,
                   ".", node_info.namespace_());
   // TODO(douglas-reid): support more than just GCP ?
   instance->set_location(
-      node_info.platform_metadata().at(Common::kGCPClusterLocationKey));
+      node_info.platform_metadata().at(Common::kGCPLocationKey));
   instance->set_cluster_name(
       node_info.platform_metadata().at(Common::kGCPClusterNameKey));
   instance->set_owner_uid(node_info.owner());

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -71,11 +71,11 @@ const char kNodeInfo[] = R"(
     value: "test_project"
   }
   platform_metadata: {
-    key: "gcp_cluster_name"
+    key: "gcp_gke_cluster_name"
     value: "test_cluster"
   }
   platform_metadata: {
-    key: "gcp_cluster_location"
+    key: "gcp_location"
     value: "test_location"
   }
   mesh_id: "test-mesh"
@@ -91,11 +91,11 @@ const char kPeerInfo[] = R"(
     value: "test_project"
   }
   platform_metadata: {
-    key: "gcp_cluster_name"
+    key: "gcp_gke_cluster_name"
     value: "test_cluster"
   }
   platform_metadata: {
-    key: "gcp_cluster_location"
+    key: "gcp_location"
     value: "test_location"
   }
   mesh_id: "test-mesh"

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -49,7 +49,7 @@ Logger::Logger(const ::wasm::common::NodeInfo& local_node_info,
   log_entries_request_->set_log_name("projects/" + project_id + "/logs/" +
                                      kServerAccessLogName);
 
-  auto& resource_type = Common::kContainerMonitoredResource;
+  std::string resource_type = Common::kContainerMonitoredResource;
   auto iter =
       local_node_info.platform_metadata().find(Common::kGCPClusterNameKey);
   if (local_node_info.platform_metadata().end() == iter) {

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -49,7 +49,7 @@ Logger::Logger(const ::wasm::common::NodeInfo& local_node_info,
   log_entries_request_->set_log_name("projects/" + project_id + "/logs/" +
                                      kServerAccessLogName);
 
-  std::string resource_type = Common::kContainerMonitoredResource;
+  auto& resource_type = Common::kContainerMonitoredResource;
   auto iter =
       local_node_info.platform_metadata().find(Common::kGCPClusterNameKey);
   if (local_node_info.platform_metadata().end() == iter) {

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -49,7 +49,7 @@ wasm::common::NodeInfo nodeInfo() {
       "test_project";
   (*node_info.mutable_platform_metadata())[Common::kGCPClusterNameKey] =
       "test_cluster";
-  (*node_info.mutable_platform_metadata())[Common::kGCPClusterLocationKey] =
+  (*node_info.mutable_platform_metadata())[Common::kGCPLocationKey] =
       "test_location";
   node_info.set_namespace_("test_namespace");
   node_info.set_name("test_pod");
@@ -63,7 +63,7 @@ wasm::common::NodeInfo peerNodeInfo() {
       "test_project";
   (*node_info.mutable_platform_metadata())[Common::kGCPClusterNameKey] =
       "test_cluster";
-  (*node_info.mutable_platform_metadata())[Common::kGCPClusterLocationKey] =
+  (*node_info.mutable_platform_metadata())[Common::kGCPLocationKey] =
       "test_location";
   node_info.set_namespace_("test_peer_namespace");
   node_info.set_name("test_peer_pod");

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -31,8 +31,8 @@ using wasm::common::NodeInfo;
 
 // Gets opencensus stackdriver exporter options.
 StackdriverOptions getStackdriverOptions(
-    const NodeInfo &local_node_info,
-    const std::string &test_monitoring_endpoint) {
+    const NodeInfo& local_node_info,
+    const std::string& test_monitoring_endpoint) {
   StackdriverOptions options;
   auto platform_metadata = local_node_info.platform_metadata();
   options.project_id = platform_metadata[kGCPProjectKey];

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -44,8 +44,8 @@ StackdriverOptions getStackdriverOptions(
         google::monitoring::v3::MetricService::NewStub(channel);
   }
 
-  auto& server_type = kContainerMonitoredResource;
-  auto& client_type = kPodMonitoredResource;
+  std::string server_type = kContainerMonitoredResource;
+  std::string client_type = kPodMonitoredResource;
   auto iter = platform_metadata.find(kGCPClusterNameKey);
   if (platform_metadata.end() == iter) {
     // if there is no cluster name, then this is a gce_instance

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -44,8 +44,8 @@ StackdriverOptions getStackdriverOptions(
         google::monitoring::v3::MetricService::NewStub(channel);
   }
 
-  std::string server_type = kContainerMonitoredResource;
-  std::string client_type = kPodMonitoredResource;
+  auto& server_type = kContainerMonitoredResource;
+  auto& client_type = kPodMonitoredResource;
   auto iter = platform_metadata.find(kGCPClusterNameKey);
   if (platform_metadata.end() == iter) {
     // if there is no cluster name, then this is a gce_instance

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/stackdriver/metric/registry.h"
+
 #include "extensions/stackdriver/common/constants.h"
 #include "extensions/stackdriver/common/utils.h"
 #include "google/api/monitored_resource.pb.h"
@@ -43,12 +44,21 @@ StackdriverOptions getStackdriverOptions(
         google::monitoring::v3::MetricService::NewStub(channel);
   }
 
+  std::string server_type = kContainerMonitoredResource;
+  std::string client_type = kPodMonitoredResource;
+  auto iter = platform_metadata.find(kGCPClusterNameKey);
+  if (platform_metadata.end() == iter) {
+    // if there is no cluster name, then this is a gce_instance
+    server_type = kGCEInstanceMonitoredResource;
+    client_type = kGCEInstanceMonitoredResource;
+  }
+
   // Get server and client monitored resource.
   google::api::MonitoredResource server_monitored_resource;
-  Common::getMonitoredResource(kContainerMonitoredResource, local_node_info,
+  Common::getMonitoredResource(server_type, local_node_info,
                                &server_monitored_resource);
   google::api::MonitoredResource client_monitored_resource;
-  Common::getMonitoredResource(kPodMonitoredResource, local_node_info,
+  Common::getMonitoredResource(client_type, local_node_info,
                                &client_monitored_resource);
   options.per_metric_monitored_resource[kServerRequestCountView] =
       server_monitored_resource;

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -31,8 +31,8 @@ using wasm::common::NodeInfo;
 
 // Gets opencensus stackdriver exporter options.
 StackdriverOptions getStackdriverOptions(
-    const NodeInfo& local_node_info,
-    const std::string& test_monitoring_endpoint) {
+    const NodeInfo &local_node_info,
+    const std::string &test_monitoring_endpoint) {
   StackdriverOptions options;
   auto platform_metadata = local_node_info.platform_metadata();
   options.project_id = platform_metadata[kGCPProjectKey];

--- a/extensions/stackdriver/metric/registry_test.cc
+++ b/extensions/stackdriver/metric/registry_test.cc
@@ -30,7 +30,7 @@ wasm::common::NodeInfo nodeInfo() {
       "test_project";
   (*node_info.mutable_platform_metadata())[Common::kGCPClusterNameKey] =
       "test_cluster";
-  (*node_info.mutable_platform_metadata())[Common::kGCPClusterLocationKey] =
+  (*node_info.mutable_platform_metadata())[Common::kGCPLocationKey] =
       "test_location";
   node_info.set_namespace_("test_namespace");
   node_info.set_name("test_pod");

--- a/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
@@ -85,9 +85,9 @@ const outboundNodeMetadata = `"NAMESPACE": "default",
 "POD_NAME": "productpage-v1-84975bc778-pxz2w",
 "istio": "sidecar",
 "PLATFORM_METADATA": {
- "gcp_gke_cluster_name": "test-cluster",
+ "gcp_cluster_name": "test-cluster",
  "gcp_project": "test-project",
- "gcp_location": "us-east4-b"
+ "gcp_cluster_location": "us-east4-b"
 },
 "LABELS": {
  "app": "productpage",
@@ -114,9 +114,9 @@ const inboundNodeMetadata = `"NAMESPACE": "default",
 "POD_NAME": "ratings-v1-84975bc778-pxz2w",
 "istio": "sidecar",
 "PLATFORM_METADATA": {
- "gcp_gke_cluster_name": "test-cluster",
+ "gcp_cluster_name": "test-cluster",
  "gcp_project": "test-project",
- "gcp_location": "us-east4-b"
+ "gcp_cluster_location": "us-east4-b"
 },
 "LABELS": {
  "app": "ratings",

--- a/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
@@ -85,9 +85,9 @@ const outboundNodeMetadata = `"NAMESPACE": "default",
 "POD_NAME": "productpage-v1-84975bc778-pxz2w",
 "istio": "sidecar",
 "PLATFORM_METADATA": {
- "gcp_cluster_name": "test-cluster",
+ "gcp_gke_cluster_name": "test-cluster",
  "gcp_project": "test-project",
- "gcp_cluster_location": "us-east4-b"
+ "gcp_location": "us-east4-b"
 },
 "LABELS": {
  "app": "productpage",
@@ -114,9 +114,9 @@ const inboundNodeMetadata = `"NAMESPACE": "default",
 "POD_NAME": "ratings-v1-84975bc778-pxz2w",
 "istio": "sidecar",
 "PLATFORM_METADATA": {
- "gcp_cluster_name": "test-cluster",
+ "gcp_gke_cluster_name": "test-cluster",
  "gcp_project": "test-project",
- "gcp_cluster_location": "us-east4-b"
+ "gcp_location": "us-east4-b"
 },
 "LABELS": {
  "app": "ratings",


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for `gce_instance` MR type to the Stackdriver extension code.

This PR also updates the metadata keys to match the keys in https://github.com/istio/istio/blob/master/pkg/bootstrap/platform/gcp.go#L27-L32.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

See: istio/istio#17081