### PR TITLE
Change filterstate  setdata to Lifespan DownstreamConnection in MXC network filter

### DIFF
--- a/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
+++ b/src/envoy/tcp/metadata_exchange/metadata_exchange.cc
@@ -279,7 +279,8 @@ void MetadataExchangeFilter::setFilterState(const std::string& key,
   read_callbacks_->connection().streamInfo().filterState()->setData(
       key,
       std::make_unique<::Envoy::Extensions::Common::Wasm::WasmState>(value),
-      StreamInfo::FilterState::StateType::Mutable);
+      StreamInfo::FilterState::StateType::Mutable,
+      StreamInfo::FilterState::LifeSpan::DownstreamConnection);
 }
 
 void MetadataExchangeFilter::getMetadata(google::protobuf::Struct* metadata) {


### PR DESCRIPTION
Change filterstate  setdata to Lifespan DownstreamConnection in MXC network filter

Signed-off-by: gargnupur <gargnupur@google.com>

