### PR TITLE
allow unknown fields in configs

### DIFF
--- a/extensions/access_log_policy/plugin.cc
+++ b/extensions/access_log_policy/plugin.cc
@@ -78,6 +78,7 @@ bool PluginRootContext::onConfigure(size_t) {
   }
   WasmDataPtr configuration = getConfiguration();
   JsonParseOptions json_options;
+  json_options.ignore_unknown_fields = true;
   Status status =
       JsonStringToMessage(configuration->toString(), &config_, json_options);
   if (status != Status::OK) {

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -149,6 +149,7 @@ bool StackdriverRootContext::onConfigure(size_t) {
   // TODO: add config validation to reject the listener if project id is not in
   // metadata. Parse configuration JSON string.
   JsonParseOptions json_options;
+  json_options.ignore_unknown_fields = true;
   Status status =
       JsonStringToMessage(configuration->toString(), &config_, json_options);
   if (status != Status::OK) {

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -340,6 +340,7 @@ bool PluginRootContext::onConfigure(size_t) {
   std::unique_ptr<WasmData> configuration = getConfiguration();
   // Parse configuration JSON string.
   JsonParseOptions json_options;
+  json_options.ignore_unknown_fields = true;
   Status status =
       JsonStringToMessage(configuration->toString(), &config_, json_options);
   if (status != Status::OK) {


### PR DESCRIPTION
To support future releases with newer config patches.