### PR TITLE
[don't merge] shows /quitquitquit timeout after 30s in stackdriver parallel test

### DIFF
--- a/test/envoye2e/env/http_client.go
+++ b/test/envoye2e/env/http_client.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// HTTP client time out.
-	httpTimeOut = 5 * time.Second
+	httpTimeOut = 30 * time.Second
 
 	// Maximum number of ping the server to wait.
 	maxAttempts = 30

--- a/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
@@ -96,7 +96,7 @@ filter_chains:
           config:
             root_id: "stackdriver_inbound"
             vm_config:
-              vm_id: "stackdriver_inbound"
+              vm_id: "stackdriver_inbound{{.N}}"
               runtime: "envoy.wasm.runtime.null"
               code:
                 inline_string: "envoy.wasm.null.stackdriver"


### PR DESCRIPTION
ENVOY_DEBUG=trace go test -v -run Parallel ./test/envoye2e/stackdriver_plugin/