### PR TITLE
Expose GCS build and artifact buckets as variables

### DIFF
--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -42,6 +42,9 @@ GIT_SHA="$(git rev-parse --verify HEAD)"
 
 export BAZEL_BUILD_ARGS="--local_ram_resources=12288 --local_cpu_resources=8 --verbose_failures"
 
+GCS_BUILD_BUCKET="${GCS_BUILD_BUCKET:-istio-build}"
+GCS_ARTIFACTS_BUCKET="${GCS_ARTIFACTS_BUCKET:-istio-artifacts}"
+
 echo 'Create and push artifacts'
-make push_release RELEASE_GCS_PATH="gs://istio-build/proxy"
-make artifacts ARTIFACTS_GCS_PATH="gs://istio-artifacts/proxy/${GIT_SHA}/artifacts/debs"
+make push_release RELEASE_GCS_PATH="gs://${GCS_BUILD_BUCKET}/proxy"
+make artifacts ARTIFACTS_GCS_PATH="gs://${GCS_ARTIFACTS_BUCKET}/proxy/${GIT_SHA}/artifacts/debs"


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows Prow (or other script executor) to set the bucket location for both *builds* and *artifacts*. Private GitHub builds in Prow will set `GCS_BUILD_BUCKET ` and `GCS_ARTIFACTS_BUCKET ` in the CI environment. This change maintains the same *defaults* and is backwards compatible.


