### PR TITLE
Allow ENVOY_SHA to be the same as one defined in WORKSPACE

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -15,6 +15,7 @@
 WD=$(dirname $0)
 WD=$(cd $WD; pwd)
 ROOT=$(dirname $WD)
+WORKSPACE="${ROOT}/WORKSPACE"
 
 # Exit immediately for non zero status
 set -e
@@ -47,9 +48,10 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
 fi
 
 # Override envoy.
-if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_SHA:-}" && "${ENVOY_PREFIX:-}" ]]; then
+if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_PREFIX:-}" ]]; then
   TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
   trap 'rm -rf ${TMP_DIR:?}' EXIT
+  ENVOY_SHA="${ENVOY_SHA:-$(grep -Pom1 "^ENVOY_SHA = \"\K[a-zA-Z0-9]{40}" "$WORKSPACE")}"
   BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --override_repository=envoy=${TMP_DIR}/${ENVOY_PREFIX}-${ENVOY_SHA}"
   curl -nsSfL "${ENVOY_REPOSITORY}/archive/${ENVOY_SHA}.tar.gz" | tar -C "${TMP_DIR}" -xz
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an extension (and follow-up) of #2555. This change will allow overriding of the `ENVOY_REPOSITORY` and `ENVOY_PREFIX` externally while retaining the same versioned `sha` for `ENVOY_SHA` - by extracting the value from `WORKSPACE`. For a broader discussion on the need, check out: https://github.com/istio/test-infra/pull/2091#discussion_r345572359
