### PR TITLE
Use struct value in setfilterstate in metadata exchange filter

### DIFF
--- a/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
@@ -257,7 +257,7 @@ void MetadataExchangeFilter::tryReadProxyData(Buffer::Instance& data) {
     setFilterState(config_->filter_direction_ == FilterDirection::Downstream
                        ? DownstreamMetadataKey
                        : UpstreamMetadataKey,
-                   val.SerializeAsString());
+                   val.struct_value().SerializeAsString());
   }
   const auto key_metadata_id_it =
       value_struct.fields().find(ExchangeMetadataHeaderId);
@@ -266,7 +266,7 @@ void MetadataExchangeFilter::tryReadProxyData(Buffer::Instance& data) {
     setFilterState(config_->filter_direction_ == FilterDirection::Downstream
                        ? DownstreamMetadataIdKey
                        : UpstreamMetadataIdKey,
-                   val.SerializeAsString());
+                   val.string_value());
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use struct value in setfilterstate in metadata exchange filter

When setting filterstate in metadata exchange filter, currently it is setting serialized bytes of Envoy::ProbufWkt::Value itself, rather than the underlying object of Value,  because of which stats plugin can's deserialize it.