### PR TITLE
fix(edges): use unknown for missing metadata instance values

### DIFF
--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -42,7 +42,7 @@ using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 
 constexpr char kUnknown[] = "unknown";
 
-std::string valueOrUnknown(std::string value) {
+std::string valueOrUnknown(const std::string& value) {
   if (value.length() == 0) {
     return kUnknown;
   }


### PR DESCRIPTION
**What this PR does / why we need it**:
If metadata values are missing, we should report Workload Instance information with "unknown" values instead of leaving them empty. This PR sets defaults via changes to `instanceFromMetadata()`.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

**Which issue this PR fixes**

fixes https://github.com/istio/istio/issues/18711
