### PR TITLE
wasm: use raw bytes for filter state, add custom struct parser

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,10 +37,10 @@ bind(
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelrc and .bazelversion files.
 #
-# envoy-wasm commit date: 10/26/2019
-ENVOY_SHA = "656dab35f8837adb57ee9f08adf02853560528c0"
+# envoy-wasm commit date: 10/28/2019
+ENVOY_SHA = "3a5f31174cc0aa0290f79e372017b474a6b7e1dd"
 
-ENVOY_SHA256 = "1a65e58409720fb799eecc1209495fed695c72bfdf86a004855bd0b3fe76d029"
+ENVOY_SHA256 = "a4545344e59f68720e47f88c942aa13bb5a318eec164d6bfc638db7f169843e0"
 
 LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
 

--- a/extensions/common/BUILD
+++ b/extensions/common/BUILD
@@ -19,6 +19,7 @@ licenses(["notice"])
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_binary",
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_package",
@@ -58,6 +59,19 @@ envoy_cc_test(
     name = "context_test",
     size = "small",
     srcs = ["context_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":context",
+        "@envoy//source/extensions/common/wasm:wasm_lib",
+    ],
+)
+
+envoy_cc_binary(
+    name = "context_speed_test",
+    srcs = ["context_speed_test.cc"],
+    external_deps = [
+        "benchmark",
+    ],
     repository = "@envoy",
     deps = [
         ":context",

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -122,6 +122,9 @@ enum class TrafficDirection : int64_t {
 google::protobuf::util::Status extractNodeMetadata(
     const google::protobuf::Struct& metadata,
     wasm::common::NodeInfo* node_info);
+google::protobuf::util::Status extractNodeMetadataGeneric(
+    const google::protobuf::Struct& metadata,
+    wasm::common::NodeInfo* node_info);
 
 // Read from local node metadata and populate node_info.
 google::protobuf::util::Status extractLocalNodeMetadata(

--- a/extensions/common/context_speed_test.cc
+++ b/extensions/common/context_speed_test.cc
@@ -1,0 +1,127 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+#include "extensions/common/context.h"
+#include "google/protobuf/util/json_util.h"
+
+// WASM_PROLOG
+#ifdef NULL_PLUGIN
+namespace Wasm {
+#endif  // NULL_PLUGIN
+
+// END WASM_PROLOG
+
+namespace Common {
+
+using namespace google::protobuf::util;
+using namespace wasm::common;
+
+constexpr absl::string_view node_metadata_json = R"###(
+{
+   "NAME":"test_pod",
+   "NAMESPACE":"test_namespace",
+   "LABELS": {
+      "app": "productpage",
+      "version": "v1",
+      "pod-template-hash": "84975bc778"
+   },
+   "OWNER":"test_owner",
+   "WORKLOAD_NAME":"test_workload",
+   "PLATFORM_METADATA":{
+      "gcp_project":"test_project",
+      "gcp_cluster_location":"test_location",
+      "gcp_cluster_name":"test_cluster"
+   },
+   "ISTIO_VERSION":"istio-1.4",
+   "MESH_ID":"test-mesh"
+}
+)###";
+
+static void BM_GenericStructParser(benchmark::State& state) {
+  int outputBytes = 0;
+  google::protobuf::Struct metadata_struct;
+  JsonParseOptions json_parse_options;
+  JsonStringToMessage(std::string(node_metadata_json), &metadata_struct,
+                      json_parse_options);
+  auto bytes = metadata_struct.SerializeAsString();
+
+  for (auto _ : state) {
+    google::protobuf::Struct test_struct;
+    test_struct.ParseFromArray(bytes.data(), bytes.size());
+    outputBytes += test_struct.SpaceUsed();
+
+    NodeInfo node_info;
+    extractNodeMetadataGeneric(test_struct, &node_info);
+    outputBytes += node_info.SpaceUsed();
+  }
+  benchmark::DoNotOptimize(outputBytes);
+}
+BENCHMARK(BM_GenericStructParser);
+
+static void BM_CustomStructParser(benchmark::State& state) {
+  int outputBytes = 0;
+  google::protobuf::Struct metadata_struct;
+  JsonParseOptions json_parse_options;
+  JsonStringToMessage(std::string(node_metadata_json), &metadata_struct,
+                      json_parse_options);
+  auto bytes = metadata_struct.SerializeAsString();
+
+  for (auto _ : state) {
+    google::protobuf::Struct test_struct;
+    test_struct.ParseFromArray(bytes.data(), bytes.size());
+    outputBytes += test_struct.SpaceUsed();
+
+    NodeInfo node_info;
+    extractNodeMetadata(test_struct, &node_info);
+    outputBytes += node_info.SpaceUsed();
+  }
+  benchmark::DoNotOptimize(outputBytes);
+}
+BENCHMARK(BM_CustomStructParser);
+
+static void BM_MessageParser(benchmark::State& state) {
+  int outputBytes = 0;
+  NodeInfo node_info;
+  JsonParseOptions json_parse_options;
+  JsonStringToMessage(std::string(node_metadata_json), &node_info,
+                      json_parse_options);
+  auto bytes = node_info.SerializeAsString();
+
+  for (auto _ : state) {
+    NodeInfo test_info;
+    test_info.ParseFromArray(bytes.data(), bytes.size());
+    outputBytes += test_info.SpaceUsed();
+  }
+  benchmark::DoNotOptimize(outputBytes);
+}
+BENCHMARK(BM_MessageParser);
+
+}  // namespace Common
+
+// WASM_EPILOG
+#ifdef NULL_PLUGIN
+}  // namespace Wasm
+#endif
+
+// Boilerplate main(), which discovers benchmarks in the same file and runs
+// them.
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
+    return 1;
+  }
+  benchmark::RunSpecifiedBenchmarks();
+}

--- a/extensions/common/context_speed_test.cc
+++ b/extensions/common/context_speed_test.cc
@@ -51,7 +51,6 @@ constexpr absl::string_view node_metadata_json = R"###(
 )###";
 
 static void BM_GenericStructParser(benchmark::State& state) {
-  int outputBytes = 0;
   google::protobuf::Struct metadata_struct;
   JsonParseOptions json_parse_options;
   JsonStringToMessage(std::string(node_metadata_json), &metadata_struct,
@@ -61,18 +60,16 @@ static void BM_GenericStructParser(benchmark::State& state) {
   for (auto _ : state) {
     google::protobuf::Struct test_struct;
     test_struct.ParseFromArray(bytes.data(), bytes.size());
-    outputBytes += test_struct.SpaceUsed();
+    benchmark::DoNotOptimize(test_struct);
 
     NodeInfo node_info;
     extractNodeMetadataGeneric(test_struct, &node_info);
-    outputBytes += node_info.SpaceUsed();
+    benchmark::DoNotOptimize(node_info);
   }
-  benchmark::DoNotOptimize(outputBytes);
 }
 BENCHMARK(BM_GenericStructParser);
 
 static void BM_CustomStructParser(benchmark::State& state) {
-  int outputBytes = 0;
   google::protobuf::Struct metadata_struct;
   JsonParseOptions json_parse_options;
   JsonStringToMessage(std::string(node_metadata_json), &metadata_struct,
@@ -82,18 +79,16 @@ static void BM_CustomStructParser(benchmark::State& state) {
   for (auto _ : state) {
     google::protobuf::Struct test_struct;
     test_struct.ParseFromArray(bytes.data(), bytes.size());
-    outputBytes += test_struct.SpaceUsed();
+    benchmark::DoNotOptimize(test_struct);
 
     NodeInfo node_info;
     extractNodeMetadata(test_struct, &node_info);
-    outputBytes += node_info.SpaceUsed();
+    benchmark::DoNotOptimize(node_info);
   }
-  benchmark::DoNotOptimize(outputBytes);
 }
 BENCHMARK(BM_CustomStructParser);
 
 static void BM_MessageParser(benchmark::State& state) {
-  int outputBytes = 0;
   NodeInfo node_info;
   JsonParseOptions json_parse_options;
   JsonStringToMessage(std::string(node_metadata_json), &node_info,
@@ -103,9 +98,8 @@ static void BM_MessageParser(benchmark::State& state) {
   for (auto _ : state) {
     NodeInfo test_info;
     test_info.ParseFromArray(bytes.data(), bytes.size());
-    outputBytes += test_info.SpaceUsed();
+    benchmark::DoNotOptimize(test_info);
   }
-  benchmark::DoNotOptimize(outputBytes);
 }
 BENCHMARK(BM_MessageParser);
 

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -104,10 +104,6 @@ FilterHeadersStatus PluginContext::onRequestHeaders() {
     removeRequestHeader(ExchangeMetadataHeader);
     auto downstream_metadata_bytes =
         Base64::decodeWithoutPadding(downstream_metadata_value->view());
-    google::protobuf::Struct metadata;
-    metadata.ParseFromArray(downstream_metadata_bytes.data(),
-                            downstream_metadata_bytes.size());
-
     setFilterState(::Wasm::Common::kDownstreamMetadataKey,
                    downstream_metadata_bytes);
   }

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -46,7 +46,7 @@ NULL_PLUGIN_ROOT_REGISTRY;
 
 namespace {
 
-bool serializeToStringDeterministic(const google::protobuf::Value& metadata,
+bool serializeToStringDeterministic(const google::protobuf::Message& metadata,
                                     std::string* metadata_bytes) {
   google::protobuf::io::StringOutputStream md(metadata_bytes);
   google::protobuf::io::CodedOutputStream mcs(&md);
@@ -71,9 +71,9 @@ void PluginRootContext::updateMetadataValue() {
     return;
   }
 
-  google::protobuf::Value metadata;
-  const auto status = ::Wasm::Common::extractNodeMetadataValue(
-      node_metadata, metadata.mutable_struct_value());
+  google::protobuf::Struct metadata;
+  const auto status =
+      ::Wasm::Common::extractNodeMetadataValue(node_metadata, &metadata);
   if (!status.ok()) {
     logWarn(status.message().ToString());
     return;
@@ -104,15 +104,20 @@ FilterHeadersStatus PluginContext::onRequestHeaders() {
     removeRequestHeader(ExchangeMetadataHeader);
     auto downstream_metadata_bytes =
         Base64::decodeWithoutPadding(downstream_metadata_value->view());
-    setFilterState(DownstreamMetadataKey, downstream_metadata_bytes);
+    google::protobuf::Struct metadata;
+    metadata.ParseFromArray(downstream_metadata_bytes.data(),
+                            downstream_metadata_bytes.size());
+
+    setFilterState(::Wasm::Common::kDownstreamMetadataKey,
+                   downstream_metadata_bytes);
   }
 
   auto downstream_metadata_id = getRequestHeader(ExchangeMetadataHeaderId);
   if (downstream_metadata_id != nullptr &&
       !downstream_metadata_id->view().empty()) {
     removeRequestHeader(ExchangeMetadataHeaderId);
-    setFilterStateStringValue(DownstreamMetadataIdKey,
-                              downstream_metadata_id->view());
+    setFilterState(::Wasm::Common::kDownstreamMetadataIdKey,
+                   downstream_metadata_id->view());
   }
 
   auto metadata = metadataValue();
@@ -137,15 +142,16 @@ FilterHeadersStatus PluginContext::onResponseHeaders() {
     removeResponseHeader(ExchangeMetadataHeader);
     auto upstream_metadata_bytes =
         Base64::decodeWithoutPadding(upstream_metadata_value->view());
-    setFilterState(UpstreamMetadataKey, upstream_metadata_bytes);
+    setFilterState(::Wasm::Common::kUpstreamMetadataKey,
+                   upstream_metadata_bytes);
   }
 
   auto upstream_metadata_id = getResponseHeader(ExchangeMetadataHeaderId);
   if (upstream_metadata_id != nullptr &&
       !upstream_metadata_id->view().empty()) {
     removeResponseHeader(ExchangeMetadataHeaderId);
-    setFilterStateStringValue(UpstreamMetadataIdKey,
-                              upstream_metadata_id->view());
+    setFilterState(::Wasm::Common::kUpstreamMetadataIdKey,
+                   upstream_metadata_id->view());
   }
 
   auto metadata = metadataValue();

--- a/extensions/metadata_exchange/plugin.h
+++ b/extensions/metadata_exchange/plugin.h
@@ -46,20 +46,6 @@ using NullPluginRootRegistry =
 constexpr StringView ExchangeMetadataHeader = "x-envoy-peer-metadata";
 constexpr StringView ExchangeMetadataHeaderId = "x-envoy-peer-metadata-id";
 
-// DownstreamMetadataKey is the key in the request metadata for downstream peer
-// metadata
-constexpr StringView DownstreamMetadataKey =
-    "envoy.wasm.metadata_exchange.downstream";
-constexpr StringView DownstreamMetadataIdKey =
-    "envoy.wasm.metadata_exchange.downstream_id";
-
-// UpstreamMetadataKey is the key in the request metadata for downstream peer
-// metadata
-constexpr StringView UpstreamMetadataKey =
-    "envoy.wasm.metadata_exchange.upstream";
-constexpr StringView UpstreamMetadataIdKey =
-    "envoy.wasm.metadata_exchange.upstream_id";
-
 // PluginRootContext is the root context for all streams processed by the
 // thread. It has the same lifetime as the worker thread and acts as target for
 // interactions that outlives individual stream, e.g. timer, async calls.

--- a/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
@@ -246,35 +246,28 @@ void MetadataExchangeFilter::tryReadProxyData(Buffer::Instance& data) {
   auto key_metadata_it = value_struct.fields().find(ExchangeMetadataHeader);
   if (key_metadata_it != value_struct.fields().end()) {
     Envoy::ProtobufWkt::Value val = key_metadata_it->second;
-    setMetadata(config_->filter_direction_ == FilterDirection::Downstream
-                    ? UpstreamMetadataKey
-                    : DownstreamMetadataKey,
-                val);
+    setFilterState(config_->filter_direction_ == FilterDirection::Downstream
+                       ? UpstreamMetadataKey
+                       : DownstreamMetadataKey,
+                   val.SerializeAsString());
   }
   const auto key_metadata_id_it =
       value_struct.fields().find(ExchangeMetadataHeaderId);
   if (key_metadata_id_it != value_struct.fields().end()) {
     Envoy::ProtobufWkt::Value val = key_metadata_it->second;
-    setMetadata(config_->filter_direction_ == FilterDirection::Downstream
-                    ? UpstreamMetadataIdKey
-                    : DownstreamMetadataIdKey,
-                val);
+    setFilterState(config_->filter_direction_ == FilterDirection::Downstream
+                       ? UpstreamMetadataIdKey
+                       : DownstreamMetadataIdKey,
+                   val.SerializeAsString());
   }
 }
 
-void MetadataExchangeFilter::setMetadata(const std::string& key,
-                                         Envoy::ProtobufWkt::Value& value) {
+void MetadataExchangeFilter::setFilterState(const std::string& key,
+                                            absl::string_view value) {
   read_callbacks_->connection().streamInfo().filterState().setData(
       key,
       std::make_unique<::Envoy::Extensions::Common::Wasm::WasmState>(value),
       StreamInfo::FilterState::StateType::Mutable);
-}
-
-void MetadataExchangeFilter::setMetadataStringValue(
-    const std::string& key, const std::string& str_value) {
-  Envoy::ProtobufWkt::Value value;
-  value.set_string_value(str_value);
-  setMetadata(key, value);
 }
 
 void MetadataExchangeFilter::getMetadata(google::protobuf::Struct* metadata) {

--- a/src/envoy/tcp/metadata_exchange/metadata_exchange.h
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange.h
@@ -126,15 +126,8 @@ class MetadataExchangeFilter : public Network::Filter {
   // form of google::protobuf::any which encapsulates google::protobuf::struct.
   void tryReadProxyData(Buffer::Instance& data);
 
-  // Helper function to set Dynamic metadata.
-  void setMetadata(const std::string& key, ProtobufWkt::Value& value);
-
-  // Helper function to set Dynamic metadata string value.
-  void setMetadataStringValue(const std::string& key, const std::string& value);
-
-  // Helper function to set Dynamic metadata string value.
-  void setMetadataStructValue(const std::string& key,
-                              const ProtobufWkt::Value& value);
+  // Helper function to share the metadata with other filters.
+  void setFilterState(const std::string& key, absl::string_view value);
 
   // Helper function to get Dynamic metadata.
   void getMetadata(google::protobuf::Struct* metadata);


### PR DESCRIPTION
Benchmark result:
```
2019-10-28 16:06:41
Running bazel-bin/extensions/common/context_speed_test
Run on (32 X 2200 MHz CPU s)
CPU Caches:
  L1 Data 32K (x16)
  L1 Instruction 32K (x16)
  L2 Unified 256K (x16)
  L3 Unified 56320K (x1)
Load Average: 0.05, 0.29, 2.10
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
BM_GenericStructParser      37498 ns        37495 ns        18653
BM_CustomStructParser        5075 ns         5075 ns       139243
BM_MessageParser             1623 ns         1623 ns       430605
```

Seems like the custom struct parser is preferred, since it's not far off from protobuf parser (that is keep struct on the wire and ABI, and parse as message inside plugins).