### PR TITLE
update istio/envoy to ea73c7f21b2048820cc01df92635bef94e3bda6b

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,9 +42,9 @@ ENVOY_PROJECT = "istio"
 
 ENVOY_REPO = "envoy"
 
-ENVOY_SHA = "5c68a90aaebd0a2249361c0e05e17b531b1f6e22"
+ENVOY_SHA = "ea73c7f21b2048820cc01df92635bef94e3bda6b"
 
-ENVOY_SHA256 = "91c844c37c9b7609dd023c0dfa9e6e11c5f83546929d55761135387192ad89d2"
+ENVOY_SHA256 = "c67756be1aae1d5409a9cfa318f4b3c574352b551aec6e95a6e4a33c8e026e23"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.


### PR DESCRIPTION
This PR updates the istio/envoy sha to include the following commits:

```
ea73c7f21b Merge pull request #147 from istio/path-matcher
12dae8171b fix wasm test
c1ef20c5f7 matcher: add PathMatcher and use in routing, jwt and rbac
138043f350 Merge pull request #146 from istio/ignore-case
40a99f1caa add ignore_case to StringMatcher that allows case insensitive exact/prefix/suffix string matching
0ff001ddba Merge pull request #144 from bianpengyuan/relesae-1-5-envoy-tracer
86ffbbec0d use channel credential
61df0c0ed2 use sts for call credential when STS_PORT is provided
```

Signed-off-by: Yangmin Zhu <ymzhu@google.com>

