### PR TITLE
Make envoy archive configurable from environment.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -185,3 +185,9 @@ build:debug -c dbg
 build --cxxopt -Wnon-virtual-dtor
 build --cxxopt -Wformat
 build --cxxopt -Wformat-security
+
+# Envoy repo overrides from the environment.
+build --action_env=ENVOY_REPOSITORY
+build --action_env=ENVOY_SHA
+build --action_env=ENVOY_SHA256
+build --action_env=ENVOY_PREFIX

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,8 +16,6 @@
 #
 workspace(name = "io_istio_proxy")
 
-# http_archive is not a native function since bazel 0.19
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//:repositories.bzl",
     "docker_dependencies",
@@ -34,6 +32,8 @@ bind(
     actual = "//external:ssl",
 )
 
+load("//:envoy_repository_rule.bzl", "envoy_repository_rule")
+
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelrc and .bazelversion files.
 #
@@ -42,13 +42,18 @@ ENVOY_SHA = "f12c992f9fb8c86e5f4f9bae4fa55ebf280acd30"
 
 ENVOY_SHA256 = "cb7915c17f5f8f093b105263b3da593c8a1359baa47faf0ba5ecaac33e84dc06"
 
+ENVOY_REPOSITORY = "https://github.com/envoyproxy/envoy-wasm"
+
+ENVOY_PREFIX = "envoy-wasm-"
+
 LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
 
-http_archive(
+envoy_repository_rule(
     name = "envoy",
+    prefix = ENVOY_PREFIX,
+    repository = ENVOY_REPOSITORY,
+    sha = ENVOY_SHA,
     sha256 = ENVOY_SHA256,
-    strip_prefix = "envoy-wasm-" + ENVOY_SHA,
-    url = "https://github.com/envoyproxy/envoy-wasm/archive/" + ENVOY_SHA + ".tar.gz",
 )
 
 # TODO(silentdai) Use bazel args to select envoy between local or http

--- a/envoy_repository_rule.bzl
+++ b/envoy_repository_rule.bzl
@@ -1,0 +1,42 @@
+# Copyright 2019 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+def _envoy_repository_rule_impl(ctx):
+    """Core implementation of envoy_repository_rule."""
+
+    # Set repo, sha, sha256, and prefix from environment (if defined) or supplied attribute.
+    _repo = ctx.os.environ.get("ENVOY_REPOSITORY", default = ctx.attr.repository)
+    _sha = ctx.os.environ.get("ENVOY_SHA", default = ctx.attr.sha)
+    _sha256 = ctx.os.environ.get("ENVOY_SHA256", default = ctx.attr.sha256)
+    _prefix = ctx.os.environ.get("ENVOY_PREFIX", default = ctx.attr.prefix)
+
+    # Download and extract archive.
+    ctx.download_and_extract(
+        sha256 = _sha256,
+        stripPrefix = _prefix + _sha,
+        url = _repo + "/archive/" + _sha + ".tar.gz",
+    )
+
+envoy_repository_rule = repository_rule(
+    environ = ["ENVOY_REPOSITORY", "ENVOY_SHA", "ENVOY_SHA256", "ENVOY_PREFIX"],
+    implementation = _envoy_repository_rule_impl,
+    attrs = {
+        "repository": attr.string(mandatory = True),
+        "sha": attr.string(mandatory = True),
+        "sha256": attr.string(mandatory = True),
+        "prefix": attr.string(mandatory = True),
+    },
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a new `envoy_repository_rule` bazel rule. It is a `repository_rule` with attributes that can be configured from the environment (e.g. `ENVOY_REPOSITORY`, `ENVOY_SHA`, `ENVOY_SHA256`, `ENVOY_PREFIX`). If the aforementioned env variables are **not** specified then the locally defined values are used (same as before this change).
