### PR TITLE
Lazy set BAZEL_OUTPUT_PATH so that bazel is not required

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -53,7 +53,7 @@ BAZEL_CONFIG_ASAN = --config=macos-asan
 BAZEL_CONFIG_TSAN = # no working config
 endif
 
-BAZEL_OUTPUT_PATH := $(shell bazel info $(BAZEL_BUILD_ARGS) output_path)
+BAZEL_OUTPUT_PATH = $(shell bazel info $(BAZEL_BUILD_ARGS) output_path)
 BAZEL_ENVOY_PATH ?= $(BAZEL_OUTPUT_PATH)/k8-fastbuild/bin/src/envoy/envoy
 
 build:


### PR DESCRIPTION
**What this PR does / why we need it**:

*Lazy* set (rather than *immediate* set) `BAZEL_OUTPUT_PATH` so that `bazel` is not required for `make` targets in [`Makefile.common.mk`](https://github.com/istio/proxy/blob/master/common/Makefile.common.mk). 

**Example**:


```bash
BUILD_WITH_CONTAINER=1 make update-common
```

##### Before
```console
Building with the build container: gcr.io/istio-testing/build-tools-proxy:master-2020-01-18T00-45-13.
Using docker credential directory /Users/clarketm/.docker.
Using gcr credential directory /Users/clarketm/.config/gcloud.
Using local Kubernetes configuration /Users/clarketm/.kube
2020/02/14 10:46:32 Downloading https://releases.bazel.build/2.0.0/release/bazel-2.0.0-linux-x86_64...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
...
```

##### After
```console
Building with the build container: gcr.io/istio-testing/build-tools-proxy:master-2020-01-18T00-45-13.
Using docker credential directory /Users/clarketm/.docker.
Using gcr credential directory /Users/clarketm/.config/gcloud.
Using local Kubernetes configuration /Users/clarketm/.kube
...
```

