### PR TITLE
fix(edges): remove unknown defaults

### DIFF
--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -40,39 +40,29 @@ using google::cloud::meshtelemetry::v1alpha1::
     TrafficAssertion_Protocol_PROTOCOL_TCP;
 using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 
-constexpr char kUnknown[] = "unknown";
-
-std::string valueOrUnknown(const std::string& value) {
-  if (value.length() == 0) {
-    return kUnknown;
-  }
-  return value;
-}
-
 namespace {
 void instanceFromMetadata(const ::wasm::common::NodeInfo& node_info,
                           WorkloadInstance* instance) {
   // TODO(douglas-reid): support more than just kubernetes instances
-  absl::StrAppend(instance->mutable_uid(), "kubernetes://",
-                  valueOrUnknown(node_info.name()), ".",
-                  valueOrUnknown(node_info.namespace_()));
+  if ((node_info.name().length() > 0) &&
+      (node_info.namespace_().length() > 0)) {
+    absl::StrAppend(instance->mutable_uid(), "kubernetes://", node_info.name(),
+                    ".", node_info.namespace_());
+  }
   // TODO(douglas-reid): support more than just GCP ?
   const auto& platform_metadata = node_info.platform_metadata();
   const auto location_iter = platform_metadata.find(Common::kGCPLocationKey);
   if (location_iter != platform_metadata.end()) {
     instance->set_location(location_iter->second);
-  } else {
-    instance->set_location(kUnknown);
   }
   const auto cluster_iter = platform_metadata.find(Common::kGCPClusterNameKey);
   if (cluster_iter != platform_metadata.end()) {
     instance->set_cluster_name(cluster_iter->second);
-  } else {
-    instance->set_cluster_name(kUnknown);
   }
-  instance->set_owner_uid(valueOrUnknown(node_info.owner()));
-  instance->set_workload_name(valueOrUnknown(node_info.workload_name()));
-  instance->set_workload_namespace(valueOrUnknown(node_info.namespace_()));
+
+  instance->set_owner_uid(node_info.owner());
+  instance->set_workload_name(node_info.workload_name());
+  instance->set_workload_namespace(node_info.namespace_());
 };
 
 }  // namespace

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -134,14 +134,7 @@ const char kWantUnknownGrpcRequest[] = R"(
     protocol: PROTOCOL_HTTP
     destination_service_name: "httpbin"
     destination_service_namespace: "test_namespace"
-    source: {
-      workload_namespace: "unknown"
-      workload_name: "unknown"
-      cluster_name: "unknown"
-      location: "unknown"
-      owner_uid: "unknown"
-      uid: "kubernetes://unknown.unknown"
-    }
+    source: {}
     destination: {
       workload_namespace: "test_namespace"
       workload_name: "test_workload"


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the handling of missing metadata from the edges reporter.

Support on the server-side was added to handle missing values. This is no longer needed, and is actually harmful (as it can lead to invalid locations, etc.).

/cc @quentinmit