### PR TITLE
Add support for Access Log Policy Filter

### DIFF
--- a/extensions/access_log_policy/BUILD
+++ b/extensions/access_log_policy/BUILD
@@ -1,0 +1,29 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "access_log_policy_lib",
+    srcs = [
+        "config.cc",
+        "plugin.cc",
+    ],
+    hdrs = [
+        "plugin.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//extensions/access_log_policy/config/v1alpha1:access_log_policy_config_cc_proto",
+        "//extensions/common:context",
+        "//extensions/common:istio_dimensions",
+        "@envoy//source/common/common:base64_lib",
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
+    ],
+)

--- a/extensions/access_log_policy/Makefile
+++ b/extensions/access_log_policy/Makefile
@@ -1,0 +1,17 @@
+DOCKER_SDK=/sdk
+CPP_API:=${DOCKER_SDK}
+CPP_CONTEXT_LIB = ${CPP_API}/proxy_wasm_intrinsics.cc
+ABSL = /root/abseil-cpp
+ABSL_CPP = ${ABSL}/absl/strings/str_cat.cc ${ABSL}/absl/strings/str_split.cc ${ABSL}/absl/strings/numbers.cc ${ABSL}/absl/strings/ascii.cc
+
+PROTO_SRCS = extensions/common/node_info.pb.cc
+COMMON_SRCS = extensions/common/context.cc
+
+all: plugin.wasm
+
+%.wasm %.wat: %.cc ${CPP_API}/proxy_wasm_intrinsics.h ${CPP_API}/proxy_wasm_enums.h ${CPP_API}/proxy_wasm_externs.h ${CPP_API}/proxy_wasm_api.h ${CPP_API}/proxy_wasm_intrinsics.js ${CPP_CONTEXT_LIB}
+	protoc extensions/common/node_info.proto --cpp_out=.
+	em++ -s STANDALONE_WASM=1 -s EMIT_EMSCRIPTEN_METADATA=1 --std=c++17 -O3 -I${CPP_API} -I${CPP_API}/google/protobuf -I../../extensions/common -I. -I/usr/local/include -I${ABSL} --js-library ${CPP_API}/proxy_wasm_intrinsics.js ${ABSL_CPP} $*.cc ${CPP_API}/proxy_wasm_intrinsics.pb.cc ${PROTO_SRCS} ${COMMON_SRCS} ${CPP_CONTEXT_LIB} ${CPP_API}/libprotobuf.a -o $*.wasm
+	rm -f $*.wast
+	rm -f extensions/common/node_info.pb.*
+	chown ${uid}.${gid} $^

--- a/extensions/access_log_policy/README.md
+++ b/extensions/access_log_policy/README.md
@@ -1,0 +1,13 @@
+# WebAssembly
+
+This plugin can be compiled and run via the Envoy WebAssembly support.
+
+## Creating build Docker image.
+
+Follow the instructions in the github.com/istio/envoy/api/wasm/cpp/README.md to build the WebAssembly Docker build image.
+
+## Build via the Docker image.
+
+```bash
+./build_wasm.sh
+```

--- a/extensions/access_log_policy/build_wasm.sh
+++ b/extensions/access_log_policy/build_wasm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+docker run -e uid="$(id -u)" -e gid="$(id -g)" -v $PWD:/work -w /work -v $(realpath $PWD/../../extensions):/work/extensions gcr.io/istio-testing/wasmsdk:v2 bash /build_wasm.sh
+rmdir extensions

--- a/extensions/access_log_policy/config.cc
+++ b/extensions/access_log_policy/config.cc
@@ -1,0 +1,52 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/common/base64.h"
+#include "extensions/access_log_policy/plugin.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Wasm {
+namespace AccessLogPolicy {
+namespace Plugin {
+::Envoy::Extensions::Common::Wasm::Null::NullPluginRootRegistry*
+    context_registry_{};
+}  // namespace Plugin
+
+// Registration glue
+
+class AccessLogPolicyFactory
+    : public ::Envoy::Extensions::Common::Wasm::Null::NullVmPluginFactory {
+ public:
+  const std::string name() const override {
+    return "envoy.wasm.access_log_policy";
+  }
+  std::unique_ptr<::Envoy::Extensions::Common::Wasm::Null::NullVmPlugin>
+  create() const override {
+    return std::make_unique<
+        ::Envoy::Extensions::Common::Wasm::Null::NullPlugin>(
+        Plugin::context_registry_);
+  }
+};
+
+static Registry::RegisterFactory<
+    AccessLogPolicyFactory,
+    ::Envoy::Extensions::Common::Wasm::Null::NullVmPluginFactory>
+    register_;
+
+}  // namespace AccessLogPolicy
+}  // namespace Wasm
+}  // namespace Extensions
+}  // namespace Envoy

