### PR TITLE
Fix environment variable passing in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,6 @@ RUN = $(CONTAINER_CLI) run -t -i --sig-proxy=true -u $(UID):docker --rm \
 	--mount type=volume,source=go,destination="/go" \
 	--mount type=volume,source=gocache,destination="/gocache" \
 	-w /work $(IMG)
-else
-$(info Building with your local toolchain.)
-RUN =
-GOBIN ?= $(GOPATH)/bin
-endif
 
 MAKE = $(RUN) make --no-print-directory -e -f Makefile.core.mk
 
@@ -97,3 +92,11 @@ default:
 	@$(MAKE)
 
 .PHONY: default
+
+else
+
+$(info Building with your local toolchain.)
+GOBIN ?= $(GOPATH)/bin
+include Makefile.core.mk
+
+endif


### PR DESCRIPTION
This fixes a regression caused by updating (which in this case was
really a downgrade) during branches


I am not sure if this is the best fix... we may want to port this to the 1.4 common files branch and update here. I don't want to just revert because then we will be pointing to the master branch