### PR TITLE
Update Envoy SHA to HEAD of istio/envoy:release-1.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,11 +35,11 @@ bind(
 # When updating envoy sha manually please update the sha in istio.deps file also
 #
 # Determine SHA256 `wget https://github.com/istio/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
-# envoy commit date: 11/06/2019
+# envoy commit date: 11/21/2019
 # bazel version: 0.28.1
-ENVOY_SHA = "de61162e207b2ab3ea42ae72afa4b8f7fc346ec7"
+ENVOY_SHA = "57d5df8e871f6451d9f24249c5fc8cdbbc3f45ae"
 
-ENVOY_SHA256 = "c0a2bc24893d95c05be202bdcd20dae4fe3416fe9c7115097cde7b48161297e2"
+ENVOY_SHA256 = "79c13ed6bde021915b2bb50f487f51354ca16296a03fc7142b78aef1395bd58b"
 
 LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
 

--- a/istio.deps
+++ b/istio.deps
@@ -11,6 +11,6 @@
 		"name": "ENVOY_SHA",
 		"repoName": "istio/envoy",
 		"file": "WORKSPACE",
-		"lastStableSHA": "de61162e207b2ab3ea42ae72afa4b8f7fc346ec7"
+		"lastStableSHA": "57d5df8e871f6451d9f24249c5fc8cdbbc3f45ae"
 	}
 ]


### PR DESCRIPTION
Cherry-pick the Envoy SHA update from the [`release-1.3.6-patch` branch](https://github.com/istio/proxy/tree/release-1.3.6-cherrypick) / [`1.3.6` tag](https://github.com/istio/proxy/releases/tag/1.3.6).