### PR TITLE
feat(edges): enable edge reporting in stackdriver extension

### DIFF
--- a/extensions/stackdriver/BUILD
+++ b/extensions/stackdriver/BUILD
@@ -36,6 +36,8 @@ envoy_cc_library(
         "//extensions/common:context",
         "//extensions/stackdriver/common:constants",
         "//extensions/stackdriver/config/v1alpha1:stackdriver_plugin_config_cc_proto",
+        "//extensions/stackdriver/edges:edge_reporter",
+        "//extensions/stackdriver/edges:mesh_edges_service_client",
         "//extensions/stackdriver/log:exporter",
         "//extensions/stackdriver/log:logger",
         "//extensions/stackdriver/metric",

--- a/extensions/stackdriver/config/v1alpha1/BUILD
+++ b/extensions/stackdriver/config/v1alpha1/BUILD
@@ -27,4 +27,7 @@ cc_proto_library(
 proto_library(
     name = "stackdriver_plugin_config_proto",
     srcs = ["stackdriver_plugin_config.proto"],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+    ],
 )

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -18,6 +18,8 @@ syntax = "proto3";
 package stackdriver.config.v1alpha1;
 
 message PluginConfig {
+  // next id: 7
+
   // Optional. Controls whether to export server access log.
   bool disable_server_access_logging = 1;
 
@@ -31,6 +33,15 @@ message PluginConfig {
   string test_monitoring_endpoint = 3;
 
   // Optional. The endpoint that plugin targets for access log reporting. If not
-  // specified, the default Stackdriver monitoring endpoint will be used.
+  // specified, the default Stackdriver logging endpoint will be used.
   string test_logging_endpoint = 4;
+
+  // Optional. Controls whether or not to export mesh edges to a mesh edges
+  // service. This is disabled by default.
+  bool enable_mesh_edges_reporting = 5;
+
+  // Optional. The service endpoint that the plugin should use for mesh edges
+  // reporting. If not specified, the default Stackdriver endpoint will be used
+  // (when mesh edges reporting is enabled).
+  string mesh_edges_service_endpoint = 6;
 }

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -17,8 +17,10 @@ syntax = "proto3";
 
 package stackdriver.config.v1alpha1;
 
+import "google/protobuf/duration.proto";
+
 message PluginConfig {
-  // next id: 7
+  // next id: 8
 
   // Optional. Controls whether to export server access log.
   bool disable_server_access_logging = 1;
@@ -44,4 +46,9 @@ message PluginConfig {
   // reporting. If not specified, the default Stackdriver endpoint will be used
   // (when mesh edges reporting is enabled).
   string mesh_edges_service_endpoint = 6;
+
+  // Optional. Allows configuration of the time between calls out to the mesh
+  // edges service to report edges. The minimum configurable duration is `10s`.
+  // The default duration is `10m`.
+  google.protobuf.Duration mesh_edges_reporting_duration = 7;
 }

--- a/extensions/stackdriver/edges/TODO
+++ b/extensions/stackdriver/edges/TODO
@@ -2,6 +2,4 @@
 (P1) Destination service shortname (as opposed to host)
 (P1) Retries
 (P1) Better debugging / monitoring (exported metrics)
-(P1) WASM bits
 (P2) Support for other platforms / error handling when not on GCP
-(P3) Refactoring / alignment with other Stackdriver extension components

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -65,6 +65,7 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
   };
 
   GrpcService grpc_service;
+  grpc_service.mutable_google_grpc()->set_stat_prefix("mesh_edges");
   if (edges_endpoint.empty()) {
     // use application default creds and default target
     grpc_service.mutable_google_grpc()->set_target_uri(kMeshTelemetryService);

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -59,7 +59,6 @@ constexpr char kStackdriverExporter[] = "stackdriver_exporter";
 constexpr char kExporterRegistered[] = "registered";
 constexpr int kDefaultLogExportMilliseconds = 10000;                      // 10s
 constexpr long int kDefaultEdgeReportDurationNanoseconds = 600000000000;  // 10m
-constexpr int kNanosPerMillis = 1000000;
 
 bool StackdriverRootContext::onConfigure(
     std::unique_ptr<WasmData> configuration) {

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -90,6 +90,10 @@ class StackdriverRootContext : public RootContext {
 
   std::unique_ptr<::Extensions::Stackdriver::Edges::EdgeReporter>
       edge_reporter_;
+
+  long int last_edge_report_call_nanos_;
+
+  long int edge_report_duration_nanos_;
 };
 
 // StackdriverContext is per stream context. It has the same lifetime as

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -18,6 +18,7 @@
 #include "extensions/common/context.h"
 #include "extensions/stackdriver/common/constants.h"
 #include "extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.pb.h"
+#include "extensions/stackdriver/edges/edge_reporter.h"
 #include "extensions/stackdriver/log/logger.h"
 #include "extensions/stackdriver/metric/record.h"
 
@@ -71,6 +72,9 @@ class StackdriverRootContext : public RootContext {
   // Indicates whether to export server access log or not.
   bool enableServerAccessLog();
 
+  // Indicates whether or not to report edges to Stackdriver.
+  bool enableEdgeReporting();
+
   // Config for Stackdriver plugin.
   stackdriver::config::v1alpha1::PluginConfig config_;
 
@@ -83,6 +87,9 @@ class StackdriverRootContext : public RootContext {
 
   // Logger records and exports log entries to Stackdriver backend.
   std::unique_ptr<::Extensions::Stackdriver::Log::Logger> logger_;
+
+  std::unique_ptr<::Extensions::Stackdriver::Edges::EdgeReporter>
+      edge_reporter_;
 };
 
 // StackdriverContext is per stream context. It has the same lifetime as


### PR DESCRIPTION
This PR hooks in the edges reporting library into the full stackdriver extension. This will be disabled by default, but config params are added to support testing and transition to on-by-default.

This is a follow-on to https://github.com/istio/proxy/pull/2439.
