### PR TITLE
feat(edges): support configurable batch size

### DIFF
--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -20,7 +20,7 @@ package stackdriver.config.v1alpha1;
 import "google/protobuf/duration.proto";
 
 message PluginConfig {
-  // next id: 7
+  // next id: 8
 
   // Optional. Controls whether to export server access log.
   bool disable_server_access_logging = 1;
@@ -52,4 +52,8 @@ message PluginConfig {
   // not available from the controlplane. Disable the fallback if the host
   // header originates outsides the mesh, like at ingress.
   bool disable_host_header_fallback = 6;
+
+  // Optional. Allows configuration of the number of traffic assertions to batch
+  // into a single request. Default is 250.
+  int32 max_edges_batch_size = 7;
 }

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -54,6 +54,6 @@ message PluginConfig {
   bool disable_host_header_fallback = 6;
 
   // Optional. Allows configuration of the number of traffic assertions to batch
-  // into a single request. Default is 250.
+  // into a single request. Default is 100. Max is 1000.
   int32 max_edges_batch_size = 7;
 }

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -69,14 +69,14 @@ void instanceFromMetadata(const ::wasm::common::NodeInfo& node_info,
 
 EdgeReporter::EdgeReporter(const ::wasm::common::NodeInfo& local_node_info,
                            std::unique_ptr<MeshEdgesServiceClient> edges_client,
-                           const int batch_size)
+                           int batch_size)
     : EdgeReporter(local_node_info, std::move(edges_client), batch_size, []() {
         return TimeUtil::NanosecondsToTimestamp(getCurrentTimeNanoseconds());
       }) {}
 
 EdgeReporter::EdgeReporter(const ::wasm::common::NodeInfo& local_node_info,
                            std::unique_ptr<MeshEdgesServiceClient> edges_client,
-                           const int batch_size, TimestampFn now)
+                           int batch_size, TimestampFn now)
     : edges_client_(std::move(edges_client)),
       now_(now),
       max_assertions_per_request_(batch_size) {

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -68,15 +68,18 @@ void instanceFromMetadata(const ::wasm::common::NodeInfo& node_info,
 }  // namespace
 
 EdgeReporter::EdgeReporter(const ::wasm::common::NodeInfo& local_node_info,
-                           std::unique_ptr<MeshEdgesServiceClient> edges_client)
-    : EdgeReporter(local_node_info, std::move(edges_client), []() {
+                           std::unique_ptr<MeshEdgesServiceClient> edges_client,
+                           const int batch_size)
+    : EdgeReporter(local_node_info, std::move(edges_client), batch_size, []() {
         return TimeUtil::NanosecondsToTimestamp(getCurrentTimeNanoseconds());
       }) {}
 
 EdgeReporter::EdgeReporter(const ::wasm::common::NodeInfo& local_node_info,
                            std::unique_ptr<MeshEdgesServiceClient> edges_client,
-                           TimestampFn now)
-    : edges_client_(std::move(edges_client)), now_(now) {
+                           const int batch_size, TimestampFn now)
+    : edges_client_(std::move(edges_client)),
+      now_(now),
+      max_assertions_per_request_(batch_size) {
   current_request_ = std::make_unique<ReportTrafficAssertionsRequest>();
   epoch_current_request_ = std::make_unique<ReportTrafficAssertionsRequest>();
 

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -58,11 +58,11 @@ class EdgeReporter {
  public:
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
                std::unique_ptr<MeshEdgesServiceClient> edges_client,
-               const int batch_size = kDefaultAssertionBatchSize);
+               int batch_size = kDefaultAssertionBatchSize);
 
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
                std::unique_ptr<MeshEdgesServiceClient> edges_client,
-               const int batch_size, TimestampFn now);
+               int batch_size, TimestampFn now);
 
   ~EdgeReporter();  // this will call `reportEdges`
 

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -37,6 +37,8 @@ using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
 using google::cloud::meshtelemetry::v1alpha1::WorkloadInstance;
 using google::protobuf::util::TimeUtil;
 
+constexpr int kDefaultAssertionBatchSize = 100;
+
 // EdgeReporter provides a mechanism for generating information on traffic
 // "edges" for a mesh. It should be used **only** to document incoming edges for
 // a proxy. This means that the proxy in which this reporter is running should
@@ -55,11 +57,12 @@ class EdgeReporter {
 
  public:
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
-               std::unique_ptr<MeshEdgesServiceClient> edges_client);
+               std::unique_ptr<MeshEdgesServiceClient> edges_client,
+               const int batch_size = kDefaultAssertionBatchSize);
 
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
                std::unique_ptr<MeshEdgesServiceClient> edges_client,
-               TimestampFn now);
+               const int batch_size, TimestampFn now);
 
   ~EdgeReporter();  // this will call `reportEdges`
 
@@ -117,8 +120,7 @@ class EdgeReporter {
   std::vector<std::unique_ptr<ReportTrafficAssertionsRequest>>
       epoch_queued_requests_;
 
-  // TODO(douglas-reid): make adjustable.
-  const int max_assertions_per_request_ = 1000;
+  const int max_assertions_per_request_;
 };
 
 }  // namespace Edges

