### PR TITLE
remove config time build metric

### DIFF
--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -80,11 +80,6 @@ bool PluginRootContext::onConfigure(std::unique_ptr<WasmData> configuration) {
   // scraper"
   stat_prefix = absl::StrCat("_", stat_prefix, "_");
 
-  Metric build(MetricType::Gauge, absl::StrCat(stat_prefix, "build"),
-               {MetricTag{"component", MetricTag::TagType::String},
-                MetricTag{"tag", MetricTag::TagType::String}});
-  build.record(1, "proxy", absl::StrCat(local_node_info_.istio_version(), ";"));
-
   stats_ = std::vector<StatGen>{
       StatGen(
           absl::StrCat(stat_prefix, "requests_total"), MetricType::Counter,


### PR DESCRIPTION
Removing build_metric until it can be properly added back from the sandbox.

fixes https://github.com/envoyproxy/envoy-wasm/issues/255#issuecomment-543237444

Sandbox does not support metric recording during config change.

I have tested this change and it *does not* crash.
