### PR TITLE
remove response header and not request header

### DIFF
--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -143,7 +143,7 @@ FilterHeadersStatus PluginContext::onResponseHeaders() {
   auto upstream_metadata_id = getResponseHeader(ExchangeMetadataHeaderId);
   if (upstream_metadata_id != nullptr &&
       !upstream_metadata_id->view().empty()) {
-    removeRequestHeader(ExchangeMetadataHeaderId);
+    removeResponseHeader(ExchangeMetadataHeaderId);
     setFilterStateStringValue(UpstreamMetadataIdKey,
                               upstream_metadata_id->view());
   }


### PR DESCRIPTION
When processing upstream response headers, the code was removing the request header instead of removing the response header for the x-peer-metadata-id