--- a/extensions/stackdriver/edges/edge_reporter.h
+++ b/extensions/stackdriver/edges/edge_reporter.h
@@ -58,7 +58,7 @@ class EdgeReporter {
  public:
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
                std::unique_ptr<MeshEdgesServiceClient> edges_client,
-               int batch_size = kDefaultAssertionBatchSize);
+               int batch_size);
 
   EdgeReporter(const ::wasm::common::NodeInfo &local_node_info,
                std::unique_ptr<MeshEdgesServiceClient> edges_client,

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -191,7 +191,7 @@ TEST(EdgesTest, TestAddEdge) {
       });
 
   auto edges = std::make_unique<EdgeReporter>(
-      nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
+      nodeInfo(), std::move(test_client), 10, TimeUtil::GetCurrentTime);
   edges->addEdge(requestInfo(), "test", peerNodeInfo());
   edges->reportEdges(false /* only report new edges */);
 
@@ -220,7 +220,7 @@ TEST(EdgeReporterTest, TestRequestEdgeCache) {
       });
 
   auto edges = std::make_unique<EdgeReporter>(
-      nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
+      nodeInfo(), std::move(test_client), 1000, TimeUtil::GetCurrentTime);
 
   // force at least three queued reqs + current (four total)
   for (int i = 0; i < 3500; i++) {
@@ -245,14 +245,14 @@ TEST(EdgeReporterTest, TestPeriodicFlushAndCacheReset) {
       });
 
   auto edges = std::make_unique<EdgeReporter>(
-      nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
+      nodeInfo(), std::move(test_client), 100, TimeUtil::GetCurrentTime);
 
   // this should work as follows: 1 assertion in 1 request, the rest dropped
   // (due to cache)
-  for (int i = 0; i < 3500; i++) {
+  for (int i = 0; i < 350; i++) {
     edges->addEdge(requestInfo(), "test", peerNodeInfo());
-    // flush on 1000, 2000, 3000
-    if (i % 1000 == 0 && i > 0) {
+    // flush on 100, 200, 300
+    if (i % 100 == 0 && i > 0) {
       edges->reportEdges(false /* only send current */);
     }
   }
@@ -277,7 +277,7 @@ TEST(EdgeReporterTest, TestCacheMisses) {
       });
 
   auto edges = std::make_unique<EdgeReporter>(
-      nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
+      nodeInfo(), std::move(test_client), 1000, TimeUtil::GetCurrentTime);
 
   // force at least three queued reqs + current (four total)
   for (int i = 0; i < 3500; i++) {
@@ -303,7 +303,7 @@ TEST(EdgeReporterTest, TestMissingPeerMetadata) {
   auto test_client = std::make_unique<TestMeshEdgesServiceClient>(
       [&got](const ReportTrafficAssertionsRequest& req) { got = req; });
   auto edges = std::make_unique<EdgeReporter>(
-      nodeInfo(), std::move(test_client), TimeUtil::GetCurrentTime);
+      nodeInfo(), std::move(test_client), 100, TimeUtil::GetCurrentTime);
   edges->addEdge(requestInfo(), "test", wasm::common::NodeInfo());
   edges->reportEdges(false /* only send current */);
 

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -182,7 +182,8 @@ bool StackdriverRootContext::onConfigure(size_t) {
         this, getMeshTelemetryEndpoint(), sts_port, getTokenFile(),
         getCACertFile());
 
-    if (config_.has_max_edges_batch_size()) {
+    if (config_.max_edges_batch_size() > 0 &&
+        config_.max_edges_batch_size() <= 1000) {
       edge_reporter_ = std::make_unique<EdgeReporter>(
           local_node_info_, std::move(edges_client),
           config_.max_edges_batch_size());

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -181,8 +181,15 @@ bool StackdriverRootContext::onConfigure(size_t) {
     auto edges_client = std::make_unique<MeshEdgesServiceClientImpl>(
         this, getMeshTelemetryEndpoint(), sts_port, getTokenFile(),
         getCACertFile());
-    edge_reporter_ = std::make_unique<EdgeReporter>(local_node_info_,
-                                                    std::move(edges_client));
+
+    if (config_.has_max_edges_batch_size()) {
+      edge_reporter_ = std::make_unique<EdgeReporter>(
+          local_node_info_, std::move(edges_client),
+          config_.max_edges_batch_size());
+    } else {
+      edge_reporter_ = std::make_unique<EdgeReporter>(local_node_info_,
+                                                      std::move(edges_client));
+    }
   }
 
   if (config_.has_mesh_edges_reporting_duration()) {

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -188,8 +188,9 @@ bool StackdriverRootContext::onConfigure(size_t) {
           local_node_info_, std::move(edges_client),
           config_.max_edges_batch_size());
     } else {
-      edge_reporter_ = std::make_unique<EdgeReporter>(local_node_info_,
-                                                      std::move(edges_client));
+      edge_reporter_ = std::make_unique<EdgeReporter>(
+          local_node_info_, std::move(edges_client),
+          ::Extensions::Stackdriver::Edges::kDefaultAssertionBatchSize);
     }
   }
 


### PR DESCRIPTION
This PR adds support for a configurable batch size to the mesh telemetry reporting. It also lowers the default to 100 traffic assertions per request (from 1000).

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

