### PR TITLE
fix(edges): add debug log for generated requests

### DIFF
--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -87,8 +87,8 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
 
 void MeshEdgesServiceClientImpl::reportTrafficAssertions(
     const ReportTrafficAssertionsRequest& request) const {
-
-  LOG_TRACE("mesh edge services client: sending request '" + request.DebugString() + "'");
+  LOG_TRACE("mesh edge services client: sending request '" +
+            request.DebugString() + "'");
 
   context_->grpcSimpleCall(
       grpc_service_, kMeshEdgesService, kReportTrafficAssertions, request,

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -87,6 +87,9 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
 
 void MeshEdgesServiceClientImpl::reportTrafficAssertions(
     const ReportTrafficAssertionsRequest& request) const {
+
+  logDebug("mesh edge services client: sending request '" + request.DebugString() + "'");
+
   context_->grpcSimpleCall(
       grpc_service_, kMeshEdgesService, kReportTrafficAssertions, request,
       kDefaultTimeoutMillisecond, success_callback_, failure_callback_);

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -88,7 +88,7 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
 void MeshEdgesServiceClientImpl::reportTrafficAssertions(
     const ReportTrafficAssertionsRequest& request) const {
 
-  logDebug("mesh edge services client: sending request '" + request.DebugString() + "'");
+  LOG_TRACE("mesh edge services client: sending request '" + request.DebugString() + "'");
 
   context_->grpcSimpleCall(
       grpc_service_, kMeshEdgesService, kReportTrafficAssertions, request,


### PR DESCRIPTION
Adding a debug log to view outgoing requests to mesh telemetry endpoint.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

