### PR TITLE
Remove not getting TCP Metrics for unknown peers and Add Context in onTick calls

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,9 +38,9 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # envoy-wasm commit date: Mar 3 2020
-ENVOY_SHA = "373eafdb20958a019f5556e508b5286eba88af06"
+ENVOY_SHA = "e64efd960cd8e97287764b9bae39b3a0def95046"
 
-ENVOY_SHA256 = "e7fbb8b14f1a30024a07d40019df4dfd944cbbc813be08b46a2b5fca5f495a79"
+ENVOY_SHA256 = "3bac67e31d920725b0655d2c5dd1934d63d57d542f80e324d661c6b3b536b4bf"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,10 +37,10 @@ bind(
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy-wasm/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
-# envoy-wasm commit date: Feb 28 2020
-ENVOY_SHA = "f4ace91833442010118a592c2dff3689d984337d"
+# envoy-wasm commit date: Mar 3 2020
+ENVOY_SHA = "373eafdb20958a019f5556e508b5286eba88af06"
 
-ENVOY_SHA256 = "ae09c53f6b6e99e7262e8275a0d4c0af67b984bd5520a368a4321e88b09e39f1"
+ENVOY_SHA256 = "e7fbb8b14f1a30024a07d40019df4dfd944cbbc813be08b46a2b5fca5f495a79"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -46,7 +46,6 @@ namespace Stats {
 constexpr long long kDefaultTCPReportDurationMilliseconds = 15000;  // 15s
 // No healthy upstream.
 constexpr uint64_t kNoHealthyUpstream = 0x2;
-using ::Envoy::Extensions::Common::Wasm::Null::Plugin::getContext;
 
 namespace {
 

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -457,13 +457,6 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
   const auto& destination_node_info = outbound_ ? peer_node : local_node_info_;
 
   if (is_tcp) {
-    // For TCP, if peer metadata is not available, peer id is set as not found.
-    // Otherwise, we wait for metadata exchange to happen before we report  any
-    // metric.
-    if (peer_node_ptr == nullptr &&
-        peer_id != ::Wasm::Common::kMetadataNotFoundValue) {
-      return false;
-    }
     if (!request_info.is_populated) {
       ::Wasm::Common::populateTCPRequestInfo(
           outbound_, &request_info, destination_node_info.namespace_());


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove not getting TCP Metrics for unknown peers
Also, add context in onTick. calls which makes possible to get streaminfo from context in wasm plugin

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Ref: https://github.com/istio/istio/issues/21566


