### PR TITLE
Fix duration for timer in stats plugin for TCP metrics

### DIFF
--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -42,7 +42,7 @@ namespace Plugin {
 
 namespace Stats {
 
-constexpr long long kDefaultTCPReportDurationNanoseconds = 15000000000;  // 15s
+constexpr long long kDefaultTCPReportDurationMilliseconds= 15000;  // 15s
 
 namespace {
 
@@ -370,13 +370,13 @@ bool PluginRootContext::onConfigure(size_t) {
 
   initializeDimensions();
 
-  long long tcp_report_duration_nanos = kDefaultTCPReportDurationNanoseconds;
+  long long tcp_report_duration_milis = kDefaultTCPReportDurationMilliseconds;
   if (config_.has_tcp_reporting_duration()) {
-    tcp_report_duration_nanos =
-        ::google::protobuf::util::TimeUtil::DurationToNanoseconds(
+    tcp_report_duration_milis =
+        ::google::protobuf::util::TimeUtil::DurationToMilliseconds(
             config_.tcp_reporting_duration());
   }
-  proxy_set_tick_period_milliseconds(tcp_report_duration_nanos);
+  proxy_set_tick_period_milliseconds(tcp_report_duration_milis);
 
   return true;
 }

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -42,7 +42,7 @@ namespace Plugin {
 
 namespace Stats {
 
-constexpr long long kDefaultTCPReportDurationMilliseconds= 15000;  // 15s
+constexpr long long kDefaultTCPReportDurationMilliseconds = 15000;  // 15s
 
 namespace {
 


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

**What this PR does / why we need it**:
Duration was passed in nanoseconds to ticker in stats plugin for TCP metrics.
It needed to be passed in milliseconds 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/istio/istio/issues/21566

