### PR TITLE
metadata: skip sending metadata for explicit inbound/outbound

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -84,6 +84,15 @@ StringView AuthenticationPolicyString(ServiceAuthenticationPolicy policy) {
   ;
 }
 
+// Retrieves the traffic direction from the configuration context.
+TrafficDirection getTrafficDirection() {
+  int64_t direction;
+  if (getValue({"listener_direction"}, &direction)) {
+    return static_cast<TrafficDirection>(direction);
+  }
+  return TrafficDirection::Unspecified;
+}
+
 using google::protobuf::util::JsonStringToMessage;
 using google::protobuf::util::MessageToJsonString;
 

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -126,6 +126,9 @@ enum class TrafficDirection : int64_t {
   Outbound = 2,
 };
 
+// Retrieves the traffic direction from the configuration context.
+TrafficDirection getTrafficDirection();
+
 // Extracts NodeInfo from proxy node metadata passed in as a protobuf struct.
 // It converts the metadata struct to a JSON struct and parse NodeInfo proto
 // from that JSON struct.

--- a/extensions/metadata_exchange/plugin.h
+++ b/extensions/metadata_exchange/plugin.h
@@ -26,6 +26,7 @@ static const std::string EMPTY_STRING;
 
 #else
 
+#include "extensions/common/context.h"
 #include "extensions/common/wasm/null/null_plugin.h"
 
 namespace Envoy {
@@ -71,7 +72,9 @@ class PluginRootContext : public RootContext {
 // Per-stream context.
 class PluginContext : public Context {
  public:
-  explicit PluginContext(uint32_t id, RootContext* root) : Context(id, root) {}
+  explicit PluginContext(uint32_t id, RootContext* root) : Context(id, root) {
+    direction_ = ::Wasm::Common::getTrafficDirection();
+  }
 
   void onCreate() override{};
   FilterHeadersStatus onRequestHeaders() override;
@@ -83,6 +86,8 @@ class PluginContext : public Context {
   };
   inline StringView metadataValue() { return rootContext()->metadataValue(); };
   inline StringView nodeId() { return rootContext()->nodeId(); }
+
+  ::Wasm::Common::TrafficDirection direction_;
 };
 
 #ifdef NULL_PLUGIN

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -117,12 +117,7 @@ bool StackdriverRootContext::onConfigure(
     return false;
   }
 
-  int64_t direction;
-  if (getValue({"listener_direction"}, &direction)) {
-    direction_ = static_cast<::Wasm::Common::TrafficDirection>(direction);
-  } else {
-    logWarn("Unable to get plugin direction");
-  }
+  direction_ = ::Wasm::Common::getTrafficDirection();
 
   if (!logger_) {
     // logger should only be initiated once, for now there is no reason to

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -52,13 +52,9 @@ bool PluginRootContext::onConfigure(std::unique_ptr<WasmData> configuration) {
     LOG_WARN("cannot parse local node metadata ");
     return false;
   }
-  int64_t direction;
-  if (getValue({"listener_direction"}, &direction)) {
-    outbound_ = ::Wasm::Common::TrafficDirection::Outbound ==
-                static_cast<::Wasm::Common::TrafficDirection>(direction);
-  } else {
-    LOG_WARN("Unable to get plugin direction");
-  }
+  outbound_ = ::Wasm::Common::TrafficDirection::Outbound ==
+              ::Wasm::Common::getTrafficDirection();
+
   // Local data does not change, so populate it on config load.
   istio_dimensions_.init(outbound_, local_node_info_);
 


### PR DESCRIPTION
I've kept the root context a singleton so as not to break EnvoyFilter. 
This adds an extra call to ABI to read direction per request.