### PR TITLE
cleanup: deprecate empty proto as config

### DIFF
--- a/src/envoy/tcp/forward_downstream_sni/BUILD
+++ b/src/envoy/tcp/forward_downstream_sni/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        ":config_cc_proto",
         ":forward_downstream_sni_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
@@ -54,4 +55,14 @@ envoy_cc_test(
         "@envoy//test/mocks/server:server_mocks",
         "@envoy//test/mocks/stream_info:stream_info_mocks",
     ],
+)
+
+cc_proto_library(
+    name = "config_cc_proto",
+    deps = ["config_proto"],
+)
+
+proto_library(
+    name = "config_proto",
+    srcs = ["config.proto"],
 )

--- a/src/envoy/tcp/forward_downstream_sni/config.cc
+++ b/src/envoy/tcp/forward_downstream_sni/config.cc
@@ -17,6 +17,7 @@
 
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
+#include "src/envoy/tcp/forward_downstream_sni/config.pb.h"
 #include "src/envoy/tcp/forward_downstream_sni/forward_downstream_sni.h"
 
 namespace Envoy {
@@ -33,7 +34,7 @@ ForwardDownstreamSniNetworkFilterConfigFactory::createFilterFactoryFromProto(
 
 ProtobufTypes::MessagePtr
 ForwardDownstreamSniNetworkFilterConfigFactory::createEmptyConfigProto() {
-  return std::make_unique<ProtobufWkt::Empty>();
+  return std::make_unique<io::istio::tcp::forward_downstream_sni::v1::Config>();
 }
 
 /**

--- a/src/envoy/tcp/forward_downstream_sni/config.proto
+++ b/src/envoy/tcp/forward_downstream_sni/config.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package io.istio.tcp.forward_downstream_sni.v1;
+
+message Config {}

--- a/src/envoy/tcp/forward_downstream_sni/config.proto
+++ b/src/envoy/tcp/forward_downstream_sni/config.proto
@@ -1,3 +1,18 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 syntax = "proto3";
 
 package io.istio.tcp.forward_downstream_sni.v1;

--- a/src/envoy/tcp/sni_verifier/BUILD
+++ b/src/envoy/tcp/sni_verifier/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
     repository = "@envoy",
     visibility = ["//visibility:public"],
     deps = [
+        ":config_cc_proto",
         ":sni_verifier_lib",
         "@envoy//source/exe:envoy_common_lib",
     ],
@@ -55,4 +56,14 @@ envoy_cc_test(
         "@envoy//test/mocks/network:network_mocks",
         "@envoy//test/mocks/server:server_mocks",
     ],
+)
+
+cc_proto_library(
+    name = "config_cc_proto",
+    deps = ["config_proto"],
+)
+
+proto_library(
+    name = "config_proto",
+    srcs = ["config.proto"],
 )

--- a/src/envoy/tcp/sni_verifier/config.cc
+++ b/src/envoy/tcp/sni_verifier/config.cc
@@ -16,6 +16,7 @@
 #include "src/envoy/tcp/sni_verifier/config.h"
 
 #include "envoy/registry/registry.h"
+#include "src/envoy/tcp/sni_verifier/config.pb.h"
 #include "src/envoy/tcp/sni_verifier/sni_verifier.h"
 
 namespace Envoy {
@@ -28,7 +29,7 @@ Network::FilterFactoryCb SniVerifierConfigFactory::createFilterFactoryFromProto(
 }
 
 ProtobufTypes::MessagePtr SniVerifierConfigFactory::createEmptyConfigProto() {
-  return ProtobufTypes::MessagePtr{new Envoy::ProtobufWkt::Empty()};
+  return std::make_unique<io::istio::tcp::sni_verifier::v1::Config>();
 }
 
 Network::FilterFactoryCb

--- a/src/envoy/tcp/sni_verifier/config.proto
+++ b/src/envoy/tcp/sni_verifier/config.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package io.istio.tcp.sni_verifier.v1;
+
+message Config {}

--- a/src/envoy/tcp/sni_verifier/config.proto
+++ b/src/envoy/tcp/sni_verifier/config.proto
@@ -1,3 +1,18 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 syntax = "proto3";
 
 package io.istio.tcp.sni_verifier.v1;


### PR DESCRIPTION
Empty proto is deprecated as config.
Fixes https://github.com/istio/istio/issues/21034