### PR TITLE
Update clang-format and buildifier.

### DIFF
--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <set>
+
 #include "absl/strings/string_view.h"
 #include "extensions/common/node_info.pb.h"
 #include "google/protobuf/struct.pb.h"

--- a/extensions/common/context_test.cc
+++ b/extensions/common/context_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/common/context.h"
+
 #include "google/protobuf/struct.pb.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/text_format.h"

--- a/extensions/common/node_info_cache.cc
+++ b/extensions/common/node_info_cache.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/common/node_info_cache.h"
+
 #include "extensions/common/context.h"
 
 #ifdef NULL_PLUGIN

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -16,6 +16,7 @@
 #include "extensions/metadata_exchange/plugin.h"
 
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_split.h"
 #include "extensions/common/node_info.pb.h"

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
+#include "extensions/stackdriver/log/logger.h"
+
 #include <memory>
 
 #include "extensions/stackdriver/common/constants.h"
 #include "extensions/stackdriver/common/utils.h"
-#include "extensions/stackdriver/log/logger.h"
 #include "gmock/gmock.h"
 #include "google/logging/v2/log_entry.pb.h"
 #include "google/protobuf/util/message_differencer.h"

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/stackdriver/metric/record.h"
+
 #include "extensions/stackdriver/common/constants.h"
 #include "extensions/stackdriver/metric/registry.h"
 

--- a/extensions/stackdriver/metric/registry_test.cc
+++ b/extensions/stackdriver/metric/registry_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "extensions/stackdriver/metric/registry.h"
+
 #include "extensions/stackdriver/common/constants.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"

--- a/extensions/stats/plugin_test.cc
+++ b/extensions/stats/plugin_test.cc
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
+#include "extensions/stats/plugin.h"
+
 #include <set>
 
 #include "absl/hash/hash_testing.h"
-#include "extensions/stats/plugin.h"
 #include "gtest/gtest.h"
 
 // WASM_PROLOG

--- a/include/istio/mixerclient/client.h
+++ b/include/istio/mixerclient/client.h
@@ -16,13 +16,13 @@
 #ifndef ISTIO_MIXERCLIENT_CLIENT_H
 #define ISTIO_MIXERCLIENT_CLIENT_H
 
+#include <vector>
+
 #include "environment.h"
 #include "include/istio/quota_config/requirement.h"
 #include "options.h"
 #include "src/istio/mixerclient/check_context.h"
 #include "src/istio/mixerclient/shared_attributes.h"
