### PR TITLE
disable tsan integ test

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -81,7 +81,8 @@ test_asan:
 test_tsan:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) //src/envoy:envoy
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) -- $(BAZEL_TEST_TARGETS) $(SANITIZER_EXCLUSIONS)
-	env ENVOY_PATH=$(BAZEL_ENVOY_PATH) GO111MODULE=on go test ./...
+	# Disabled due to flakiness
+	# env ENVOY_PATH=$(BAZEL_ENVOY_PATH) GO111MODULE=on go test ./...
 
 check:
 	@echo >&2 "Please use \"make lint\" instead."


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

We need to fight flakes with fire. Disabling until we can make tests more stable and known TSAN issues are solved.
