### PR TITLE
istio_authn: bypass CORS preflight request

### DIFF
--- a/src/envoy/http/authn/BUILD
+++ b/src/envoy/http/authn/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//src/envoy/utils:filter_names_lib",
         "//src/envoy/utils:utils_lib",
         "//src/istio/authn:context_proto_cc_proto",
+        "@envoy//source/common/http:headers_lib",
     ],
 )
 

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -165,5 +165,35 @@ TEST_P(AuthenticationFilterIntegrationTest, CheckValidJwtPassAuthentication) {
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 }
 
+TEST_P(AuthenticationFilterIntegrationTest, CORSPreflight) {
+  config_helper_.addFilter(kAuthnFilterWithJwt);
+  initialize();
+
+  // The AuthN filter requires JWT. The http request contains validated JWT and
+  // the authentication should succeed.
+  codec_client_ =
+      makeHttpConnection(makeClientConnection((lookupPort("http"))));
+  auto headers = Http::TestHeaderMapImpl{
+      {":method", "OPTIONS"},
+      {":path", "/"},
+      {":scheme", "http"},
+      {":authority", "host"},
+      {"x-forwarded-for", "10.0.0.1"},
+      {"access-control-request-method", "GET"},
+      {"origin", "example.com"},
+  };
+  auto response = codec_client_->makeHeaderOnlyRequest(headers);
+
+  // Wait for request to upstream (backend)
+  waitForNextUpstreamRequest();
+  // Send backend response.
+  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}},
+                                   true);
+
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
 }  // namespace
 }  // namespace Envoy

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -169,8 +169,8 @@ TEST_P(AuthenticationFilterIntegrationTest, CORSPreflight) {
   config_helper_.addFilter(kAuthnFilterWithJwt);
   initialize();
 
-  // The AuthN filter requires JWT. The http request contains validated JWT and
-  // the authentication should succeed.
+  // The AuthN filter requires JWT but should bypass CORS preflight request even it doesn't have
+  // JWT token.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto headers = Http::TestHeaderMapImpl{

--- a/src/envoy/http/authn/http_filter_integration_test.cc
+++ b/src/envoy/http/authn/http_filter_integration_test.cc
@@ -169,8 +169,8 @@ TEST_P(AuthenticationFilterIntegrationTest, CORSPreflight) {
   config_helper_.addFilter(kAuthnFilterWithJwt);
   initialize();
 
-  // The AuthN filter requires JWT but should bypass CORS preflight request even it doesn't have
-  // JWT token.
+  // The AuthN filter requires JWT but should bypass CORS preflight request even
+  // it doesn't have JWT token.
   codec_client_ =
       makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto headers = Http::TestHeaderMapImpl{


### PR DESCRIPTION
**What this PR does / why we need it**:
Bypass the CORS preflight request in the istio_authn filter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/istio/istio/issues/16171

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
