### PR TITLE
feat(stackdriver): add support for destination_subset_name

### DIFF
--- a/extensions/stackdriver/metric/BUILD
+++ b/extensions/stackdriver/metric/BUILD
@@ -42,6 +42,7 @@ envoy_cc_library(
         "//extensions/stackdriver/common:constants",
         "//extensions/stackdriver/common:utils",
         "//extensions/stackdriver/config/v1alpha1:stackdriver_plugin_config_cc_proto",
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
         "@io_opencensus_cpp//opencensus/exporters/stats/stackdriver:stackdriver_exporter",
         "@io_opencensus_cpp//opencensus/stats",
     ],

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -122,6 +122,17 @@ StackdriverOptions getStackdriverOptions(
     view_descriptor.RegisterForExport();                     \
   }
 
+#define REGISTER_CLIENT_COUNT_VIEW(_v)                              \
+  void register##_v##View() {                                       \
+    const ViewDescriptor view_descriptor =                          \
+        ViewDescriptor()                                            \
+            .set_name(k##_v##View)                                  \
+            .set_measure(k##_v##Measure)                            \
+            .set_aggregation(Aggregation::Count()) ADD_CLIENT_TAGS; \
+    View view(view_descriptor);                                     \
+    view_descriptor.RegisterForExport();                            \
+  }
+
 #define REGISTER_DISTRIBUTION_VIEW(_v)                              \
   void register##_v##View() {                                       \
     const ViewDescriptor view_descriptor =                          \
@@ -132,6 +143,18 @@ StackdriverOptions getStackdriverOptions(
                 BucketBoundaries::Exponential(20, 1, 2))) ADD_TAGS; \
     View view(view_descriptor);                                     \
     view_descriptor.RegisterForExport();                            \
