### PR TITLE
feat(stackdriver): support canonical service labels

### DIFF
--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -42,29 +42,23 @@ void record(bool is_outbound, const ::wasm::common::NodeInfo &local_node_info,
   const auto &local_labels = local_node_info.labels();
   const auto &peer_labels = peer_node_info.labels();
 
-  std::string local_canonical_name = local_node_info.workload_name();
-  const auto local_name = local_labels.find(kCanonicalNameLabel);
-  if (local_labels.end() != local_name) {
-    local_canonical_name = local_name->second;
-  }
+  const auto local_name_iter = local_labels.find(kCanonicalNameLabel);
+  const string &local_canonical_name = local_name_iter == local_labels.end()
+                                           ? local_node_info.workload_name()
+                                           : local_name->second;
 
-  std::string peer_canonical_name = peer_node_info.workload_name();
-  const auto peer_name = peer_labels.find(kCanonicalNameLabel);
-  if (peer_labels.end() != peer_name) {
-    peer_canonical_name = peer_name->second;
-  }
+  const auto peer_name_iter = peer_labels.find(kCanonicalNameLabel);
+  const string &peer_canonical_name = peer_name_iter == peer_labels.end()
+                                          ? peer_node_info.workload_name()
+                                          : peer_name->second;
 
-  std::string local_canonical_rev = kLatest;
-  const auto local_rev = local_labels.find(kCanonicalRevisionLabel);
-  if (local_labels.end() != local_rev) {
-    local_canonical_rev = local_rev->second;
-  }
+  const auto local_rev_iter = local_labels.find(kCanonicalRevisionLabel);
+  const string &local_canonical_rev =
+      local_rev_iter == local_labels.end() ? kLatest : local_rev->second;
 
-  std::string peer_canonical_rev = kLatest;
-  const auto peer_rev = peer_labels.find(kCanonicalRevisionLabel);
-  if (peer_labels.end() != peer_rev) {
-    peer_canonical_rev = peer_rev->second;
-  }
+  const auto peer_rev_iter = peer_labels.find(kCanonicalRevisionLabel);
+  const string &peer_canonical_rev =
+      peer_rev_iter == peer_labels.end() ? kLatest : peer_rev->second;
 
   if (is_outbound) {
     opencensus::stats::Record(

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -43,22 +43,22 @@ void record(bool is_outbound, const ::wasm::common::NodeInfo &local_node_info,
   const auto &peer_labels = peer_node_info.labels();
 
   const auto local_name_iter = local_labels.find(kCanonicalNameLabel);
-  const string &local_canonical_name = local_name_iter == local_labels.end()
-                                           ? local_node_info.workload_name()
-                                           : local_name->second;
+  const std::string &local_canonical_name =
+      local_name_iter == local_labels.end() ? local_node_info.workload_name()
+                                            : local_name_iter->second;
 
   const auto peer_name_iter = peer_labels.find(kCanonicalNameLabel);
-  const string &peer_canonical_name = peer_name_iter == peer_labels.end()
-                                          ? peer_node_info.workload_name()
-                                          : peer_name->second;
+  const std::string &peer_canonical_name = peer_name_iter == peer_labels.end()
+                                               ? peer_node_info.workload_name()
+                                               : peer_name_iter->second;
 
   const auto local_rev_iter = local_labels.find(kCanonicalRevisionLabel);
-  const string &local_canonical_rev =
-      local_rev_iter == local_labels.end() ? kLatest : local_rev->second;
+  const std::string &local_canonical_rev =
+      local_rev_iter == local_labels.end() ? kLatest : local_rev_iter->second;
 
   const auto peer_rev_iter = peer_labels.find(kCanonicalRevisionLabel);
-  const string &peer_canonical_rev =
-      peer_rev_iter == peer_labels.end() ? kLatest : peer_rev->second;
+  const std::string &peer_canonical_rev =
+      peer_rev_iter == peer_labels.end() ? kLatest : peer_rev_iter->second;
 
   if (is_outbound) {
     opencensus::stats::Record(

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -121,23 +121,29 @@ StackdriverOptions getStackdriverOptions(
     view_descriptor.RegisterForExport();                            \
   }
 
-#define ADD_TAGS                                     \
-  .add_column(requestOperationKey())                 \
-      .add_column(requestProtocolKey())              \
-      .add_column(serviceAuthenticationPolicyKey())  \
-      .add_column(meshUIDKey())                      \
-      .add_column(destinationServiceNameKey())       \
-      .add_column(destinationServiceNamespaceKey())  \
-      .add_column(destinationPortKey())              \
-      .add_column(responseCodeKey())                 \
-      .add_column(sourcePrincipalKey())              \
-      .add_column(sourceWorkloadNameKey())           \
-      .add_column(sourceWorkloadNamespaceKey())      \
-      .add_column(sourceOwnerKey())                  \
-      .add_column(destinationPrincipalKey())         \
-      .add_column(destinationWorkloadNameKey())      \
-      .add_column(destinationWorkloadNamespaceKey()) \
-      .add_column(destinationOwnerKey())
+#define ADD_TAGS                                             \
+  .add_column(requestOperationKey())                         \
+      .add_column(requestProtocolKey())                      \
+      .add_column(serviceAuthenticationPolicyKey())          \
+      .add_column(meshUIDKey())                              \
+      .add_column(destinationServiceNameKey())               \
+      .add_column(destinationServiceNamespaceKey())          \
+      .add_column(destinationPortKey())                      \
+      .add_column(responseCodeKey())                         \
+      .add_column(sourcePrincipalKey())                      \
+      .add_column(sourceWorkloadNameKey())                   \
+      .add_column(sourceWorkloadNamespaceKey())              \
+      .add_column(sourceOwnerKey())                          \
+      .add_column(destinationPrincipalKey())                 \
+      .add_column(destinationWorkloadNameKey())              \
+      .add_column(destinationWorkloadNamespaceKey())         \
+      .add_column(destinationOwnerKey())                     \
+      .add_column(destinationCanonicalServiceNameKey())      \
+      .add_column(destinationCanonicalServiceNamespaceKey()) \
+      .add_column(sourceCanonicalServiceNameKey())           \
+      .add_column(sourceCanonicalServiceNamespaceKey())      \
+      .add_column(destinationCanonicalRevisionKey())         \
+      .add_column(sourceCanonicalRevisionKey())
 
 // Functions to register opencensus views to export.
 REGISTER_COUNT_VIEW(ServerRequestCount)
@@ -218,6 +224,15 @@ TAG_KEY_FUNC(destination_principal, destinationPrincipal)
 TAG_KEY_FUNC(destination_workload_name, destinationWorkloadName)
 TAG_KEY_FUNC(destination_workload_namespace, destinationWorkloadNamespace)
 TAG_KEY_FUNC(destination_owner, destinationOwner)
+TAG_KEY_FUNC(source_canonical_service_name, sourceCanonicalServiceName)
+TAG_KEY_FUNC(source_canonical_service_namespace,
+             sourceCanonicalServiceNamespace)
+TAG_KEY_FUNC(destination_canonical_service_name,
+             destinationCanonicalServiceName)
+TAG_KEY_FUNC(destination_canonical_service_namespace,
+             destinationCanonicalServiceNamespace)
+TAG_KEY_FUNC(source_canonical_revision, sourceCanonicalRevision)
+TAG_KEY_FUNC(destination_canonical_revision, destinationCanonicalRevision)
 
 }  // namespace Metric
 }  // namespace Stackdriver

--- a/extensions/stackdriver/metric/registry.h
+++ b/extensions/stackdriver/metric/registry.h
@@ -57,6 +57,12 @@ opencensus::tags::TagKey destinationPrincipalKey();
 opencensus::tags::TagKey destinationWorkloadNameKey();
 opencensus::tags::TagKey destinationWorkloadNamespaceKey();
 opencensus::tags::TagKey destinationOwnerKey();
+opencensus::tags::TagKey destinationCanonicalServiceNameKey();
+opencensus::tags::TagKey destinationCanonicalServiceNamespaceKey();
+opencensus::tags::TagKey sourceCanonicalServiceNameKey();
+opencensus::tags::TagKey sourceCanonicalServiceNamespaceKey();
+opencensus::tags::TagKey destinationCanonicalRevisionKey();
+opencensus::tags::TagKey sourceCanonicalRevisionKey();
 
 // Opencensus measure functions.
 opencensus::stats::MeasureInt64 serverRequestCountMeasure();

--- a/testdata/client_node_metadata.json.tmpl
+++ b/testdata/client_node_metadata.json.tmpl
@@ -9,7 +9,8 @@
     "app": "productpage",
     "pod-template-hash": "84975bc778",
     "version": "v1",
-    "service.istio.io/canonical-name": "productpage-v1"
+    "service.istio.io/canonical-name": "productpage-v1",
+    "service.istio.io/canonical-revision": "version-1"
 },
 "MESH_ID": "mesh",
 "NAME": "productpage-v1-84975bc778-pxz2w",

--- a/testdata/server_node_metadata.json.tmpl
+++ b/testdata/server_node_metadata.json.tmpl
@@ -9,7 +9,8 @@
     "app": "ratings",
     "pod-template-hash": "84975bc778",
     "version": "v1",
-    "service.istio.io/canonical-name": "ratings"
+    "service.istio.io/canonical-name": "ratings",
+    "service.istio.io/canonical-revision": "version-1"
 },
 "MESH_ID": "mesh",
 "NAME": "ratings-v1-84975bc778-pxz2w",

--- a/testdata/stackdriver/client_request_count.yaml.tmpl
+++ b/testdata/stackdriver/client_request_count.yaml.tmpl
@@ -1,5 +1,8 @@
 metric:
   labels:
+    destination_canonical_revision: version-1
+    destination_canonical_service_name: ratings
+    destination_canonical_service_namespace: default
     destination_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/ratings-v1
     destination_port: '{{ .Vars.ServerPort }}'
     destination_principal: "{{ .Vars.DestinationPrincipal }}"
@@ -12,6 +15,9 @@ metric:
     request_protocol: http
     response_code: "200"
     service_authentication_policy: "" # TODO: upstream TLS indicator is not reported
+    source_canonical_revision: version-1
+    source_canonical_service_name: productpage-v1
+    source_canonical_service_namespace: default
     source_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/productpage-v1
     source_principal: "{{ .Vars.SourcePrincipal }}"
     source_workload_name: productpage-v1

--- a/testdata/stackdriver/server_request_count.yaml.tmpl
+++ b/testdata/stackdriver/server_request_count.yaml.tmpl
@@ -1,5 +1,8 @@
 metric:
   labels:
+    destination_canonical_revision: version-1
+    destination_canonical_service_name: ratings
+    destination_canonical_service_namespace: default
     destination_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/ratings-v1
     destination_port: '{{ .Vars.ServerPort }}'
     destination_principal: "{{ .Vars.DestinationPrincipal }}"
@@ -12,6 +15,9 @@ metric:
     request_protocol: http
     response_code: "200"
     service_authentication_policy: {{ .Vars.ServiceAuthenticationPolicy }}
+    source_canonical_revision: version-1
+    source_canonical_service_name: productpage-v1
+    source_canonical_service_namespace: default
     source_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/productpage-v1
     source_principal: "{{ .Vars.SourcePrincipal }}"
     source_workload_name: productpage-v1


### PR DESCRIPTION
This PR adds support for canonical service labels to the Stackdriver plugin.  In particular, it adds support for `{source|destination}_canonical_service_{name|namespace}` and `{source|destination}_caonical_revision}`.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>