### PR TITLE
Update proxy to latest envoy-wasm

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,10 +37,10 @@ bind(
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
-# envoy-wasm commit date: 12/03/2019
-ENVOY_SHA = "957f3e23b07d22f1cb849e216feb9c58e7e8a607"
+# envoy-wasm commit date: 12/12/2019
+ENVOY_SHA = "097b7f2e4cc1fb490cc1943d0d633655ac3c522f"
 
-ENVOY_SHA256 = "2269913f3b19adab8fa3cf19869a3fe6c79763a51bc28d6d7f35b90579c0f994"
+ENVOY_SHA256 = "eecb4ca7536524e6dea3e214d693f179ca4c079f83c0d99f10091cd796b26f3e"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.

--- a/src/envoy/http/jwt_auth/jwt_authenticator.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator.cc
@@ -146,10 +146,9 @@ void JwtAuthenticator::FetchPubkey(PubkeyCacheItem *issuer) {
   ExtractUriHostPath(uri_, &host, &path);
 
   MessagePtr message(new RequestMessageImpl());
-  message->headers().insertMethod().value().setReference(
-      Http::Headers::get().MethodValues.Get);
-  message->headers().insertPath().value(path);
-  message->headers().insertHost().value(host);
+  message->headers().setReferenceMethod(Http::Headers::get().MethodValues.Get);
+  message->headers().setPath(path);
+  message->headers().setHost(host);
 
   const auto &cluster = issuer->jwt_config().remote_jwks().http_uri().cluster();
   if (cm_.get(cluster) == nullptr) {

--- a/src/envoy/http/mixer/filter.cc
+++ b/src/envoy/http/mixer/filter.cc
@@ -58,7 +58,7 @@ void Filter::ReadPerRouteConfig(
 
 FilterHeadersStatus Filter::decodeHeaders(HeaderMap& headers, bool) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
-  request_total_size_ += headers.refreshByteSize();
+  request_total_size_ += headers.byteSize();
 
   ::istio::control::http::Controller::PerRouteConfig config;
   auto route = decoder_callbacks_->route();
@@ -103,7 +103,7 @@ FilterDataStatus Filter::decodeData(Buffer::Instance& data, bool end_stream) {
 
 FilterTrailersStatus Filter::decodeTrailers(HeaderMap& trailers) {
   ENVOY_LOG(debug, "Called Mixer::Filter : {}", __func__);
-  request_total_size_ += trailers.refreshByteSize();
+  request_total_size_ += trailers.byteSize();
   if (state_ == Calling) {
     return FilterTrailersStatus::StopIteration;
   }

--- a/src/envoy/http/mixer/report_data.h
+++ b/src/envoy/http/mixer/report_data.h
@@ -72,14 +72,10 @@ class ReportData : public ::istio::control::http::ReportData,
         response_total_size_(info.bytesSent()),
         request_total_size_(request_total_size) {
     if (response_headers != nullptr) {
-      response_total_size_ +=
-          (response_headers->byteSize() ? response_headers->byteSize().value()
-                                        : response_headers->byteSizeInternal());
+      response_total_size_ += response_headers->byteSize();
     }
     if (response_trailers != nullptr) {
-      response_total_size_ += (response_trailers->byteSize()
-                                   ? response_trailers->byteSize().value()
-                                   : response_trailers->byteSizeInternal());
+      response_total_size_ += response_trailers->byteSize();
     }
   }
 

--- a/src/envoy/utils/grpc_transport.cc
+++ b/src/envoy/utils/grpc_transport.cc
@@ -61,7 +61,7 @@ void GrpcTransport<RequestType, ResponseType>::onCreateInitialMetadata(
   // We generate cluster name contains invalid characters, so override the
   // authority header temorarily until it can be specified via CDS.
   // See https://github.com/envoyproxy/envoy/issues/3297 for details.
-  metadata.Host()->value("mixer", 5);
+  metadata.setHost(absl::string_view("mixer", 5));
 
   if (!serialized_forward_attributes_.empty()) {
     HeaderUpdate header_update_(&metadata);


### PR DESCRIPTION
**What this PR does / why we need it**:
Update proxy to latest envoy-wasm on 12/12.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Along with other fixes, it has a fix for crash when gRPC responds after context is lost.