### PR TITLE
Values stored in context is incorrect under high load

### DIFF
--- a/src/istio/mixerclient/client_impl.cc
+++ b/src/istio/mixerclient/client_impl.cc
@@ -104,18 +104,12 @@ void MixerClientImpl::Check(CheckContextSharedPtr &context,
     // immediately accept the request.
     //
     ++total_check_cache_hit_accepts_;
-    if (!context->quotaCheckRequired()) {
-      context->setFinalStatus(context->policyStatus());
-      on_done(*context);
-      return;
-    }
   } else {
     ++total_check_cache_misses_;
   }
 
   bool remote_quota_prefetch{false};
 
-  if (context->quotaCheckRequired()) {
     context->checkQuotaCache(*quota_cache_);
     ++total_quota_calls_;
 
@@ -149,7 +143,6 @@ void MixerClientImpl::Check(CheckContextSharedPtr &context,
     } else {
       ++total_quota_cache_misses_;
     }
-  }
 
   // TODO(jblatt) mjog thinks this is a big CPU hog.  Look into it.
   context->compressRequest(


### PR DESCRIPTION
**What this PR does / why we need it**:
Sidecar is not sending check request under hight traffic load.
This is just a code change that prove/as workaround that the values stored in context is incorrect, need more investigation to fix it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #17967

**Special notes for your reviewer**:


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
