### PR TITLE
feat(edges): add support for reporting two batches (new vs full)

### DIFF
--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -35,11 +35,10 @@ message PluginConfig {
   bool enable_mesh_edges_reporting = 3;
 
   // Optional. Allows configuration of the time between calls out to the mesh
-  // edges service to report *NEW* edges. The minimum configurable duration is `10s`.
-  // NOTE: This option ONLY configures the intermediate reporting of novel edges.
-  // Once every `10m`, all edges observed in that 10m window are reported and the
-  // local cache is cleared.
-  // The default duration is `1m`.
+  // edges service to report *NEW* edges. The minimum configurable duration is
+  // `10s`. NOTE: This option ONLY configures the intermediate reporting of
+  // novel edges. Once every `10m`, all edges observed in that 10m window are
+  // reported and the local cache is cleared. The default duration is `1m`.
   google.protobuf.Duration mesh_edges_reporting_duration = 4;
 
   // maximum size of the peer metadata cache.

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -38,7 +38,9 @@ message PluginConfig {
   // edges service to report *NEW* edges. The minimum configurable duration is
   // `10s`. NOTE: This option ONLY configures the intermediate reporting of
   // novel edges. Once every `10m`, all edges observed in that 10m window are
-  // reported and the local cache is cleared. The default duration is `1m`.
+  // reported and the local cache is cleared.
+  // The default duration is `1m`. Any value greater than `10m` will result in
+  // reporting every `10m`.
   google.protobuf.Duration mesh_edges_reporting_duration = 4;
 
   // maximum size of the peer metadata cache.

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -35,8 +35,11 @@ message PluginConfig {
   bool enable_mesh_edges_reporting = 3;
 
   // Optional. Allows configuration of the time between calls out to the mesh
-  // edges service to report edges. The minimum configurable duration is `10s`.
-  // The default duration is `10m`.
+  // edges service to report *NEW* edges. The minimum configurable duration is `10s`.
+  // NOTE: This option ONLY configures the intermediate reporting of novel edges.
+  // Once every `10m`, all edges observed in that 10m window are reported and the
+  // local cache is cleared.
+  // The default duration is `1m`.
   google.protobuf.Duration mesh_edges_reporting_duration = 4;
 
   // maximum size of the peer metadata cache.

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -65,12 +65,15 @@ class EdgeReporter {
 
   // reportEdges sends the buffered requests to the configured edges
   // service via the supplied client.
-  void reportEdges();
+  void reportEdges(bool report_all=false);
 
  private:
   // builds a full request out of the current traffic assertions (edges),
   // adds that request to the queue, and resets the current request and state.
-  void flush();
+  void flush(bool flush_all=false);
+
+  void rotateCurrentRequest();
+  void rotateEpochRequest();
 
   // client used to send requests to the edges service
   std::unique_ptr<MeshEdgesServiceClient> edges_client_;
@@ -81,14 +84,20 @@ class EdgeReporter {
   // the active pending request to which edges are being added
   std::unique_ptr<ReportTrafficAssertionsRequest> current_request_;
 
+  // the active pending request to which edges are being added
+  std::unique_ptr<ReportTrafficAssertionsRequest> epoch_current_request_;
+
   // represents the workload instance for the current proxy
   WorkloadInstance node_instance_;
 
   // current peers for which edges have been created in current_request_;
-  std::unordered_set<std::string> current_peers_;
+  std::unordered_set<std::string> known_peers_;
 
-  // requests waiting to be sent to backend
-  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> queued_requests_;
+  // requests waiting to be sent to backend per intermediate flush
+  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> current_queued_requests_;
+
+  // requests waiting to be sent to backend per full flush
+  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> epoch_queued_requests_;
 
   // TODO(douglas-reid): make adjustable.
   const int max_assertions_per_request_ = 1000;

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -41,6 +41,13 @@ using google::protobuf::util::TimeUtil;
 // "edges" for a mesh. It should be used **only** to document incoming edges for
 // a proxy. This means that the proxy in which this reporter is running should
 // be the destination workload instance for all reported traffic.
+//
+// EdgeReporter tracks edges in two distinct batches. A full batch of edges for
+// an entire epoch of reporting is maintained, as is a batch of new edges
+// observed during intervals within that epoch. This allows continual
+// incremental updating of the edges in the system with a periodic full sync of
+// observed edges.
+//
 // This should only be used in a single-threaded context. No support for
 // threading is currently provided.
 class EdgeReporter {
@@ -64,15 +71,23 @@ class EdgeReporter {
                const ::wasm::common::NodeInfo &peer_node_info);
 
   // reportEdges sends the buffered requests to the configured edges
-  // service via the supplied client.
-  void reportEdges(bool report_all=false);
+  // service via the supplied client. When full_epoch is false, only
+  // the most recent *new* edges are reported. When full_epoch is true,
+  // all edges observed for the entire current epoch are reported.
+  void reportEdges(bool full_epoch = false);
 
  private:
   // builds a full request out of the current traffic assertions (edges),
-  // adds that request to the queue, and resets the current request and state.
-  void flush(bool flush_all=false);
+  // and adds that request to a queue. when flush_epoch is true, this operation
+  // is performed on the epoch-maintained assertions and the cache is cleared.
+  void flush(bool flush_epoch = false);
 
+  // moves the current request to the queue and creates a new current request
+  // for new edges to be added into.
   void rotateCurrentRequest();
+
+  // moves the current epoch request to the queue and creates a new epoch
+  // request for new edges to be added into.
   void rotateEpochRequest();
 
   // client used to send requests to the edges service
@@ -81,23 +96,26 @@ class EdgeReporter {
   // gets the current time
   TimestampFn now_;
 
-  // the active pending request to which edges are being added
+  // the active pending new edges request to which edges are being added
   std::unique_ptr<ReportTrafficAssertionsRequest> current_request_;
 
-  // the active pending request to which edges are being added
+  // the active pending epoch request to which edges are being added
   std::unique_ptr<ReportTrafficAssertionsRequest> epoch_current_request_;
 
   // represents the workload instance for the current proxy
   WorkloadInstance node_instance_;
 
-  // current peers for which edges have been created in current_request_;
+  // current peers for which edges have been observed in the current epoch;
   std::unordered_set<std::string> known_peers_;
 
-  // requests waiting to be sent to backend per intermediate flush
-  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> current_queued_requests_;
+  // requests waiting to be sent to backend for the intra-epoch reporting
+  // interval
+  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>>
+      current_queued_requests_;
 
-  // requests waiting to be sent to backend per full flush
-  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>> epoch_queued_requests_;
+  // requests waiting to be sent to backend for the entire epoch
+  std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>>
+      epoch_queued_requests_;
 
   // TODO(douglas-reid): make adjustable.
   const int max_assertions_per_request_ = 1000;

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -247,7 +247,8 @@ TEST(EdgeReporterTest, TestPeriodicFlushAndCacheReset) {
   auto edges = std::make_unique<EdgeReporter>(
       nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
 
-  // this should work as follows: 1 assertion in 1 request, the rest dropped (due to cache)
+  // this should work as follows: 1 assertion in 1 request, the rest dropped
+  // (due to cache)
   for (int i = 0; i < 3500; i++) {
     edges->addEdge(requestInfo(), "test", peerNodeInfo());
     // flush on 1000, 2000, 3000
@@ -293,7 +294,7 @@ TEST(EdgeReporterTest, TestCacheMisses) {
   // only as part of the epoch. and since we don't flush i == 0,
   // the initial batch is 1001.
   // so, 3001 + 3500 = 6500.
-  EXPECT_EQ(6501, num_assertions); 
+  EXPECT_EQ(6501, num_assertions);
 }
 
 TEST(EdgeReporterTest, TestMissingPeerMetadata) {

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -193,7 +193,7 @@ TEST(EdgesTest, TestAddEdge) {
   auto edges = std::make_unique<EdgeReporter>(
       nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
   edges->addEdge(requestInfo(), "test", peerNodeInfo());
-  edges->reportEdges();
+  edges->reportEdges(false /* only report new edges */);
 
   // must ensure that we used the client to report the edges
   EXPECT_EQ(1, calls);
@@ -203,6 +203,10 @@ TEST(EdgesTest, TestAddEdge) {
 
   EXPECT_PROTO_EQUAL(want(), got,
                      "ERROR: addEdge() produced unexpected result.");
+
+  edges->reportEdges(true /* report all edges */);
+  // must ensure that we used the client to report the edges
+  EXPECT_EQ(2, calls);
 }
 
 TEST(EdgeReporterTest, TestRequestEdgeCache) {
@@ -222,7 +226,7 @@ TEST(EdgeReporterTest, TestRequestEdgeCache) {
   for (int i = 0; i < 3500; i++) {
     edges->addEdge(requestInfo(), "test", peerNodeInfo());
   }
-  edges->reportEdges();
+  edges->reportEdges(false /* only send current request */);
 
   // nothing has changed in the peer info, so only a single edge should be
   // reported.
@@ -243,20 +247,22 @@ TEST(EdgeReporterTest, TestPeriodicFlushAndCacheReset) {
   auto edges = std::make_unique<EdgeReporter>(
       nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
 
-  // force at least three queued reqs + current (four total)
+  // this should work as follows: 1 assertion in 1 request, the rest dropped (due to cache)
   for (int i = 0; i < 3500; i++) {
     edges->addEdge(requestInfo(), "test", peerNodeInfo());
     // flush on 1000, 2000, 3000
     if (i % 1000 == 0 && i > 0) {
-      edges->reportEdges();
+      edges->reportEdges(false /* only send current */);
     }
   }
-  edges->reportEdges();
+  // then a final assertion and additional request for a full flush.
+  edges->reportEdges(true /* send full epoch-observed results */);
 
   // nothing has changed in the peer info, but reportEdges should be called four
-  // times
-  EXPECT_EQ(4, calls);
-  EXPECT_EQ(4, num_assertions);
+  // times. two of the calls will result in no new edges or assertions. the last
+  // call will have the full set.
+  EXPECT_EQ(2, calls);
+  EXPECT_EQ(2, num_assertions);
 }
 
 TEST(EdgeReporterTest, TestCacheMisses) {
@@ -275,11 +281,19 @@ TEST(EdgeReporterTest, TestCacheMisses) {
   // force at least three queued reqs + current (four total)
   for (int i = 0; i < 3500; i++) {
     edges->addEdge(requestInfo(), std::to_string(i), peerNodeInfo());
+    // flush on 1000, 2000, 3000
+    if (i % 1000 == 0 && i > 0) {
+      edges->reportEdges(false /* only send current */);
+    }
   }
-  edges->reportEdges();
+  edges->reportEdges(true /* only send current */);
 
-  EXPECT_EQ(4, calls);
-  EXPECT_EQ(3500, num_assertions);
+  EXPECT_EQ(7, calls);
+  // the last 500 new are not sent as part of the current
+  // only as part of the epoch. and since we don't flush i == 0,
+  // the initial batch is 1001.
+  // so, 3001 + 3500 = 6500.
+  EXPECT_EQ(6501, num_assertions); 
 }
 
 TEST(EdgeReporterTest, TestMissingPeerMetadata) {
@@ -290,7 +304,7 @@ TEST(EdgeReporterTest, TestMissingPeerMetadata) {
   auto edges = std::make_unique<EdgeReporter>(
       nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
   edges->addEdge(requestInfo(), "test", wasm::common::NodeInfo());
-  edges->reportEdges();
+  edges->reportEdges(false /* only send current */);
 
   // ignore timestamps in proto comparisons.
   got.set_allocated_timestamp(nullptr);

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -287,7 +287,7 @@ TEST(EdgeReporterTest, TestCacheMisses) {
       edges->reportEdges(false /* only send current */);
     }
   }
-  edges->reportEdges(true /* only send current */);
+  edges->reportEdges(true /* send full epoch */);
 
   EXPECT_EQ(7, calls);
   // the last 500 new are not sent as part of the current

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -59,8 +59,7 @@ using ::Wasm::Common::RequestInfo;
 
 constexpr char kStackdriverExporter[] = "stackdriver_exporter";
 constexpr char kExporterRegistered[] = "registered";
-constexpr int kDefaultLogExportMilliseconds = 10000;                     // 10s
-constexpr long int kDefaultEdgeReportDurationNanoseconds = 60000000000;  // 1m
+constexpr int kDefaultLogExportMilliseconds = 10000;  // 10s
 
 namespace {
 
@@ -168,11 +167,16 @@ bool StackdriverRootContext::onConfigure(size_t) {
   }
 
   if (config_.has_mesh_edges_reporting_duration()) {
-    edge_new_report_duration_nanos_ =
-        ::google::protobuf::util::TimeUtil::DurationToNanoseconds(
-            config_.mesh_edges_reporting_duration());
+    auto duration = ::google::protobuf::util::TimeUtil::DurationToNanoseconds(
+        config_.mesh_edges_reporting_duration());
+    // if the interval duration is longer than the epoch duration, use the
+    // epoch duration.
+    if (duration >= kDefaultEdgeEpochReportDurationNanoseconds) {
+      duration = kDefaultEdgeEpochReportDurationNanoseconds;
+    }
+    edge_new_report_duration_nanos_ = duration;
   } else {
-    edge_new_report_duration_nanos_ = kDefaultEdgeReportDurationNanoseconds;
+    edge_new_report_duration_nanos_ = kDefaultEdgeNewReportDurationNanoseconds;
   }
 
   node_info_cache_.setMaxCacheSize(config_.max_peer_cache_size());
@@ -206,16 +210,17 @@ void StackdriverRootContext::onTick() {
   }
   if (enableEdgeReporting()) {
     auto cur = static_cast<long int>(getCurrentTimeNanoseconds());
-    if ((cur - last_edge_report_call_nanos_) >
+    if ((cur - last_edge_epoch_report_call_nanos_) >
         edge_epoch_report_duration_nanos_) {
       // end of epoch
       edge_reporter_->reportEdges(true /* report ALL edges from epoch*/);
-      last_edge_report_call_nanos_ = cur;
-    } else if ((cur - last_edge_report_call_nanos_) >
+      last_edge_epoch_report_call_nanos_ = cur;
+      last_edge_new_report_call_nanos_ = cur;
+    } else if ((cur - last_edge_new_report_call_nanos_) >
                edge_new_report_duration_nanos_) {
       // end of intra-epoch interval
       edge_reporter_->reportEdges(false /* only report new edges*/);
-      last_edge_report_call_nanos_ = cur;
+      last_edge_new_report_call_nanos_ = cur;
     }
   }
 }

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -59,8 +59,8 @@ using ::Wasm::Common::RequestInfo;
 
 constexpr char kStackdriverExporter[] = "stackdriver_exporter";
 constexpr char kExporterRegistered[] = "registered";
-constexpr int kDefaultLogExportMilliseconds = 10000;                         // 10s
-constexpr long int kDefaultEdgeReportDurationNanoseconds = 60000000000;      // 1m
+constexpr int kDefaultLogExportMilliseconds = 10000;                     // 10s
+constexpr long int kDefaultEdgeReportDurationNanoseconds = 60000000000;  // 1m
 
 namespace {
 
@@ -206,10 +206,14 @@ void StackdriverRootContext::onTick() {
   }
   if (enableEdgeReporting()) {
     auto cur = static_cast<long int>(getCurrentTimeNanoseconds());
-    if ((cur - last_edge_report_call_nanos_) > edge_epoch_report_duration_nanos_) {
+    if ((cur - last_edge_report_call_nanos_) >
+        edge_epoch_report_duration_nanos_) {
+      // end of epoch
       edge_reporter_->reportEdges(true /* report ALL edges from epoch*/);
       last_edge_report_call_nanos_ = cur;
-    } else if ((cur - last_edge_report_call_nanos_) > edge_new_report_duration_nanos_) {
+    } else if ((cur - last_edge_report_call_nanos_) >
+               edge_new_report_duration_nanos_) {
+      // end of intra-epoch interval
       edge_reporter_->reportEdges(false /* only report new edges*/);
       last_edge_report_call_nanos_ = cur;
     }

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -45,7 +45,8 @@ namespace Plugin {
 
 namespace Stackdriver {
 
-constexpr long int kDefaultEdgeFullReportDurationNanoseconds = 600000000000; // 10m
+constexpr long int kDefaultEdgeFullReportDurationNanoseconds =
+    600000000000;  // 10m
 
 #ifdef NULL_PLUGIN
 NULL_PLUGIN_REGISTRY;
@@ -109,7 +110,8 @@ class StackdriverRootContext : public RootContext {
 
   long int edge_new_report_duration_nanos_;
 
-  long int edge_epoch_report_duration_nanos_ = kDefaultEdgeFullReportDurationNanoseconds;
+  long int edge_epoch_report_duration_nanos_ =
+      kDefaultEdgeFullReportDurationNanoseconds;
 
   bool use_host_header_fallback_;
 };

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -45,7 +45,9 @@ namespace Plugin {
 
 namespace Stackdriver {
 
-constexpr long int kDefaultEdgeFullReportDurationNanoseconds =
+constexpr long int kDefaultEdgeNewReportDurationNanoseconds =
+    60000000000;  // 1m
+constexpr long int kDefaultEdgeEpochReportDurationNanoseconds =
     600000000000;  // 10m
 
 #ifdef NULL_PLUGIN
@@ -106,12 +108,15 @@ class StackdriverRootContext : public RootContext {
   std::unique_ptr<::Extensions::Stackdriver::Edges::EdgeReporter>
       edge_reporter_;
 
-  long int last_edge_report_call_nanos_ = 0;
+  long int last_edge_epoch_report_call_nanos_ = 0;
 
-  long int edge_new_report_duration_nanos_;
+  long int last_edge_new_report_call_nanos_ = 0;
+
+  long int edge_new_report_duration_nanos_ =
+      kDefaultEdgeNewReportDurationNanoseconds;
 
   long int edge_epoch_report_duration_nanos_ =
-      kDefaultEdgeFullReportDurationNanoseconds;
+      kDefaultEdgeEpochReportDurationNanoseconds;
 
   bool use_host_header_fallback_;
 };

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -45,6 +45,8 @@ namespace Plugin {
 
 namespace Stackdriver {
 
+constexpr long int kDefaultEdgeFullReportDurationNanoseconds = 600000000000; // 10m
+
 #ifdef NULL_PLUGIN
 NULL_PLUGIN_REGISTRY;
 #endif
@@ -105,7 +107,9 @@ class StackdriverRootContext : public RootContext {
 
   long int last_edge_report_call_nanos_ = 0;
 
-  long int edge_report_duration_nanos_;
+  long int edge_new_report_duration_nanos_;
+
+  long int edge_epoch_report_duration_nanos_ = kDefaultEdgeFullReportDurationNanoseconds;
 
   bool use_host_header_fallback_;
 };


### PR DESCRIPTION
The contract for meshtelemetry is ~1m reporting of new edges, followed by a ~10m reporting of all seen edges.

This PR attempts to adhere closely to that contract. Of note, it repurposes the configurable duration in the proto to handle intra-epoch reporting duration.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>