### PR TITLE
Fix Makefile bugs on Arm64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ export BUILD_WITH_CONTAINER ?= 0
 LOCAL_ARCH := $(shell uname -m)
 ifeq ($(LOCAL_ARCH),x86_64)
     TARGET_ARCH ?= amd64
-else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
+else ifeq ($(LOCAL_ARCH) ,aarch64)
     TARGET_ARCH ?= arm64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
     TARGET_ARCH ?= arm


### PR DESCRIPTION
The command `uname -m` on arm64 platform return the value
'aarch64', but not arm64.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

**What this PR does / why we need it**:
Fix Arm64 native build bugs in Makefile

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
