### PR TITLE
Update authn filter to use first spiffe san

### DIFF
--- a/src/envoy/utils/utils_test.cc
+++ b/src/envoy/utils/utils_test.cc
@@ -128,6 +128,16 @@ TEST_P(UtilsTest, GetPrincipalNoSpiffePrefix) {
   testGetPrincipal(sans, "spiffe:foo/bar", true);
 }
 
+TEST_P(UtilsTest, GetPrincipalFromSpiffePrefixSAN) {
+  std::vector<std::string> sans{"bad", "spiffe://foo/bar"};
+  testGetPrincipal(sans, "foo/bar", true);
+}
+
+TEST_P(UtilsTest, GetPrincipalFromNonSpiffePrefixSAN) {
+  std::vector<std::string> sans{"foobar", "xyz"};
+  testGetPrincipal(sans, "foobar", true);
+}
+
 TEST_P(UtilsTest, GetPrincipalEmpty) {
   std::vector<std::string> sans;
   testGetPrincipal(sans, "", false);
@@ -145,6 +155,16 @@ TEST_P(UtilsTest, GetTrustDomainEmpty) {
 
 TEST_P(UtilsTest, GetTrustDomainNoSpiffePrefix) {
   std::vector<std::string> sans{"spiffe:td/bar", "bad"};
+  testGetTrustDomain(sans, "", false);
+}
+
+TEST_P(UtilsTest, GetTrustDomainFromSpiffePrefixSAN) {
+  std::vector<std::string> sans{"bad", "spiffe://td/bar", "xyz"};
+  testGetTrustDomain(sans, "td", true);
+}
+
+TEST_P(UtilsTest, GetTrustDomainFromNonSpiffePrefixSAN) {
+  std::vector<std::string> sans{"tdbar", "xyz"};
   testGetTrustDomain(sans, "", false);
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates authN filter to loop over the cert sans and use the first one **with the prefix** `spiffe://` as the `source.principal`

**Which issue this PR fixes** : fixes https://github.com/istio/istio/issues/19767

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
AuthN filter looks for the first san with `spiffe://` prefix
```
