### PR TITLE
fix bazel calls when using local envoy and --override_repository

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -53,7 +53,7 @@ BAZEL_CONFIG_ASAN = --config=macos-asan
 BAZEL_CONFIG_TSAN = # no working config
 endif
 
-BAZEL_OUTPUT_PATH := $(shell bazel info output_path)
+BAZEL_OUTPUT_PATH := $(shell bazel info $(BAZEL_BUILD_ARGS) output_path)
 BAZEL_ENVOY_PATH ?= $(BAZEL_OUTPUT_PATH)/k8-fastbuild/bin/src/envoy/envoy
 
 build:

--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -30,8 +30,17 @@ ROOT=/go/src
 # Configure available resources and disable IPv6 tests.
 export BAZEL_BUILD_ARGS="--local_ram_resources=12288 --local_cpu_resources=8 --verbose_failures --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
 
+# Override envoy.
+if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_PREFIX:-}" ]]; then
+  TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
+  trap 'rm -rf ${TMP_DIR:?}' EXIT
+  ENVOY_SHA="${ENVOY_SHA:-$(grep -Pom1 "^ENVOY_SHA = \"\K[a-zA-Z0-9]{40}" "$WORKSPACE")}"
+  BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --override_repository=envoy=${TMP_DIR}/${ENVOY_PREFIX}-${ENVOY_SHA}"
+  curl -nsSfL "${ENVOY_REPOSITORY}/archive/${ENVOY_SHA}.tar.gz" | tar -C "${TMP_DIR}" -xz
+fi
+
 # e2e tests under //test/envoye2e/... use Bazel artifacts.
-export BAZEL_OUT="$(bazel info output_path)/k8-fastbuild/bin"
+export BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-fastbuild/bin"
 
 # Use GCP service account when available.
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
@@ -45,13 +54,4 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
     echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE}"
     export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --google_credentials=${GOOGLE_APPLICATION_CREDENTIALS} --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
   fi
-fi
-
-# Override envoy.
-if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_PREFIX:-}" ]]; then
-  TMP_DIR=$(mktemp -d -t envoy-XXXXXXXXXX)
-  trap 'rm -rf ${TMP_DIR:?}' EXIT
-  ENVOY_SHA="${ENVOY_SHA:-$(grep -Pom1 "^ENVOY_SHA = \"\K[a-zA-Z0-9]{40}" "$WORKSPACE")}"
-  BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --override_repository=envoy=${TMP_DIR}/${ENVOY_PREFIX}-${ENVOY_SHA}"
-  curl -nsSfL "${ENVOY_REPOSITORY}/archive/${ENVOY_SHA}.tar.gz" | tar -C "${TMP_DIR}" -xz
 fi

--- a/scripts/push-debian.sh
+++ b/scripts/push-debian.sh
@@ -67,7 +67,7 @@ fi
 # Symlinks don't work, use full path as a temporary workaround.
 # See: https://github.com/istio/istio/issues/15714 for details.
 # k8-opt is the output directory for x86_64 optimized builds (-c opt, so --config=release-symbol and --config=release).
-BAZEL_OUT="$(bazel info output_path)/k8-opt/bin"
+BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
 BAZEL_BINARY="${BAZEL_OUT}/tools/deb/istio-proxy"
 
 bazel build ${BAZEL_BUILD_ARGS} --config=release ${BAZEL_TARGET}

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -98,13 +98,13 @@ do
       CONFIG_PARAMS="--config=release"
       BINARY_BASE_NAME="envoy-alpha"
       PACKAGE_BASE_NAME="istio-proxy"
-      BAZEL_OUT="$(bazel info output_path)/k8-opt/bin"
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "release-symbol")
       CONFIG_PARAMS="--config=release-symbol"
       BINARY_BASE_NAME="envoy-symbol"
       PACKAGE_BASE_NAME=""
-      BAZEL_OUT="$(bazel info output_path)/k8-opt/bin"
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "asan")
       # NOTE: libc++ is dynamically linked in this build.
@@ -112,13 +112,13 @@ do
       CONFIG_PARAMS="${BAZEL_CONFIG_ASAN} --config=release-symbol"
       BINARY_BASE_NAME="envoy-asan"
       PACKAGE_BASE_NAME=""
-      BAZEL_OUT="$(bazel info output_path)/k8-opt/bin"
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "debug")
       CONFIG_PARAMS="--config=debug"
       BINARY_BASE_NAME="envoy-debug"
       PACKAGE_BASE_NAME="istio-proxy-debug"
-      BAZEL_OUT="$(bazel info output_path)/k8-dbg/bin"
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-dbg/bin"
       ;;
   esac
 


### PR DESCRIPTION
**What this PR does / why we need it**:
For performing **build/test** operations with a **local** envoy source; one configured via the `--override_repository` flag.

Otherwise, bazel will emit errors like:
```console
ERROR: An error occurred during the fetch of repository 'envoy'
```
and 
```console
ERROR: no such package @envoy//...
``` 

on `bazel info` calls (since the *override* flag is unknown to the command) which is problematic for some/most `make` targets that need to be aware of the envoy binary or bazel output locations.

cc @howardjohn @yxue 