--- a/extensions/access_log_policy/config/v1alpha1/BUILD
+++ b/extensions/access_log_policy/config/v1alpha1/BUILD
@@ -1,0 +1,32 @@
+# Copyright 2019 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+cc_proto_library(
+    name = "access_log_policy_config_cc_proto",
+    visibility = [
+        "//extensions/access_log_policy:__pkg__",
+    ],
+    deps = ["access_log_policy_config_proto"],
+)
+
+proto_library(
+    name = "access_log_policy_config_proto",
+    srcs = ["access_log_policy_config.proto"],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+    ],
+)

--- a/extensions/access_log_policy/config/v1alpha1/access_log_policy_config.proto
+++ b/extensions/access_log_policy/config/v1alpha1/access_log_policy_config.proto
@@ -1,0 +1,28 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package accesslogpolicy.config.v1alpha1;
+
+import "google/protobuf/duration.proto";
+
+message AccessLogPolicyConfig {
+  // next id: 2
+
+  // Optional. Allows specifying logging window for successful requests.
+  // The default duration is `12h`.
+  google.protobuf.Duration log_window_duration = 1;
+}

--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -117,7 +117,8 @@ void PluginContext::onLog() {
   getStringValue({kConnection, kUriSanPeerCertificate}, &source_principal);
   istio_dimensions_.set_downstream_ip(downstream_ip);
   istio_dimensions_.set_source_principal(source_principal);
-
+  GOOGLE_LOG(INFO)<<"downstream_ip: "<<downstream_ip;
+  GOOGLE_LOG(INFO)<<"source_principal: "<<source_principal;
   absl::Time last_log_time_nanos = lastLogTimeNanos();
   auto cur = absl::Now();
   if ((cur - last_log_time_nanos) > logTimeDurationNanos()) {

--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -103,6 +103,7 @@ void PluginContext::onLog() {
   getValue({"response", "code"}, &response_code);
   // If request is a failure, log it.
   if (response_code != 200) {
+    GOOGLE_LOG(INFO)<<"Reached  here setting filterstate true, response code 200";
     setFilterStateValue(true);
     return;
   }
@@ -120,12 +121,14 @@ void PluginContext::onLog() {
   absl::Time last_log_time_nanos = lastLogTimeNanos();
   auto cur = absl::Now();
   if ((cur - last_log_time_nanos) > logTimeDurationNanos()) {
+    GOOGLE_LOG(INFO)<<"Reached  here setting filterstate true, time to log";
     if (setFilterStateValue(true)) {
       updateLastLogTimeNanos(cur);
     }
     return;
   }
 
+  GOOGLE_LOG(INFO)<<"Reached  here setting filterstate false";
   setFilterStateValue(false);
 }
 

--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -103,8 +103,6 @@ void PluginContext::onLog() {
   getValue({"response", "code"}, &response_code);
   // If request is a failure, log it.
   if (response_code != 200) {
-    GOOGLE_LOG(INFO)
-        << "Reached  here setting filterstate true, response code 200";
     setFilterStateValue(true);
     return;
   }
@@ -118,19 +116,15 @@ void PluginContext::onLog() {
   getStringValue({kConnection, kUriSanPeerCertificate}, &source_principal);
   istio_dimensions_.set_downstream_ip(downstream_ip);
   istio_dimensions_.set_source_principal(source_principal);
-  GOOGLE_LOG(INFO) << "downstream_ip: " << downstream_ip;
-  GOOGLE_LOG(INFO) << "source_principal: " << source_principal;
   absl::Time last_log_time_nanos = lastLogTimeNanos();
   auto cur = absl::Now();
   if ((cur - last_log_time_nanos) > logTimeDurationNanos()) {
-    GOOGLE_LOG(INFO) << "Reached  here setting filterstate true, time to log";
     if (setFilterStateValue(true)) {
       updateLastLogTimeNanos(cur);
     }
     return;
   }
 
-  GOOGLE_LOG(INFO) << "Reached  here setting filterstate false";
   setFilterStateValue(false);
 }
 

--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -1,0 +1,138 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/access_log_policy/plugin.h"
+
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
+#include "extensions/common/istio_dimensions.h"
+#include "extensions/common/node_info.pb.h"
+#include "google/protobuf/util/json_util.h"
+
+#ifndef NULL_PLUGIN
+
+#include "base64.h"
+
+#else
+
+#include "common/common/base64.h"
+namespace Envoy {
+namespace Extensions {
+namespace Wasm {
+namespace AccessLogPolicy {
+namespace Plugin {
+using namespace ::Envoy::Extensions::Common::Wasm::Null::Plugin;
+using NullPluginRootRegistry =
+    ::Envoy::Extensions::Common::Wasm::Null::NullPluginRootRegistry;
+using google::protobuf::util::JsonParseOptions;
+using google::protobuf::util::Status;
+
+NULL_PLUGIN_ROOT_REGISTRY;
+
+#endif
+
+namespace {
+
+bool setFilterStateValue(bool log) {
+  auto r = setFilterStateStringValue(::Wasm::Common::kAccessLogPolicyKey,
+                                     log ? "yes" : "no");
+  if (r != WasmResult::Ok) {
+    logWarn(toString(r));
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+constexpr absl::Duration kDefaultLogWindowDurationNanoseconds =
+    absl::Hours(12);  // 12h
+
+constexpr StringView kDestination = "destination";
+constexpr StringView kAddress = "address";
+constexpr StringView kConnection = "connection";
+constexpr StringView kUriSanPeerCertificate = "uri_san_peer_certificate";
+
+static RegisterContextFactory register_AccessLogPolicy(
+    CONTEXT_FACTORY(PluginContext), ROOT_FACTORY(PluginRootContext));
+
+bool PluginRootContext::onConfigure(size_t) {
+  if (::Wasm::Common::TrafficDirection::Inbound !=
+      ::Wasm::Common::getTrafficDirection()) {
+    throw EnvoyException("ASM Acess Logging Policy is an inbound filter only.");
+  }
+  WasmDataPtr configuration = getConfiguration();
+  JsonParseOptions json_options;
+  Status status =
+      JsonStringToMessage(configuration->toString(), &config_, json_options);
+  if (status != Status::OK) {
+    logWarn("Cannot parse Stackdriver plugin configuration JSON string " +
+            configuration->toString() + ", " + status.message().ToString());
+    return false;
+  }
+
+  if (config_.has_log_window_duration()) {
+    log_time_duration_nanos_ = absl::Nanoseconds(
+        ::google::protobuf::util::TimeUtil::DurationToNanoseconds(
+            config_.log_window_duration()));
+  } else {
+    log_time_duration_nanos_ = kDefaultLogWindowDurationNanoseconds;
+  }
+
+  return true;
+}
+
+void PluginContext::onLog() {
+  // Check if request is a failure.
+  int64_t response_code = 0;
+  // TODO(gargnupur): Add check for gRPC status too.
+  getValue({"response", "code"}, &response_code);
+  // If request is a failure, log it.
+  if (response_code != 200) {
+    setFilterStateValue(true);
+    return;
+  }
+
+  // If request is not a failure, check cache to see if it should be logged or
+  // not, based on last time a successful request was logged for this client ip
+  // and principal combination.
+  std::string downstream_ip = "";
+  getStringValue({kDestination, kAddress}, &downstream_ip);
+  std::string source_principal = "";
+  getStringValue({kConnection, kUriSanPeerCertificate}, &source_principal);
+  istio_dimensions_.set_downstream_ip(downstream_ip);
+  istio_dimensions_.set_source_principal(source_principal);
+
+  absl::Time last_log_time_nanos = lastLogTimeNanos();
+  auto cur = absl::Now();
+  if ((cur - last_log_time_nanos) > logTimeDurationNanos()) {
+    if (setFilterStateValue(true)) {
+      updateLastLogTimeNanos(cur);
+    }
+    return;
+  }
+
+  setFilterStateValue(false);
+}
+
+#ifdef NULL_PLUGIN
+}  // namespace Plugin
+}  // namespace AccessLogPolicy
+}  // namespace Wasm
+}  // namespace Extensions
+}  // namespace Envoy
+#endif

--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -103,7 +103,8 @@ void PluginContext::onLog() {
   getValue({"response", "code"}, &response_code);
   // If request is a failure, log it.
   if (response_code != 200) {
-    GOOGLE_LOG(INFO)<<"Reached  here setting filterstate true, response code 200";
+    GOOGLE_LOG(INFO)
+        << "Reached  here setting filterstate true, response code 200";
     setFilterStateValue(true);
     return;
   }
@@ -117,19 +118,19 @@ void PluginContext::onLog() {
   getStringValue({kConnection, kUriSanPeerCertificate}, &source_principal);
   istio_dimensions_.set_downstream_ip(downstream_ip);
   istio_dimensions_.set_source_principal(source_principal);
-  GOOGLE_LOG(INFO)<<"downstream_ip: "<<downstream_ip;
-  GOOGLE_LOG(INFO)<<"source_principal: "<<source_principal;
+  GOOGLE_LOG(INFO) << "downstream_ip: " << downstream_ip;
+  GOOGLE_LOG(INFO) << "source_principal: " << source_principal;
   absl::Time last_log_time_nanos = lastLogTimeNanos();
   auto cur = absl::Now();
   if ((cur - last_log_time_nanos) > logTimeDurationNanos()) {
-    GOOGLE_LOG(INFO)<<"Reached  here setting filterstate true, time to log";
+    GOOGLE_LOG(INFO) << "Reached  here setting filterstate true, time to log";
     if (setFilterStateValue(true)) {
       updateLastLogTimeNanos(cur);
     }
     return;
   }
 
-  GOOGLE_LOG(INFO)<<"Reached  here setting filterstate false";
+  GOOGLE_LOG(INFO) << "Reached  here setting filterstate false";
   setFilterStateValue(false);
 }
 

--- a/extensions/access_log_policy/plugin.h
+++ b/extensions/access_log_policy/plugin.h
@@ -61,22 +61,14 @@ class PluginRootContext : public RootContext {
   bool onConfigure(size_t) override;
 
   absl::Time lastLogTimeNanos(const IstioDimensions& key) {
-    absl::MutexLock lock(&mutex_);
     if (cache_.contains(key)) {
-      GOOGLE_LOG(INFO) << "Reached here in cache lastLogTimeNanos key: "
-                       << key.to_string();
       return cache_[key];
     }
-    GOOGLE_LOG(INFO) << "Reached here out of cache lastLogTimeNanos key: "
-                     << key.to_string();
     return absl::UnixEpoch();
   }
 
   void updateLastLogTimeNanos(const IstioDimensions& key,
                               absl::Time last_log_time_nanos) {
-    absl::MutexLock lock(&mutex_);
-    GOOGLE_LOG(INFO) << "Reached here updates last log key: " << key.to_string()
-                     << " value: " << absl::ToUniversal(last_log_time_nanos);
     cache_[key] = last_log_time_nanos;
   }
 
@@ -87,7 +79,6 @@ class PluginRootContext : public RootContext {
   // Cache storing last log time by a client.
   absl::flat_hash_map<IstioDimensions, absl::Time> cache_;
   absl::Duration log_time_duration_nanos_;
-  mutable absl::Mutex mutex_;
 };
 
 // Per-stream context.

--- a/extensions/access_log_policy/plugin.h
+++ b/extensions/access_log_policy/plugin.h
@@ -61,12 +61,14 @@ class PluginRootContext : public RootContext {
   bool onConfigure(size_t) override;
 
   absl::Time lastLogTimeNanos(const IstioDimensions& key) {
+    absl::MutexLock lock(&mutex_);
     if (cache_.contains(key)) return cache_[key];
     return absl::UnixEpoch();
   }
 
   void updateLastLogTimeNanos(const IstioDimensions& key,
                               absl::Time last_log_time_nanos) {
+    absl::MutexLock lock(&mutex_);
     cache_[key] = last_log_time_nanos;
   }
 
@@ -77,6 +79,7 @@ class PluginRootContext : public RootContext {
   // Cache storing last log time by a client.
   absl::flat_hash_map<IstioDimensions, absl::Time> cache_;
   absl::Duration log_time_duration_nanos_;
+  mutable absl::Mutex mutex_;
 };
 
 // Per-stream context.

--- a/extensions/access_log_policy/plugin.h
+++ b/extensions/access_log_policy/plugin.h
@@ -1,0 +1,113 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "absl/container/flat_hash_map.h"
+#include "extensions/access_log_policy/config/v1alpha1/access_log_policy_config.pb.h"
+#include "extensions/common/context.h"
+#include "extensions/common/istio_dimensions.h"
+
+#ifndef NULL_PLUGIN
+
+#include <assert.h>
+#define ASSERT(_X) assert(_X)
+
+#include "proxy_wasm_intrinsics.h"
+
+static const std::string EMPTY_STRING;
+
+#else
+
+#include "extensions/common/wasm/null/null_plugin.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Wasm {
+namespace AccessLogPolicy {
+namespace Plugin {
+
+using namespace Envoy::Extensions::Common::Wasm::Null::Plugin;
+
+// TODO(jplevyak): move these into the base envoy repo
+using WasmResult = Envoy::Extensions::Common::Wasm::WasmResult;
+using NullPluginRootRegistry =
+    ::Envoy::Extensions::Common::Wasm::Null::NullPluginRootRegistry;
+using ::Wasm::Common::IstioDimensions;
+
+#endif
+
+// PluginRootContext is the root context for all streams processed by the
+// thread. It has the same lifetime as the worker thread and acts as target for
+// interactions that outlives individual stream, e.g. timer, async calls.
+class PluginRootContext : public RootContext {
+ public:
+  PluginRootContext(uint32_t id, StringView root_id)
+      : RootContext(id, root_id) {}
+  ~PluginRootContext() = default;
+
+  bool onConfigure(size_t) override;
+
+  absl::Time lastLogTimeNanos(const IstioDimensions& key) {
+    if (cache_.contains(key)) return cache_[key];
+    return absl::UnixEpoch();
+  }
+
+  void updateLastLogTimeNanos(const IstioDimensions& key,
+                              absl::Time last_log_time_nanos) {
+    cache_[key] = last_log_time_nanos;
+  }
+
+  absl::Duration logTimeDurationNanos() { return log_time_duration_nanos_; };
+
+ private:
+  accesslogpolicy::config::v1alpha1::AccessLogPolicyConfig config_;
+  // Cache storing last log time by a client.
+  absl::flat_hash_map<IstioDimensions, absl::Time> cache_;
+  absl::Duration log_time_duration_nanos_;
+};
+
+// Per-stream context.
+class PluginContext : public Context {
+ public:
+  explicit PluginContext(uint32_t id, RootContext* root) : Context(id, root) {}
+
+  void onLog() override;
+
+ private:
+  inline PluginRootContext* rootContext() {
+    return dynamic_cast<PluginRootContext*>(this->root());
+  };
+  inline absl::Time lastLogTimeNanos() {
+    return rootContext()->lastLogTimeNanos(istio_dimensions_);
+  };
+  inline void updateLastLogTimeNanos(absl::Time last_log_time_nanos) {
+    rootContext()->updateLastLogTimeNanos(istio_dimensions_,
+                                          last_log_time_nanos);
+  };
+  inline absl::Duration logTimeDurationNanos() {
+    return rootContext()->logTimeDurationNanos();
+  };
+
+  IstioDimensions istio_dimensions_;
+};
+
+#ifdef NULL_PLUGIN
+}  // namespace Plugin
+}  // namespace AccessLogPolicy
+}  // namespace Wasm
+}  // namespace Extensions
+}  // namespace Envoy
+#endif

--- a/extensions/access_log_policy/plugin.h
+++ b/extensions/access_log_policy/plugin.h
@@ -62,13 +62,21 @@ class PluginRootContext : public RootContext {
 
   absl::Time lastLogTimeNanos(const IstioDimensions& key) {
     absl::MutexLock lock(&mutex_);
-    if (cache_.contains(key)) return cache_[key];
+    if (cache_.contains(key)) {
+      GOOGLE_LOG(INFO) << "Reached here in cache lastLogTimeNanos key: "
+                       << key.to_string();
+      return cache_[key];
+    }
+    GOOGLE_LOG(INFO) << "Reached here out of cache lastLogTimeNanos key: "
+                     << key.to_string();
     return absl::UnixEpoch();
   }
 
   void updateLastLogTimeNanos(const IstioDimensions& key,
                               absl::Time last_log_time_nanos) {
     absl::MutexLock lock(&mutex_);
+    GOOGLE_LOG(INFO) << "Reached here updates last log key: " << key.to_string()
+                     << " value: " << absl::ToUniversal(last_log_time_nanos);
     cache_[key] = last_log_time_nanos;
   }
 

--- a/extensions/common/BUILD
+++ b/extensions/common/BUILD
@@ -35,6 +35,7 @@ envoy_cc_library(
     ],
     hdrs = [
         "context.h",
+        "istio_dimensions.h",
         "util.h",
     ],
     repository = "@envoy",
@@ -44,6 +45,15 @@ envoy_cc_library(
         "@com_google_protobuf//:protobuf",
         "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
     ],
+)
+
+envoy_cc_library(
+    name = "istio_dimensions",
+    hdrs = [
+        "istio_dimensions.h",
+    ],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
 )
 
 envoy_cc_library(
@@ -93,6 +103,17 @@ envoy_cc_test(
     deps = [
         ":context",
         "@envoy//source/extensions/common/wasm:wasm_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "istio_dimensions_test",
+    size = "small",
+    srcs = ["istio_dimensions_test.cc"],
+    external_deps = ["abseil_hash_testing"],
+    repository = "@envoy",
+    deps = [
+        ":istio_dimensions",
     ],
 )
 

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -40,6 +40,8 @@ constexpr StringView kDownstreamMetadataIdKey =
 constexpr StringView kDownstreamMetadataKey =
     "envoy.wasm.metadata_exchange.downstream";
 
+constexpr StringView kAccessLogPolicyKey = "envoy.wasm.access_log.log";
+
 // Header keys
 constexpr StringView kAuthorityHeaderKey = ":authority";
 constexpr StringView kMethodHeaderKey = ":method";

--- a/extensions/common/istio_dimensions.h
+++ b/extensions/common/istio_dimensions.h
@@ -1,0 +1,98 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <set>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_replace.h"
+#include "absl/strings/string_view.h"
+
+namespace Wasm {
+namespace Common {
+
+#define STD_ISTIO_DIMENSIONS(FIELD_FUNC)     \
+  FIELD_FUNC(downstream_ip)                  \
+  FIELD_FUNC(reporter)                       \
+  FIELD_FUNC(source_workload)                \
+  FIELD_FUNC(source_workload_namespace)      \
+  FIELD_FUNC(source_principal)               \
+  FIELD_FUNC(source_app)                     \
+  FIELD_FUNC(source_version)                 \
+  FIELD_FUNC(destination_workload)           \
+  FIELD_FUNC(destination_workload_namespace) \
+  FIELD_FUNC(destination_principal)          \
+  FIELD_FUNC(destination_app)                \
+  FIELD_FUNC(destination_version)            \
+  FIELD_FUNC(destination_service)            \
+  FIELD_FUNC(destination_service_name)       \
+  FIELD_FUNC(destination_service_namespace)  \
+  FIELD_FUNC(destination_port)               \
+  FIELD_FUNC(request_protocol)               \
+  FIELD_FUNC(response_code)                  \
+  FIELD_FUNC(response_flags)                 \
+  FIELD_FUNC(connection_security_policy)     \
+  FIELD_FUNC(permissive_response_code)       \
+  FIELD_FUNC(permissive_response_policyid)
+
+// A structure that can hold multiple Istio dimensions(metadata variables).
+// This could be use to key caches based on Istio dimensions for various
+// filters.
+// Note: This is supposed to be used with absl::flat_hash_map only.
+// TODO: Add support for evaluating dynamic Istio dimensions.
+struct IstioDimensions {
+#define DEFINE_FIELD(name) std::string(name);
+  STD_ISTIO_DIMENSIONS(DEFINE_FIELD)
+#undef DEFINE_FIELD
+
+  bool outbound;
+
+#define SET_FIELD(name) \
+  void set_##name(std::string value) { name = value; }
+
+  STD_ISTIO_DIMENSIONS(SET_FIELD)
+#undef SET_FIELD
+
+  void set_outbound(bool value) { outbound = value; }
+
+  std::string to_string() const {
+#define TO_STRING(name) "\"", #name, "\":\"", name, "\" ,",
+    return absl::StrCat("{" STD_ISTIO_DIMENSIONS(TO_STRING) "}");
+#undef TO_STRING
+  }
+
+  // This function is required to make IstioDimensions type hashable.
+  template <typename H>
+  friend H AbslHashValue(H h, IstioDimensions d) {
+#define TO_HASH_VALUE(name) , d.name
+    return H::combine(std::move(h) STD_ISTIO_DIMENSIONS(TO_HASH_VALUE),
+                      d.outbound);
+#undef TO_HASH_VALUE
+  }
+
+  // This function is required to make IstioDimensions type hashable.
+  friend bool operator==(const IstioDimensions& lhs,
+                         const IstioDimensions& rhs) {
+    return (
+#define COMPARE(name) lhs.name == rhs.name&&
+        STD_ISTIO_DIMENSIONS(COMPARE) lhs.outbound == rhs.outbound);
+#undef COMPARE
+  }
+};
+
+}  // namespace Common
+}  // namespace Wasm

--- a/extensions/common/istio_dimensions.h
+++ b/extensions/common/istio_dimensions.h
@@ -59,7 +59,7 @@ struct IstioDimensions {
   STD_ISTIO_DIMENSIONS(DEFINE_FIELD)
 #undef DEFINE_FIELD
 
-  bool outbound;
+  bool outbound = false;
 
 #define SET_FIELD(name) \
   void set_##name(std::string value) { name = value; }
@@ -71,7 +71,8 @@ struct IstioDimensions {
 
   std::string to_string() const {
 #define TO_STRING(name) "\"", #name, "\":\"", name, "\" ,",
-    return absl::StrCat("{" STD_ISTIO_DIMENSIONS(TO_STRING) "}");
+    return absl::StrCat(
+        "{" STD_ISTIO_DIMENSIONS(TO_STRING) "\"outbound\": ", outbound, "}");
 #undef TO_STRING
   }
 

--- a/extensions/common/istio_dimensions_test.cc
+++ b/extensions/common/istio_dimensions_test.cc
@@ -1,0 +1,48 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/common/istio_dimensions.h"
+
+#include "absl/hash/hash_testing.h"
+#include "gtest/gtest.h"
+
+namespace Wasm {
+namespace Common {
+namespace {
+
+TEST(WasmCommonIstioDimensionsTest, VerifyHashing) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+      IstioDimensions{},
+      IstioDimensions{.request_protocol = "grpc"},
+      IstioDimensions{.request_protocol = "grpc", .response_code = "200"},
+      IstioDimensions{.request_protocol = "grpc", .response_code = "400"},
+      IstioDimensions{.request_protocol = "grpc", .source_app = "app_source"},
+      IstioDimensions{.request_protocol = "grpc",
+                      .source_app = "app_source",
+                      .source_version = "v2"},
+      IstioDimensions{.outbound = true,
+                      .request_protocol = "grpc",
+                      .source_app = "app_source",
+                      .source_version = "v2"},
+      IstioDimensions{.outbound = true,
+                      .request_protocol = "grpc",
+                      .source_app = "app_source",
+                      .source_version = "v2"},
+  }));
+}
+
+}  // namespace
+}  // namespace Common
+}  // namespace Wasm

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -253,11 +253,9 @@ bool StackdriverRootContext::shouldLogThisRequest() {
   std::string shouldLog = "";
   if (!getStringValue({"filter_state", ::Wasm::Common::kAccessLogPolicyKey},
                       &shouldLog)) {
-    GOOGLE_LOG(INFO) << "cannot get envoy access log info from filter state.";
     LOG_DEBUG("cannot get envoy access log info from filter state.");
     return true;
   }
-  GOOGLE_LOG(INFO) << "Reached  here shouldLog:" << shouldLog;
   return shouldLog != "no";
 }
 

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -211,7 +211,7 @@ void StackdriverRootContext::record() {
                                           destination_node_info.namespace_());
   ::Extensions::Stackdriver::Metric::record(isOutbound(), local_node_info_,
                                             peer_node_info, request_info);
-  if (enableServerAccessLog()) {
+  if (enableServerAccessLog() && shouldLogThisRequest()) {
     logger_->addLogEntry(request_info, peer_node_info);
   }
   if (enableEdgeReporting()) {
@@ -247,6 +247,16 @@ inline bool StackdriverRootContext::enableServerAccessLog() {
 
 inline bool StackdriverRootContext::enableEdgeReporting() {
   return config_.enable_mesh_edges_reporting() && !isOutbound();
+}
+
+bool StackdriverRootContext::shouldLogThisRequest() {
+  std::string shouldLog = "";
+  if (!getStringValue({"filter_state", ::Wasm::Common::kAccessLogPolicyKey},
+                      &shouldLog)) {
+    LOG_DEBUG("cannot get envoy access log info from filter state.");
+    return true;
+  }
+  return shouldLog != "no";
 }
 
 // TODO(bianpengyuan) Add final export once root context supports onDone.

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -256,6 +256,7 @@ bool StackdriverRootContext::shouldLogThisRequest() {
     LOG_DEBUG("cannot get envoy access log info from filter state.");
     return true;
   }
+  GOOGLE_LOG(INFO) << "Reached here shouldLog: " << shouldLog;
   return shouldLog != "no";
 }
 

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -256,7 +256,6 @@ bool StackdriverRootContext::shouldLogThisRequest() {
     LOG_DEBUG("cannot get envoy access log info from filter state.");
     return true;
   }
-  GOOGLE_LOG(INFO) << "Reached here shouldLog: " << shouldLog;
   return shouldLog != "no";
 }
 

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -253,11 +253,11 @@ bool StackdriverRootContext::shouldLogThisRequest() {
   std::string shouldLog = "";
   if (!getStringValue({"filter_state", ::Wasm::Common::kAccessLogPolicyKey},
                       &shouldLog)) {
-    GOOGLE_LOG(INFO)<<"cannot get envoy access log info from filter state.";                   
+    GOOGLE_LOG(INFO) << "cannot get envoy access log info from filter state.";
     LOG_DEBUG("cannot get envoy access log info from filter state.");
     return true;
   }
-  GOOGLE_LOG(INFO)<<"Reached  here shouldLog:"<<shouldLog;
+  GOOGLE_LOG(INFO) << "Reached  here shouldLog:" << shouldLog;
   return shouldLog != "no";
 }
 

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -253,9 +253,11 @@ bool StackdriverRootContext::shouldLogThisRequest() {
   std::string shouldLog = "";
   if (!getStringValue({"filter_state", ::Wasm::Common::kAccessLogPolicyKey},
                       &shouldLog)) {
+    GOOGLE_LOG(INFO)<<"cannot get envoy access log info from filter state.";                   
     LOG_DEBUG("cannot get envoy access log info from filter state.");
     return true;
   }
+  GOOGLE_LOG(INFO)<<"Reached  here shouldLog:"<<shouldLog;
   return shouldLog != "no";
 }
 

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -74,6 +74,8 @@ class StackdriverRootContext : public RootContext {
   // Indicates whether to export server access log or not.
   bool enableServerAccessLog();
 
+  bool shouldLogThisRequest();
+
   // Gets peer node info. It checks the node info cache first, and then try to
   // fetch it from host if cache miss. If cache is disabled, it will fetch from
   // host directly.

--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -25,6 +25,7 @@ envoy_cc_binary(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        "//extensions/access_log_policy:access_log_policy_lib",
         "//extensions/metadata_exchange:metadata_exchange_lib",
         "//extensions/stackdriver:stackdriver_plugin",
         "//extensions/stats:stats_plugin",

--- a/test/envoye2e/driver/stackdriver.go
+++ b/test/envoye2e/driver/stackdriver.go
@@ -46,7 +46,7 @@ func (sd *Stackdriver) Run(p *Params) error {
 	sd.done = make(chan error, 1)
 	sd.ls = make(map[string]struct{})
 	sd.ts = make(map[string]struct{})
-	metrics, logging, _ := fs.NewFakeStackdriver(sd.Port, sd.Delay)
+	metrics, logging, _, _ := fs.NewFakeStackdriver(sd.Port, sd.Delay)
 
 	go func() {
 		for {

--- a/test/envoye2e/env/setup.go
+++ b/test/envoye2e/env/setup.go
@@ -540,3 +540,9 @@ func (s *TestSetup) VerifyStatsLT(actualStats string, expectedStat string, expec
 		log.Printf("stat %s is matched. %d < %d", expectedStat, aStatsValue, expectedStatVal)
 	}
 }
+
+func (s *TestSetup) StopHTTPBackend() {
+	if s.backend != nil {
+		s.backend.Stop()
+	}
+}

--- a/test/envoye2e/stackdriver_plugin/fake_stackdriver/fake_stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/fake_stackdriver/fake_stackdriver.go
@@ -137,7 +137,7 @@ func (e *MeshEdgesServiceServer) ReportTrafficAssertions(
 }
 
 // NewFakeStackdriver creates a new fake Stackdriver server.
-func NewFakeStackdriver(port uint16, delay time.Duration) (*MetricServer, *LoggingServer, *MeshEdgesServiceServer) {
+func NewFakeStackdriver(port uint16, delay time.Duration) (*MetricServer, *LoggingServer, *MeshEdgesServiceServer, *grpc.Server) {
 	log.Printf("Stackdriver server listening on port %v\n", port)
 	grpcServer := grpc.NewServer()
 	fsdms := &MetricServer{
@@ -166,5 +166,5 @@ func NewFakeStackdriver(port uint16, delay time.Duration) (*MetricServer, *Loggi
 			log.Fatalf("fake stackdriver server terminated abnormally: %v", err)
 		}
 	}()
-	return fsdms, fsdls, edgesSvc
+	return fsdms, fsdls, edgesSvc, grpcServer
 }

--- a/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
@@ -288,7 +288,7 @@ func verifyNumberOfAccessLogs(fsdl *fs.LoggingServer, t *testing.T, expectedEntr
 		select {
 		case req := <-fsdl.RcvLoggingReq:
 			if len(req.Entries) != expectedEntries {
-				t.Errorf("WriteLogEntries verification failed. Number of entries expected: %v, got: %v", 1, len(req.Entries))
+				t.Errorf("WriteLogEntries verification failed. Number of entries expected: %v, got: %v, gotEntry: %v", 1, len(req.Entries), req)
 			}
 			logRcv = true
 		case <-to.C:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for Access Log Policy Filter

**Special notes for your reviewer**:
This just adds basic support for sampling Istio's access logs based on client-ip and principal values.
It is not doing anything fancy for now and samples based on following rules:
1) If fail -> log
2) If success, check if current client_ip and principal's request have been logged in the configured log window => If yes, then don't log, otherwise log.

Design Doc: https://docs.google.com/document/d/1Vr6ZgkdhV5avm3TmxSF3rjjjN7a_-btnf4ymXqorKCc/edit#