### PR TITLE
Fix missing response size

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,10 +37,10 @@ bind(
 # 1. Determine SHA256 `wget https://github.com/istio/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelrc and .bazelversion files.
 #
-# envoy commit date: 01/03/2020
-ENVOY_SHA = "ed8447bbc862a76c380bdcbc3699840b7338feb1"
+# envoy commit date: 01/30/2020
+ENVOY_SHA = "b5c068ee2a087818f07b2dce0debd2de7983607e"
 
-ENVOY_SHA256 = "22c52e4e6e972af4b22e1fb3bc3997d4220c8c03e004fab89498d05798bc4320"
+ENVOY_SHA256 = "1fd53be21de08cd0329694c9df4232ccf1a7ef280de09d2615ebc4d0416fa39a"
 
 LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
 


### PR DESCRIPTION
Manually verified:
```
istio_response_bytes_bucket{reporter="destination",source_workload="productpage-v1",source_workload_namespace="default",source_principal="unknown",source_app="productpage",source_version="v1",destination_workload="ratings-v1",destination_workload_namespace="default",destination_principal="unknown",destination_app="ratings",destination_version="v1",destination_service="server.default.svc.cluster.local",destination_service_name="server",destination_service_namespace="default",request_protocol="http",response_code="200",response_flags="-",connection_security_policy="NONE",permissive_response_code="none",permissive_response_policyid="none",le="+Inf"} 10
```