### PR TITLE
Update stackdriver metric label cardinality option

### DIFF
--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -44,8 +44,9 @@ message PluginConfig {
   // large cache. To turn off the cache, set this field to a negative value.
   int32 max_peer_cache_size = 5;
 
-  // Optional: Disable using host header as a fallback if destination service is
-  // not available from the controlplane. Disable the fallback if the host
-  // header originates outsides the mesh, like at ingress.
-  bool disable_host_header_fallback = 6;
+  // Optional: Disable using traffic data for metric labels. Specifically:
+  // * Disable using host header as a fallback if destination service is
+  // not available from the controlplane.
+  // * Disable using gRPC path for request operation. Fallback to HTTP methods.
+  bool disable_traffic_data_label = 6;
 }

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -22,14 +22,16 @@ namespace Extensions {
 namespace Stackdriver {
 namespace Metric {
 
-void record(bool is_outbound, const ::wasm::common::NodeInfo &local_node_info,
+void record(bool is_outbound, bool use_traffic_data,
+            const ::wasm::common::NodeInfo &local_node_info,
             const ::wasm::common::NodeInfo &peer_node_info,
             const ::Wasm::Common::RequestInfo &request_info) {
   double latency_ms =
       double(request_info.end_timestamp - request_info.start_timestamp) /
       Stackdriver::Common::kNanosecondsPerMillisecond;
   const auto &operation =
-      request_info.request_protocol == ::Wasm::Common::kProtocolGRPC
+      request_info.request_protocol == ::Wasm::Common::kProtocolGRPC &&
+              use_traffic_data
           ? request_info.request_url_path
           : request_info.request_operation;
   if (is_outbound) {

--- a/extensions/stackdriver/metric/record.h
+++ b/extensions/stackdriver/metric/record.h
@@ -24,7 +24,8 @@ namespace Metric {
 
 // Record metrics based on local node info and request info.
 // Reporter kind deceides the type of metrics to record.
-void record(bool is_outbound, const ::wasm::common::NodeInfo &local_node_info,
+void record(bool is_outbound, bool use_traffic_data,
+            const ::wasm::common::NodeInfo &local_node_info,
             const ::wasm::common::NodeInfo &peer_node_info,
             const ::Wasm::Common::RequestInfo &request_info);
 

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -65,7 +65,7 @@ class StackdriverRootContext : public RootContext {
   // Get direction of traffic relative to this proxy.
   bool isOutbound();
 
-  bool useHostHeaderFallback() const { return use_host_header_fallback_; };
+  bool useTrafficDataLabel() const { return use_traffic_data_label_; };
 
   // Records telemetry based on the given request info.
   void record(const ::Wasm::Common::RequestInfo& request_info);
@@ -105,7 +105,7 @@ class StackdriverRootContext : public RootContext {
 
   long int edge_report_duration_nanos_;
 
-  bool use_host_header_fallback_;
+  bool use_traffic_data_label_;
 };
 
 // StackdriverContext is per stream context. It has the same lifetime as

--- a/extensions/stackdriver/testdata/stackdriver_filter.yaml
+++ b/extensions/stackdriver/testdata/stackdriver_filter.yaml
@@ -67,7 +67,7 @@ spec:
             config:
               root_id: stackdriver_outbound
               configuration: |
-                {"disable_host_header_fallback": true}
+                {"disable_traffic_data_label": true}
               vm_config:
                 vm_id: stackdriver_outbound
                 runtime: envoy.wasm.runtime.null


### PR DESCRIPTION
Rename and extend the cardinality option to also control using gRPC request path for operation label. I just renamed the label directly to make it general and update the json option to ignore unknown field, since we don't actually transfer this proto over wire and it is experimental. 