### PR TITLE
Fix root cert for opencensus library

### DIFF
--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -15,6 +15,9 @@
 
 #include "extensions/stackdriver/metric/registry.h"
 
+#include <fstream>
+#include <sstream>
+
 #include "extensions/stackdriver/common/constants.h"
 #include "extensions/stackdriver/common/utils.h"
 #include "google/api/monitored_resource.pb.h"
@@ -50,7 +53,12 @@ StackdriverOptions getStackdriverOptions(
                                                                    sts_port);
     auto call_creds = grpc::experimental::StsCredentials(sts_options);
     auto ssl_creds_options = grpc::SslCredentialsOptions();
-    ssl_creds_options.pem_root_certs = kDefaultRootCertFile;
+    std::ifstream file(kDefaultRootCertFile);
+    if (!file.fail()) {
+      std::stringstream file_string;
+      file_string << file.rdbuf();
+      ssl_creds_options.pem_root_certs = file_string.str();
+    }
     auto channel_creds = grpc::SslCredentials(ssl_creds_options);
     auto channel = ::grpc::CreateChannel(
         kStackdriverStatsAddress,


### PR DESCRIPTION
**What this PR does / why we need it**:
Read root cert file, and use the content for opencensus stub. This change references https://github.com/envoyproxy/envoy/blob/1dc6e43b23e7de27064fa4e30c39a637697287a9/source/common/filesystem/posix/filesystem_impl.cc#L93.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