-
-#include <vector>
 
 namespace istio {
 namespace mixerclient {

--- a/include/istio/utils/concat_hash.h
+++ b/include/istio/utils/concat_hash.h
@@ -17,6 +17,7 @@
 #define ISTIO_UTILS_CONCAT_HASH_H_
 
 #include <string.h>
+
 #include <functional>
 #include <string>
 

--- a/include/istio/utils/protobuf.h
+++ b/include/istio/utils/protobuf.h
@@ -16,11 +16,11 @@
 #ifndef ISTIO_UTILS_PROTOBUF_H_
 #define ISTIO_UTILS_PROTOBUF_H_
 
+#include <chrono>
+
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/timestamp.pb.h"
-
-#include <chrono>
 
 namespace istio {
 namespace utils {

--- a/include/istio/utils/simple_lru_cache_inl.h
+++ b/include/istio/utils/simple_lru_cache_inl.h
@@ -47,6 +47,7 @@
 
 #include <stddef.h>
 #include <sys/time.h>
+
 #include <cassert>
 #include <cmath>
 #include <limits>

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -18,9 +18,10 @@
 #
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-CLANG_VERSION_REQUIRED="8.0.0"
-CLANG_FORMAT=$(which clang-format-${CLANG_VERSION_REQUIRED%%.*})
-if [[ ! -x "${CLANG_FORMAT}" ]]; then
+CLANG_VERSION_REQUIRED="9.0.0"
+CLANG_FORMAT=$(which clang-format)
+CLANG_VERSION="$(${CLANG_FORMAT} -version 2>/dev/null | cut -d ' ' -f 3 | cut -d '-' -f 1)"
+if [[ ! -x "${CLANG_FORMAT}" || "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then
   # Install required clang version to a folder and cache it.
   CLANG_DIRECTORY="${HOME}/clang"
   CLANG_FORMAT="${CLANG_DIRECTORY}/bin/clang-format"
@@ -33,17 +34,14 @@ if [[ ! -x "${CLANG_FORMAT}" ]]; then
     echo "Unsupported environment." ; exit 1 ;
   fi
 
-  CLANG_VERSION="$(${CLANG_FORMAT} -version 2>/dev/null | cut -d ' ' -f 3 | cut -d '-' -f 1)"
-  if [[ "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then
-    echo "Downloading clang-format: https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}"
-    echo "Installing required clang-format ${CLANG_VERSION_REQUIRED} to ${CLANG_DIRECTORY}"
+  echo "Downloading clang-format: https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}"
+  echo "Installing required clang-format ${CLANG_VERSION_REQUIRED} to ${CLANG_DIRECTORY}"
 
-    mkdir -p ${CLANG_DIRECTORY}
-    curl --silent --show-error --retry 10 \
-      "https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}" \
-      | tar Jx -C "${CLANG_DIRECTORY}" --strip=1 \
-    || { echo "Could not install required clang-format. Skip formatting." ; exit 1 ; }
-  fi
+  mkdir -p ${CLANG_DIRECTORY}
+  curl --silent --show-error --retry 10 \
+    "https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}" \
+    | tar Jx -C "${CLANG_DIRECTORY}" --strip=1 \
+  || { echo "Could not install required clang-format. Skip formatting." ; exit 1 ; }
 fi
 
 BUILDIFIER=$(which buildifier)
@@ -59,11 +57,11 @@ if [[ ! -x "${BUILDIFIER}" ]]; then
       echo "Unsupported environment." ; exit 1 ;
     fi
 
-    echo "Downloading buildifier: https://github.com/bazelbuild/buildtools/releases/download/0.20.0/${BUILDIFIER_BIN}"
+    echo "Downloading buildifier: https://github.com/bazelbuild/buildtools/releases/download/0.29.0/${BUILDIFIER_BIN}"
 
     mkdir -p "${HOME}/bin"
     curl --silent --show-error --retry 10 --location \
-      "https://github.com/bazelbuild/buildtools/releases/download/0.20.0/${BUILDIFIER_BIN}" \
+      "https://github.com/bazelbuild/buildtools/releases/download/0.29.0/${BUILDIFIER_BIN}" \
       -o "${BUILDIFIER}" \
     || { echo "Could not install required buildifier. Skip formatting." ; exit 1 ; }
     chmod +x ${BUILDIFIER}

--- a/src/envoy/http/alpn/alpn_filter.cc
+++ b/src/envoy/http/alpn/alpn_filter.cc
@@ -16,7 +16,6 @@
 #include "src/envoy/http/alpn/alpn_filter.h"
 
 #include "common/network/application_protocol.h"
-
 #include "envoy/upstream/cluster_manager.h"
 
 namespace Envoy {

--- a/src/envoy/http/authn/authenticator_base.cc
+++ b/src/envoy/http/authn/authenticator_base.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/authenticator_base.h"
+
 #include "common/common/assert.h"
 #include "common/config/metadata.h"
 #include "src/envoy/http/authn/authn_utils.h"

--- a/src/envoy/http/authn/authenticator_base_test.cc
+++ b/src/envoy/http/authn/authenticator_base_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/authenticator_base.h"
+
 #include "common/common/base64.h"
 #include "common/protobuf/protobuf.h"
 #include "envoy/api/v2/core/base.pb.h"

--- a/src/envoy/http/authn/authn_utils.cc
+++ b/src/envoy/http/authn/authn_utils.cc
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
+#include "authn_utils.h"
+
 #include <regex>
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
-#include "authn_utils.h"
 #include "common/json/json_loader.h"
 #include "google/protobuf/struct.pb.h"
 #include "src/envoy/http/jwt_auth/jwt.h"

--- a/src/envoy/http/authn/authn_utils_test.cc
+++ b/src/envoy/http/authn/authn_utils_test.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #include "src/envoy/http/authn/authn_utils.h"
+
 #include "common/common/base64.h"
 #include "common/common/utility.h"
 #include "src/envoy/http/authn/test_utils.h"

--- a/src/envoy/http/authn/filter_context.cc
+++ b/src/envoy/http/authn/filter_context.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/filter_context.h"
+
 #include "src/envoy/utils/filter_names.h"
 #include "src/envoy/utils/utils.h"
 

--- a/src/envoy/http/authn/filter_context_test.cc
+++ b/src/envoy/http/authn/filter_context_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/filter_context.h"
+
 #include "envoy/api/v2/core/base.pb.h"
 #include "src/envoy/http/authn/test_utils.h"
 #include "test/test_common/utility.h"

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/http_filter.h"
+
 #include "authentication/v1alpha1/policy.pb.h"
 #include "common/http/utility.h"
 #include "envoy/config/filter/http/authn/v2alpha1/config.pb.h"

--- a/src/envoy/http/authn/http_filter_test.cc
+++ b/src/envoy/http/authn/http_filter_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/http_filter.h"
+
 #include "common/common/base64.h"
 #include "common/http/header_map_impl.h"
 #include "common/stream_info/stream_info_impl.h"

--- a/src/envoy/http/authn/origin_authenticator.cc
+++ b/src/envoy/http/authn/origin_authenticator.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/origin_authenticator.h"
+
 #include "absl/strings/match.h"
 #include "authentication/v1alpha1/policy.pb.h"
 #include "src/envoy/http/authn/authn_utils.h"

--- a/src/envoy/http/authn/origin_authenticator_test.cc
+++ b/src/envoy/http/authn/origin_authenticator_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/origin_authenticator.h"
+
 #include "authentication/v1alpha1/policy.pb.h"
 #include "common/protobuf/protobuf.h"
 #include "envoy/api/v2/core/base.pb.h"

--- a/src/envoy/http/authn/peer_authenticator.cc
+++ b/src/envoy/http/authn/peer_authenticator.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/peer_authenticator.h"
+
 #include "common/http/utility.h"
 #include "src/envoy/utils/utils.h"
 

--- a/src/envoy/http/authn/peer_authenticator_test.cc
+++ b/src/envoy/http/authn/peer_authenticator_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/authn/peer_authenticator.h"
+
 #include "authentication/v1alpha1/policy.pb.h"
 #include "common/protobuf/protobuf.h"
 #include "envoy/api/v2/core/base.pb.h"

--- a/src/envoy/http/jwt_auth/http_filter.cc
+++ b/src/envoy/http/jwt_auth/http_filter.cc
@@ -15,13 +15,13 @@
 
 #include "src/envoy/http/jwt_auth/http_filter.h"
 
+#include <chrono>
+#include <string>
+
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"
 #include "envoy/http/async_client.h"
 #include "src/envoy/utils/filter_names.h"
-
-#include <chrono>
-#include <string>
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/http_filter.h
+++ b/src/envoy/http/jwt_auth/http_filter.h
@@ -15,10 +15,9 @@
 
 #pragma once
 
-#include "src/envoy/http/jwt_auth/jwt_authenticator.h"
-
 #include "common/common/logger.h"
 #include "envoy/http/filter.h"
+#include "src/envoy/http/jwt_auth/jwt_authenticator.h"
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/jwt.cc
+++ b/src/envoy/http/jwt_auth/jwt.cc
@@ -15,6 +15,14 @@
 
 #include "jwt.h"
 
+#include <algorithm>
+#include <cassert>
+#include <map>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "common/common/assert.h"
 #include "common/common/base64.h"
 #include "common/common/utility.h"
@@ -24,14 +32,6 @@
 #include "openssl/evp.h"
 #include "openssl/rsa.h"
 #include "openssl/sha.h"
-
-#include <algorithm>
-#include <cassert>
-#include <map>
-#include <sstream>
-#include <string>
-#include <utility>
-#include <vector>
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/jwt.h
+++ b/src/envoy/http/jwt_auth/jwt.h
@@ -15,13 +15,13 @@
 
 #pragma once
 
-#include "envoy/json/json_object.h"
-#include "openssl/ec.h"
-#include "openssl/evp.h"
-
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "envoy/json/json_object.h"
+#include "openssl/ec.h"
+#include "openssl/evp.h"
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/jwt_auth/jwt_authenticator.h"
+
 #include "common/http/message_impl.h"
 #include "common/http/utility.h"
 

--- a/src/envoy/http/jwt_auth/jwt_authenticator.h
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.h
@@ -17,7 +17,6 @@
 
 #include "common/common/logger.h"
 #include "envoy/http/async_client.h"
-
 #include "src/envoy/http/jwt_auth/auth_store.h"
 
 namespace Envoy {

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/jwt_auth/jwt_authenticator.h"
+
 #include "common/http/message_impl.h"
 #include "common/json/json_loader.h"
 #include "gtest/gtest.h"

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -15,11 +15,11 @@
 
 #include "jwt.h"
 
+#include <tuple>
+
 #include "common/common/utility.h"
 #include "common/json/json_loader.h"
 #include "test/test_common/utility.h"
-
-#include <tuple>
 
 namespace Envoy {
 namespace Http {

--- a/src/envoy/http/jwt_auth/token_extractor.cc
+++ b/src/envoy/http/jwt_auth/token_extractor.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/jwt_auth/token_extractor.h"
+
 #include "absl/strings/match.h"
 #include "common/common/utility.h"
 #include "common/http/utility.h"

--- a/src/envoy/http/jwt_auth/token_extractor_test.cc
+++ b/src/envoy/http/jwt_auth/token_extractor_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/jwt_auth/token_extractor.h"
+
 #include "gtest/gtest.h"
 #include "test/test_common/utility.h"
 

--- a/src/envoy/http/mixer/check_data.cc
+++ b/src/envoy/http/mixer/check_data.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/mixer/check_data.h"
+
 #include "absl/strings/string_view.h"
 #include "common/common/base64.h"
 #include "src/envoy/http/jwt_auth/jwt.h"

--- a/src/envoy/http/mixer/config.cc
+++ b/src/envoy/http/mixer/config.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/mixer/config.h"
+
 #include "src/envoy/utils/config.h"
 
 namespace Envoy {

--- a/src/envoy/http/mixer/control.cc
+++ b/src/envoy/http/mixer/control.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/http/mixer/control.h"
+
 #include "include/istio/utils/local_attributes.h"
 
 using ::istio::mixer::v1::Attributes;

--- a/src/envoy/tcp/forward_downstream_sni/config.cc
+++ b/src/envoy/tcp/forward_downstream_sni/config.cc
@@ -17,7 +17,6 @@
 
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
-
 #include "src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.h"
 
 namespace Envoy {

--- a/src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.cc
+++ b/src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.cc
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-#include "envoy/network/connection.h"
+#include "src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.h"
 
 #include "common/network/upstream_server_name.h"
-#include "src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.h"
+#include "envoy/network/connection.h"
 
 namespace Envoy {
 namespace Tcp {

--- a/src/envoy/tcp/forward_downstream_sni/forward_downstream_sni_test.cc
+++ b/src/envoy/tcp/forward_downstream_sni/forward_downstream_sni_test.cc
@@ -13,17 +13,15 @@
  * limitations under the License.
  */
 
+#include "src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.h"
+
+#include "common/network/upstream_server_name.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/envoy/tcp/forward_downstream_sni/config.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-#include "common/network/upstream_server_name.h"
-
-#include "src/envoy/tcp/forward_downstream_sni/config.h"
-#include "src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.h"
 
 using testing::_;
 using testing::Matcher;

--- a/src/envoy/tcp/metadata_exchange/config.cc
+++ b/src/envoy/tcp/metadata_exchange/config.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/tcp/metadata_exchange/config.h"
+
 #include "envoy/network/connection.h"
 #include "envoy/registry/registry.h"
 #include "src/envoy/tcp/metadata_exchange/metadata_exchange.h"

--- a/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include "src/envoy/tcp/metadata_exchange/metadata_exchange.h"
+
 #include <cstdint>
 #include <string>
 
@@ -25,7 +27,6 @@
 #include "envoy/stats/scope.h"
 #include "extensions/common/context.h"
 #include "extensions/common/wasm/wasm_state.h"
-#include "src/envoy/tcp/metadata_exchange/metadata_exchange.h"
 #include "src/envoy/tcp/metadata_exchange/metadata_exchange_initial_header.h"
 
 namespace Envoy {

--- a/src/envoy/tcp/metadata_exchange/metadata_exchange_test.cc
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/tcp/metadata_exchange/metadata_exchange.h"
+
 #include "common/buffer/buffer_impl.h"
 #include "common/protobuf/protobuf.h"
 #include "gmock/gmock.h"

--- a/src/envoy/tcp/mixer/control.cc
+++ b/src/envoy/tcp/mixer/control.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/tcp/mixer/control.h"
+
 #include "include/istio/utils/local_attributes.h"
 #include "src/envoy/utils/mixer_control.h"
 

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/tcp/sni_verifier/config.h"
+
 #include "envoy/registry/registry.h"
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -18,13 +18,11 @@
 
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 
+#include "common/common/assert.h"
 #include "envoy/buffer/buffer.h"
 #include "envoy/common/exception.h"
 #include "envoy/network/connection.h"
 #include "envoy/stats/scope.h"
-
-#include "common/common/assert.h"
-
 #include "openssl/err.h"
 #include "openssl/ssl.h"
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -15,11 +15,9 @@
 
 #pragma once
 
+#include "common/common/logger.h"
 #include "envoy/network/filter.h"
 #include "envoy/stats/scope.h"
-
-#include "common/common/logger.h"
-
 #include "openssl/ssl.h"
 
 namespace Envoy {

--- a/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier_test.cc
@@ -13,20 +13,18 @@
  * limitations under the License.
  */
 
+#include "src/envoy/tcp/sni_verifier/sni_verifier.h"
+
 #include <climits>
 #include <string>
 
-#include "src/envoy/tcp/sni_verifier/config.h"
-#include "src/envoy/tcp/sni_verifier/sni_verifier.h"
-
 #include "common/buffer/buffer_impl.h"
-
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/envoy/tcp/sni_verifier/config.h"
 #include "test/extensions/filters/listener/tls_inspector/tls_utility.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using testing::_;
 using testing::NiceMock;

--- a/src/envoy/tcp/tcp_cluster_rewrite/config.cc
+++ b/src/envoy/tcp/tcp_cluster_rewrite/config.cc
@@ -14,10 +14,10 @@
  */
 
 #include "src/envoy/tcp/tcp_cluster_rewrite/config.h"
-#include "src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.h"
 
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
+#include "src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.h"
 #include "src/envoy/utils/config.h"
 
 using namespace ::istio::envoy::config::filter::network::tcp_cluster_rewrite;

--- a/src/envoy/tcp/tcp_cluster_rewrite/config.h
+++ b/src/envoy/tcp/tcp_cluster_rewrite/config.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "envoy/config/filter/network/tcp_cluster_rewrite/v2alpha1/config.pb.h"
-
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
 #include "envoy/registry/registry.h"

--- a/src/envoy/tcp/tcp_cluster_rewrite/config_test.cc
+++ b/src/envoy/tcp/tcp_cluster_rewrite/config_test.cc
@@ -15,10 +15,9 @@
 
 #include "src/envoy/tcp/tcp_cluster_rewrite/config.h"
 
-#include "test/mocks/server/mocks.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "test/mocks/server/mocks.h"
 
 using namespace ::istio::envoy::config::filter::network::tcp_cluster_rewrite;
 using testing::_;

--- a/src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.cc
+++ b/src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.cc
@@ -15,10 +15,9 @@
 
 #include "src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.h"
 
-#include "envoy/network/connection.h"
-
 #include "common/common/assert.h"
 #include "common/tcp_proxy/tcp_proxy.h"
+#include "envoy/network/connection.h"
 
 using namespace ::istio::envoy::config::filter::network::tcp_cluster_rewrite;
 

--- a/src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.h
+++ b/src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.h
@@ -17,10 +17,9 @@
 
 #include <regex>
 
+#include "common/common/logger.h"
 #include "envoy/config/filter/network/tcp_cluster_rewrite/v2alpha1/config.pb.h"
 #include "envoy/network/filter.h"
-
-#include "common/common/logger.h"
 
 using namespace ::istio::envoy::config::filter::network::tcp_cluster_rewrite;
 

--- a/src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite_test.cc
+++ b/src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite_test.cc
@@ -13,17 +13,15 @@
  * limitations under the License.
  */
 
-#include "common/tcp_proxy/tcp_proxy.h"
-
-#include "src/envoy/tcp/tcp_cluster_rewrite/config.h"
 #include "src/envoy/tcp/tcp_cluster_rewrite/tcp_cluster_rewrite.h"
 
+#include "common/tcp_proxy/tcp_proxy.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/envoy/tcp/tcp_cluster_rewrite/config.h"
 #include "test/mocks/network/mocks.h"
 #include "test/mocks/server/mocks.h"
 #include "test/mocks/stream_info/mocks.h"
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 
 using namespace ::istio::envoy::config::filter::network::tcp_cluster_rewrite;
 using testing::_;

--- a/src/envoy/utils/authn.cc
+++ b/src/envoy/utils/authn.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/authn.h"
+
 #include "common/common/base64.h"
 #include "include/istio/utils/attribute_names.h"
 #include "src/envoy/utils/filter_names.h"

--- a/src/envoy/utils/authn_test.cc
+++ b/src/envoy/utils/authn_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/authn.h"
+
 #include "common/protobuf/protobuf.h"
 #include "include/istio/utils/attribute_names.h"
 #include "src/istio/authn/context.pb.h"

--- a/src/envoy/utils/config.cc
+++ b/src/envoy/utils/config.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/config.h"
+
 #include "common/common/logger.h"
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/util/json_util.h"

--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 #include "src/envoy/utils/grpc_transport.h"
+
 #include "absl/types/optional.h"
 #include "src/envoy/utils/header_update.h"
 

--- a/src/envoy/utils/grpc_transport.h
+++ b/src/envoy/utils/grpc_transport.h
@@ -16,13 +16,13 @@
 #pragma once
 
 #include <common/grpc/async_client_impl.h>
+
 #include <memory>
 
 #include "common/common/logger.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/grpc/async_client.h"
 #include "envoy/http/header_map.h"
-
 #include "envoy/upstream/cluster_manager.h"
 #include "include/istio/mixerclient/client.h"
 

--- a/src/envoy/utils/header_update.h
+++ b/src/envoy/utils/header_update.h
@@ -18,7 +18,6 @@
 #include "common/common/base64.h"
 #include "common/common/logger.h"
 #include "envoy/http/header_map.h"
-
 #include "include/istio/control/http/controller.h"
 
 namespace Envoy {

--- a/src/envoy/utils/mixer_control.cc
+++ b/src/envoy/utils/mixer_control.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/mixer_control.h"
+
 #include "src/envoy/utils/grpc_transport.h"
 
 using ::istio::mixerclient::Statistics;

--- a/src/envoy/utils/mixer_control_test.cc
+++ b/src/envoy/utils/mixer_control_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/mixer_control.h"
+
 #include "fmt/printf.h"
 #include "mixer/v1/config/client/client_config.pb.h"
 #include "src/envoy/utils/utils.h"

--- a/src/envoy/utils/stats.cc
+++ b/src/envoy/utils/stats.cc
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
-#include <chrono>
-
 #include "src/envoy/utils/stats.h"
+
+#include <chrono>
 
 namespace Envoy {
 namespace Utils {

--- a/src/envoy/utils/utils.cc
+++ b/src/envoy/utils/utils.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/utils.h"
+
 #include "absl/strings/match.h"
 #include "include/istio/utils/attributes_builder.h"
 #include "mixer/v1/attributes.pb.h"

--- a/src/envoy/utils/utils_test.cc
+++ b/src/envoy/utils/utils_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/envoy/utils/utils.h"
+
 #include "gmock/gmock.h"
 #include "mixer/v1/config/client/client_config.pb.h"
 #include "src/istio/mixerclient/check_context.h"

--- a/src/istio/control/client_context_base.cc
+++ b/src/istio/control/client_context_base.cc
@@ -14,6 +14,7 @@
  */
 
 #include "client_context_base.h"
+
 #include "include/istio/mixerclient/check_response.h"
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"

--- a/src/istio/control/http/client_context.cc
+++ b/src/istio/control/http/client_context.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/http/client_context.h"
+
 #include "include/istio/utils/attribute_names.h"
 
 using ::istio::mixer::v1::Attributes_AttributeValue;

--- a/src/istio/control/http/controller_impl.cc
+++ b/src/istio/control/http/controller_impl.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/http/controller_impl.h"
+
 #include "src/istio/control/http/request_handler_impl.h"
 
 using ::istio::mixer::v1::config::client::ServiceConfig;

--- a/src/istio/control/http/service_context.cc
+++ b/src/istio/control/http/service_context.cc
@@ -14,6 +14,7 @@
  */
 
 #include "service_context.h"
+
 #include "include/istio/utils/attribute_names.h"
 #include "src/istio/control/http/attributes_builder.h"
 

--- a/src/istio/control/tcp/attributes_builder.cc
+++ b/src/istio/control/tcp/attributes_builder.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/tcp/attributes_builder.h"
+
 #include "google/protobuf/stubs/status.h"
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"

--- a/src/istio/control/tcp/attributes_builder_test.cc
+++ b/src/istio/control/tcp/attributes_builder_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/tcp/attributes_builder.h"
+
 #include "google/protobuf/stubs/status.h"
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"

--- a/src/istio/control/tcp/controller_impl.cc
+++ b/src/istio/control/tcp/controller_impl.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/tcp/controller_impl.h"
+
 #include "src/istio/control/tcp/request_handler_impl.h"
 
 using ::istio::mixer::v1::config::client::TcpClientConfig;

--- a/src/istio/control/tcp/request_handler_impl.cc
+++ b/src/istio/control/tcp/request_handler_impl.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/control/tcp/request_handler_impl.h"
+
 #include "src/istio/control/tcp/attributes_builder.h"
 
 using ::google::protobuf::util::Status;

--- a/src/istio/mixerclient/attribute_compressor.cc
+++ b/src/istio/mixerclient/attribute_compressor.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/attribute_compressor.h"
+
 #include "google/protobuf/arena.h"
 #include "include/istio/utils/protobuf.h"
 #include "src/istio/mixerclient/global_dictionary.h"

--- a/src/istio/mixerclient/attribute_compressor_test.cc
+++ b/src/istio/mixerclient/attribute_compressor_test.cc
@@ -14,12 +14,13 @@
  */
 
 #include "src/istio/mixerclient/attribute_compressor.h"
-#include "include/istio/utils/attributes_builder.h"
 
 #include <time.h>
+
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
+#include "include/istio/utils/attributes_builder.h"
 
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::Attributes_AttributeValue;

--- a/src/istio/mixerclient/check_cache.cc
+++ b/src/istio/mixerclient/check_cache.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/check_cache.h"
+
 #include "include/istio/utils/protobuf.h"
 #include "src/istio/utils/logger.h"
 

--- a/src/istio/mixerclient/check_cache_test.cc
+++ b/src/istio/mixerclient/check_cache_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/check_cache.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "include/istio/utils/attributes_builder.h"

--- a/src/istio/mixerclient/check_context.h
+++ b/src/istio/mixerclient/check_context.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "google/protobuf/arena.h"
 #include "google/protobuf/stubs/status.h"
 #include "include/istio/mixerclient/check_response.h"
@@ -29,8 +31,6 @@
 #include "src/istio/mixerclient/quota_cache.h"
 #include "src/istio/mixerclient/shared_attributes.h"
 #include "src/istio/utils/logger.h"
-
-#include <vector>
 
 namespace istio {
 namespace mixerclient {

--- a/src/istio/mixerclient/client_impl.h
+++ b/src/istio/mixerclient/client_impl.h
@@ -16,14 +16,14 @@
 #ifndef ISTIO_MIXERCLIENT_CLIENT_IMPL_H
 #define ISTIO_MIXERCLIENT_CLIENT_IMPL_H
 
+#include <atomic>
+#include <random>
+
 #include "include/istio/mixerclient/client.h"
 #include "src/istio/mixerclient/attribute_compressor.h"
 #include "src/istio/mixerclient/check_cache.h"
 #include "src/istio/mixerclient/quota_cache.h"
 #include "src/istio/mixerclient/report_batch.h"
-
-#include <atomic>
-#include <random>
 
 using ::istio::mixerclient::CheckContextSharedPtr;
 using ::istio::mixerclient::SharedAttributesSharedPtr;

--- a/src/istio/mixerclient/referenced.cc
+++ b/src/istio/mixerclient/referenced.cc
@@ -15,12 +15,12 @@
 
 #include "src/istio/mixerclient/referenced.h"
 
-#include "global_dictionary.h"
-
 #include <algorithm>
 #include <map>
 #include <set>
 #include <sstream>
+
+#include "global_dictionary.h"
 
 using ::istio::mixer::v1::Attributes;
 using ::istio::mixer::v1::Attributes_AttributeValue;

--- a/src/istio/mixerclient/referenced_test.cc
+++ b/src/istio/mixerclient/referenced_test.cc
@@ -15,11 +15,10 @@
 
 #include "src/istio/mixerclient/referenced.h"
 
-#include "include/istio/utils/attributes_builder.h"
-#include "include/istio/utils/concat_hash.h"
-
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "include/istio/utils/attributes_builder.h"
+#include "include/istio/utils/concat_hash.h"
 
 using ::google::protobuf::TextFormat;
 using ::istio::mixer::v1::Attributes;

--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/report_batch.h"
+
 #include "include/istio/utils/protobuf.h"
 #include "src/istio/mixerclient/status_util.h"
 #include "src/istio/utils/logger.h"

--- a/src/istio/mixerclient/report_batch.h
+++ b/src/istio/mixerclient/report_batch.h
@@ -16,12 +16,12 @@
 #ifndef ISTIO_MIXERCLIENT_REPORT_BATCH_H
 #define ISTIO_MIXERCLIENT_REPORT_BATCH_H
 
-#include "include/istio/mixerclient/client.h"
-#include "src/istio/mixerclient/attribute_compressor.h"
-
 #include <atomic>
 #include <memory>
 #include <mutex>
+
+#include "include/istio/mixerclient/client.h"
+#include "src/istio/mixerclient/attribute_compressor.h"
 
 namespace istio {
 namespace mixerclient {

--- a/src/istio/mixerclient/report_batch_test.cc
+++ b/src/istio/mixerclient/report_batch_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/report_batch.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "include/istio/utils/attributes_builder.h"

--- a/src/istio/mixerclient/status_util.cc
+++ b/src/istio/mixerclient/status_util.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/mixerclient/status_util.h"
+
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 

--- a/src/istio/prefetch/circular_queue_test.cc
+++ b/src/istio/prefetch/circular_queue_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/prefetch/circular_queue.h"
+
 #include "gtest/gtest.h"
 
 namespace istio {

--- a/src/istio/prefetch/quota_prefetch.cc
+++ b/src/istio/prefetch/quota_prefetch.cc
@@ -14,11 +14,12 @@
  */
 
 #include "include/istio/prefetch/quota_prefetch.h"
+
+#include <mutex>
+
 #include "src/istio/prefetch/circular_queue.h"
 #include "src/istio/prefetch/time_based_counter.h"
 #include "src/istio/utils/logger.h"
-
-#include <mutex>
 
 using namespace std::chrono;
 

--- a/src/istio/prefetch/quota_prefetch_test.cc
+++ b/src/istio/prefetch/quota_prefetch_test.cc
@@ -14,10 +14,11 @@
  */
 
 #include "include/istio/prefetch/quota_prefetch.h"
-#include "gtest/gtest.h"
 
 #include <list>
 #include <utility>
+
+#include "gtest/gtest.h"
 
 using namespace std::chrono;
 using Tick = ::istio::prefetch::QuotaPrefetch::Tick;

--- a/src/istio/prefetch/time_based_counter_test.cc
+++ b/src/istio/prefetch/time_based_counter_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/prefetch/time_based_counter.h"
+
 #include "gtest/gtest.h"
 
 namespace istio {

--- a/src/istio/quota_config/config_parser_impl.h
+++ b/src/istio/quota_config/config_parser_impl.h
@@ -16,10 +16,10 @@
 #ifndef ISTIO_QUOTA_CONFIG_CONFIG_PARSER_IMPL_H_
 #define ISTIO_QUOTA_CONFIG_CONFIG_PARSER_IMPL_H_
 
-#include "include/istio/quota_config/config_parser.h"
-
 #include <regex>
 #include <unordered_map>
+
+#include "include/istio/quota_config/config_parser.h"
 
 namespace istio {
 namespace quota_config {

--- a/src/istio/quota_config/config_parser_impl_test.cc
+++ b/src/istio/quota_config/config_parser_impl_test.cc
@@ -13,11 +13,10 @@
  * limitations under the License.
  */
 
-#include "include/istio/quota_config/config_parser.h"
-#include "include/istio/utils/attributes_builder.h"
-
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
+#include "include/istio/quota_config/config_parser.h"
+#include "include/istio/utils/attributes_builder.h"
 
 using ::google::protobuf::TextFormat;
 using ::istio::mixer::v1::Attributes;

--- a/src/istio/utils/local_attributes.cc
+++ b/src/istio/utils/local_attributes.cc
@@ -14,6 +14,7 @@
  */
 
 #include "include/istio/utils/local_attributes.h"
+
 #include "include/istio/utils/attribute_names.h"
 #include "include/istio/utils/attributes_builder.h"
 

--- a/src/istio/utils/logger.cc
+++ b/src/istio/utils/logger.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/utils/logger.h"
+
 #include <stdarg.h>
 #include <stdio.h>
 

--- a/src/istio/utils/logger_test.cc
+++ b/src/istio/utils/logger_test.cc
@@ -14,9 +14,10 @@
  */
 
 #include "src/istio/utils/logger.h"
-#include "gtest/gtest.h"
 
 #include <memory>
+
+#include "gtest/gtest.h"
 
 namespace istio {
 namespace utils {

--- a/src/istio/utils/simple_lru_cache_test.cc
+++ b/src/istio/utils/simple_lru_cache_test.cc
@@ -17,10 +17,10 @@
 // Tests of SimpleLRUCache
 
 #include "include/istio/utils/simple_lru_cache.h"
-#include "include/istio/utils/simple_lru_cache_inl.h"
 
 #include <math.h>
 #include <unistd.h>
+
 #include <algorithm>
 #include <cmath>
 #include <iostream>
@@ -30,6 +30,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "include/istio/utils/simple_lru_cache_inl.h"
 
 using ::testing::HasSubstr;
 using ::testing::NotNull;

--- a/src/istio/utils/status.cc
+++ b/src/istio/utils/status.cc
@@ -14,6 +14,7 @@
  */
 
 #include "include/istio/utils/status.h"
+
 #include "google/protobuf/stubs/status.h"
 
 using StatusCode = ::google::protobuf::util::error::Code;

--- a/src/istio/utils/utils.h
+++ b/src/istio/utils/utils.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string>
+
 #include "google/protobuf/struct.pb.h"
 
 namespace istio {

--- a/src/istio/utils/utils_test.cc
+++ b/src/istio/utils/utils_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include "src/istio/utils/utils.h"
+
 #include "gtest/gtest.h"
 
 namespace istio {

--- a/test/integration/int_client.cc
+++ b/test/integration/int_client.cc
@@ -16,6 +16,7 @@
 #include "int_client.h"
 
 #include <future>
+
 #include "common/http/http1/codec_impl.h"
 #include "common/http/http2/codec_impl.h"
 #include "common/stats/isolated_store_impl.h"

--- a/test/integration/int_client.h
+++ b/test/integration/int_client.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <future>
+
 #include "common/api/api_impl.h"
 #include "common/common/thread.h"
 #include "common/network/raw_buffer_socket.h"

--- a/test/integration/int_client_server_test.cc
+++ b/test/integration/int_client_server_test.cc
@@ -14,6 +14,7 @@
  */
 
 #include <future>
+
 #include "common/network/utility.h"
 #include "gtest/gtest.h"
 #include "int_client.h"

--- a/test/integration/int_server.cc
+++ b/test/integration/int_server.cc
@@ -14,7 +14,9 @@
  */
 
 #include "int_server.h"
+
 #include <future>
+
 #include "common/common/lock_guard.h"
 #include "common/common/logger.h"
 #include "common/grpc/codec.h"


### PR DESCRIPTION
This prevents CI from dowloading clang-format-8 all the time.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>