### PR TITLE
Revert "Update metadata exchange filter config"

### DIFF
--- a/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
+++ b/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
@@ -6,7 +6,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_INBOUND
+        context: ANY # inbound, outbound, and gateway
         listener:
           filterChain:
             filter:
@@ -19,46 +19,6 @@ spec:
             config:
               configuration: envoy.wasm.metadata_exchange
               vm_config:
-                vm_id: mx_inbound
                 runtime: envoy.wasm.runtime.null
                 code:
                   inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: SIDECAR_OUTBOUND
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: envoy.filters.http.wasm
-          config:
-            config:
-              configuration: envoy.wasm.metadata_exchange
-              vm_config:
-                vm_id: mx_outbound
-                runtime: envoy.wasm.runtime.null
-                code:
-                  inline_string: envoy.wasm.metadata_exchange
-    - applyTo: HTTP_FILTER
-      match:
-        context: GATEWAY
-        listener:
-          filterChain:
-            filter:
-              name: "envoy.http_connection_manager"
-      patch:
-        operation: INSERT_BEFORE
-        value:
-          name: envoy.filters.http.wasm
-          config:
-            config:
-              configuration: envoy.wasm.metadata_exchange
-              vm_config:
-                vm_id: mx_outbound
-                runtime: envoy.wasm.runtime.null
-                code:
-                  inline_string: envoy.wasm.metadata_exchange
-


### PR DESCRIPTION
Reverts istio/proxy#2539

This is not needed since per stream context actually has corresponding listener config. Mx filter gets direction in each stream, so it does not need vm id to distinguish.