### PR TITLE
Enable TCP Metrics in Stats Plugin

### DIFF
--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -47,6 +47,7 @@ constexpr StringView kContentTypeHeaderKey = "content-type";
 
 const std::string kProtocolHTTP = "http";
 const std::string kProtocolGRPC = "grpc";
+const std::string kProtocolTCP = "tcp";
 
 const std::set<std::string> kGrpcContentTypes{
     "application/grpc", "application/grpc+proto", "application/grpc+json"};
@@ -155,6 +156,11 @@ google::protobuf::util::Status extractLocalNodeMetadata(
 void populateHTTPRequestInfo(bool outbound, bool use_host_header,
                              RequestInfo* request_info,
                              const std::string& destination_namespace);
+
+// populateTCPRequestInfo populates the RequestInfo struct. It needs access to
+// the request context.
+void populateTCPRequestInfo(bool outbound, RequestInfo* request_info,
+                            const std::string& destination_namespace);
 
 // Extracts node metadata value. It looks for values of all the keys
 // corresponding to EXCHANGE_KEYS in node_metadata and populates it in

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -427,7 +427,6 @@ class PluginContext : public Context {
   bool upstream_closed_;
   bool downstream_closed_;
   bool tcp_reported_;
-  ::Wasm::Common::RequestInfo request_info_;
 };
 
 #ifdef NULL_PLUGIN

--- a/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
@@ -262,7 +262,7 @@ void MetadataExchangeFilter::tryReadProxyData(Buffer::Instance& data) {
   const auto key_metadata_id_it =
       value_struct.fields().find(ExchangeMetadataHeaderId);
   if (key_metadata_id_it != value_struct.fields().end()) {
-    Envoy::ProtobufWkt::Value val = key_metadata_it->second;
+    Envoy::ProtobufWkt::Value val = key_metadata_id_it->second;
     setFilterState(config_->filter_direction_ == FilterDirection::Downstream
                        ? DownstreamMetadataIdKey
                        : UpstreamMetadataIdKey,

--- a/test/envoye2e/env/tcp_envoy_conf.go
+++ b/test/envoye2e/env/tcp_envoy_conf.go
@@ -45,6 +45,7 @@ static_resources:
 {{.ClusterTLSContext | indent 4 }}
   listeners:
   - name: app-to-client
+    traffic_direction: OUTBOUND
     address:
       socket_address:
         address: 127.0.0.1
@@ -99,6 +100,7 @@ static_resources:
 {{.ClusterTLSContext | indent 4 }}
   listeners:
   - name: server
+    traffic_direction: INBOUND
     address:
       socket_address:
         address: 127.0.0.1


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable TCP Metrics in Stats Plugin

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This currently works only on destination side and not on source side because 
we are not able to access filter state from upstream filters in downstream filters.
Will add issue# for it soon.
