### PR TITLE
Enable envoy repo override w/ ENVOY_REPOSITORY, ENVOY_SHA, ENVOY_PREFIX

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -45,3 +45,11 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
     export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --google_credentials=${GOOGLE_APPLICATION_CREDENTIALS} --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
   fi
 fi
+
+# Override envoy.
+if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_SHA:-}" && "${ENVOY_PREFIX:-}" ]]; then
+  TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
+  trap 'rm -rf ${TMP_DIR:?}' EXIT
+  BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --override_repository=envoy=${TMP_DIR}/${ENVOY_PREFIX}-${ENVOY_SHA}"
+  curl -nsSfL "${ENVOY_REPOSITORY}/archive/${ENVOY_SHA}.tar.gz" | tar -C "${TMP_DIR}" -xz
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a means to override the `envoy` repo in `istio/proxy`. It can be configured from the environment (e.g. `ENVOY_REPOSITORY`, `ENVOY_SHA`, `ENVOY_PREFIX`). This is a more robust and less intrusive alternative to the original attempt: #2496.

This works both locally and in CI (i.e. Prow) (given a valid`.netrc` file).

Example **.netrc**
```text
machine github.com login <access-token>
```

**Which issue this PR fixes** 

fixes https://github.com/istio/istio/issues/18730