+  }
+
+#define REGISTER_CLIENT_DISTRIBUTION_VIEW(_v)                              \
+  void register##_v##View() {                                              \
+    const ViewDescriptor view_descriptor =                                 \
+        ViewDescriptor()                                                   \
+            .set_name(k##_v##View)                                         \
+            .set_measure(k##_v##Measure)                                   \
+            .set_aggregation(Aggregation::Distribution(                    \
+                BucketBoundaries::Exponential(20, 1, 2))) ADD_CLIENT_TAGS; \
+    View view(view_descriptor);                                            \
+    view_descriptor.RegisterForExport();                                   \
   }
 
 #define ADD_TAGS                                             \
@@ -158,15 +181,40 @@ StackdriverOptions getStackdriverOptions(
       .add_column(destinationCanonicalRevisionKey())         \
       .add_column(sourceCanonicalRevisionKey())
 
+#define ADD_CLIENT_TAGS                                      \
+  .add_column(requestOperationKey())                         \
+      .add_column(requestProtocolKey())                      \
+      .add_column(serviceAuthenticationPolicyKey())          \
+      .add_column(meshUIDKey())                              \
+      .add_column(destinationServiceNameKey())               \
+      .add_column(destinationServiceNamespaceKey())          \
+      .add_column(destinationPortKey())                      \
+      .add_column(responseCodeKey())                         \
+      .add_column(sourcePrincipalKey())                      \
+      .add_column(sourceWorkloadNameKey())                   \
+      .add_column(sourceWorkloadNamespaceKey())              \
+      .add_column(sourceOwnerKey())                          \
+      .add_column(destinationPrincipalKey())                 \
+      .add_column(destinationWorkloadNameKey())              \
+      .add_column(destinationWorkloadNamespaceKey())         \
+      .add_column(destinationOwnerKey())                     \
+      .add_column(destinationCanonicalServiceNameKey())      \
+      .add_column(destinationCanonicalServiceNamespaceKey()) \
+      .add_column(sourceCanonicalServiceNameKey())           \
+      .add_column(sourceCanonicalServiceNamespaceKey())      \
+      .add_column(destinationCanonicalRevisionKey())         \
+      .add_column(sourceCanonicalRevisionKey())              \
+      .add_column(destinationSubsetNameKey())
+
 // Functions to register opencensus views to export.
 REGISTER_COUNT_VIEW(ServerRequestCount)
 REGISTER_DISTRIBUTION_VIEW(ServerRequestBytes)
 REGISTER_DISTRIBUTION_VIEW(ServerResponseBytes)
 REGISTER_DISTRIBUTION_VIEW(ServerResponseLatencies)
-REGISTER_COUNT_VIEW(ClientRequestCount)
-REGISTER_DISTRIBUTION_VIEW(ClientRequestBytes)
-REGISTER_DISTRIBUTION_VIEW(ClientResponseBytes)
-REGISTER_DISTRIBUTION_VIEW(ClientRoundtripLatencies)
+REGISTER_CLIENT_COUNT_VIEW(ClientRequestCount)
+REGISTER_CLIENT_DISTRIBUTION_VIEW(ClientRequestBytes)
+REGISTER_CLIENT_DISTRIBUTION_VIEW(ClientResponseBytes)
+REGISTER_CLIENT_DISTRIBUTION_VIEW(ClientRoundtripLatencies)
 
 /*
  * measure function macros
@@ -246,6 +294,7 @@ TAG_KEY_FUNC(destination_canonical_service_namespace,
              destinationCanonicalServiceNamespace)
 TAG_KEY_FUNC(source_canonical_revision, sourceCanonicalRevision)
 TAG_KEY_FUNC(destination_canonical_revision, destinationCanonicalRevision)
+TAG_KEY_FUNC(destination_subset_name, destinationSubsetName)
 
 }  // namespace Metric
 }  // namespace Stackdriver

--- a/extensions/stackdriver/metric/registry.h
+++ b/extensions/stackdriver/metric/registry.h
@@ -64,6 +64,7 @@ opencensus::tags::TagKey sourceCanonicalServiceNameKey();
 opencensus::tags::TagKey sourceCanonicalServiceNamespaceKey();
 opencensus::tags::TagKey destinationCanonicalRevisionKey();
 opencensus::tags::TagKey sourceCanonicalRevisionKey();
+opencensus::tags::TagKey destinationSubsetNameKey();
 
 // Opencensus measure functions.
 opencensus::stats::MeasureInt64 serverRequestCountMeasure();

--- a/test/envoye2e/env/envoy_conf.go
+++ b/test/envoye2e/env/envoy_conf.go
@@ -36,11 +36,15 @@ admin:
       port_value: {{.Ports.ClientAdminPort}}
 static_resources:
   clusters:
-  - name: client
+  - name: server
+    metadata:
+      filter_metadata:
+        istio:
+          subset: server
     connect_timeout: 5s
     type: STATIC
     load_assignment:
-      cluster_name: client
+      cluster_name: server
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -79,7 +83,7 @@ static_resources:
               - match:
                   prefix: /
                 route:
-                  cluster: client
+                  cluster: server
                   timeout: 0s
 {{.TLSContext | indent 6 }}`
 

--- a/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
@@ -300,7 +300,7 @@ func TestStackdriverPlugin(t *testing.T) {
 		case req := <-fsdm.RcvMetricReq:
 			isClient, err := verifyCreateTimeSeriesReq(req)
 			if err != nil {
-				t.Errorf("CreateTimeSeries verification failed: %v", err)
+				t.Errorf("CreateTimeSeries verification failed (client=%t): %v", isClient, err)
 			}
 			if isClient {
 				cltMetricRcv = true

--- a/testdata/bootstrap/client.yaml.tmpl
+++ b/testdata/bootstrap/client.yaml.tmpl
@@ -34,6 +34,10 @@ static_resources:
     http2_protocol_options: {}
     name: xds_cluster
   - name: server
+    metadata:
+      filter_metadata:
+        istio:
+          subset: server
     connect_timeout: 1s
     type: STATIC
     http2_protocol_options: {}

--- a/testdata/stackdriver/client_request_count.yaml.tmpl
+++ b/testdata/stackdriver/client_request_count.yaml.tmpl
@@ -8,6 +8,7 @@ metric:
     destination_principal: "{{ .Vars.DestinationPrincipal }}"
     destination_service_name: "127.0.0.1:{{ .Vars.ClientPort }}"
     destination_service_namespace: default
+    destination_subset_name: "server"
     destination_workload_name: ratings-v1
     destination_workload_namespace: default
     mesh_uid: mesh


### PR DESCRIPTION
This PR adds `destination_subset_name` to the Stackdriver extension for client-side metrics. The name is taken from cluster metadata, according to the changes in https://github.com/istio/istio/pull/21611.

This PR should not be submitted until the Stackdriver schema changes have been approved.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>

/hold