### PR TITLE
Added support for aarch64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ ifeq ($(LOCAL_ARCH),x86_64)
     TARGET_ARCH ?= amd64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 5),armv8)
     TARGET_ARCH ?= arm64
+else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 7),aarch64)
+    TARGET_ARCH ?= arm64
 else ifeq ($(shell echo $(LOCAL_ARCH) | head -c 4),armv)
     TARGET_ARCH ?= arm
 else


### PR DESCRIPTION
Added support for aarch64 architecture

**What this PR does / why we need it**:
When I compiled on aarch64 machine, it suggested that this architecture is not supported
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes support for aarch64 architecture
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
