### PR TITLE
Fix access logging plugin to be WASM compatible

### DIFF
--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -59,8 +59,8 @@ bool setFilterStateValue(bool log) {
 
 }  // namespace
 
-constexpr absl::Duration kDefaultLogWindowDurationNanoseconds =
-    absl::Hours(12);  // 12h
+constexpr long long kDefaultLogWindowDurationNanoseconds =
+    43200000000000;  // 12h
 
 constexpr StringView kDestination = "destination";
 constexpr StringView kAddress = "address";
@@ -73,7 +73,8 @@ static RegisterContextFactory register_AccessLogPolicy(
 bool PluginRootContext::onConfigure(size_t) {
   if (::Wasm::Common::TrafficDirection::Inbound !=
       ::Wasm::Common::getTrafficDirection()) {
-    throw EnvoyException("ASM Acess Logging Policy is an inbound filter only.");
+    logError("ASM Acess Logging Policy is an inbound filter only.");
+    return false;
   }
   WasmDataPtr configuration = getConfiguration();
   JsonParseOptions json_options;
@@ -86,9 +87,9 @@ bool PluginRootContext::onConfigure(size_t) {
   }
 
   if (config_.has_log_window_duration()) {
-    log_time_duration_nanos_ = absl::Nanoseconds(
+    log_time_duration_nanos_ =
         ::google::protobuf::util::TimeUtil::DurationToNanoseconds(
-            config_.log_window_duration()));
+            config_.log_window_duration());
   } else {
     log_time_duration_nanos_ = kDefaultLogWindowDurationNanoseconds;
   }
@@ -116,8 +117,8 @@ void PluginContext::onLog() {
   getStringValue({kConnection, kUriSanPeerCertificate}, &source_principal);
   istio_dimensions_.set_downstream_ip(downstream_ip);
   istio_dimensions_.set_source_principal(source_principal);
-  absl::Time last_log_time_nanos = lastLogTimeNanos();
-  auto cur = absl::Now();
+  long long last_log_time_nanos = lastLogTimeNanos();
+  auto cur = static_cast<long long>(getCurrentTimeNanoseconds());
   if ((cur - last_log_time_nanos) > logTimeDurationNanos()) {
     if (setFilterStateValue(true)) {
       updateLastLogTimeNanos(cur);

--- a/extensions/access_log_policy/plugin.h
+++ b/extensions/access_log_policy/plugin.h
@@ -60,25 +60,25 @@ class PluginRootContext : public RootContext {
 
   bool onConfigure(size_t) override;
 
-  absl::Time lastLogTimeNanos(const IstioDimensions& key) {
+  long long lastLogTimeNanos(const IstioDimensions& key) {
     if (cache_.contains(key)) {
       return cache_[key];
     }
-    return absl::UnixEpoch();
+    return 0;
   }
 
   void updateLastLogTimeNanos(const IstioDimensions& key,
-                              absl::Time last_log_time_nanos) {
+                              long long last_log_time_nanos) {
     cache_[key] = last_log_time_nanos;
   }
 
-  absl::Duration logTimeDurationNanos() { return log_time_duration_nanos_; };
+  long long logTimeDurationNanos() { return log_time_duration_nanos_; };
 
  private:
   accesslogpolicy::config::v1alpha1::AccessLogPolicyConfig config_;
   // Cache storing last log time by a client.
-  absl::flat_hash_map<IstioDimensions, absl::Time> cache_;
-  absl::Duration log_time_duration_nanos_;
+  absl::flat_hash_map<IstioDimensions, long long> cache_;
+  long long log_time_duration_nanos_;
 };
 
 // Per-stream context.
@@ -92,14 +92,14 @@ class PluginContext : public Context {
   inline PluginRootContext* rootContext() {
     return dynamic_cast<PluginRootContext*>(this->root());
   };
-  inline absl::Time lastLogTimeNanos() {
+  inline long long lastLogTimeNanos() {
     return rootContext()->lastLogTimeNanos(istio_dimensions_);
   };
-  inline void updateLastLogTimeNanos(absl::Time last_log_time_nanos) {
+  inline void updateLastLogTimeNanos(long long last_log_time_nanos) {
     rootContext()->updateLastLogTimeNanos(istio_dimensions_,
                                           last_log_time_nanos);
   };
-  inline absl::Duration logTimeDurationNanos() {
+  inline long long logTimeDurationNanos() {
     return rootContext()->logTimeDurationNanos();
   };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes access logging plugin to be WASM compatible.
Basically, covers feedback from https://github.com/istio/proxy/pull/2602 PR.

