### PR TITLE
Avoid an expensive copy of ReportRequest.

### DIFF
--- a/src/istio/mixerclient/report_batch.cc
+++ b/src/istio/mixerclient/report_batch.cc
@@ -72,7 +72,7 @@ void ReportBatch::FlushWithLock() {
   }
 
   ++total_remote_report_calls_;
-  auto request = batch_compressor_->Finish();
+  const auto& request = batch_compressor_->Finish();
   std::shared_ptr<ReportResponse> response{new ReportResponse()};
 
   // TODO(jblatt) I replaced a ReportResponse raw pointer with a shared


### PR DESCRIPTION
**What this PR does / why we need it**:
This copy seems redundant, removing it can save ~1ms at batch size == 100 in MixerV1's reporting.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improves reporting performance for Mixer.
```
