### PR TITLE
Push wasm build container in presubmit

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -71,7 +71,7 @@ build_wasm:
 
 check_wasm:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) //src/envoy:envoy
-	./scripts/generate-wasm.sh -b
+	./scripts/generate-wasm.sh -b -p
 	env ENVOY_PATH=$(BAZEL_ENVOY_PATH) GO111MODULE=on WASM=true go test ./test/envoye2e/stats/...
 
 clean:

--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -30,7 +30,7 @@ function usage() {
 }
 
 BUILD_CONTAINER=0
-PUSH_CONTAINER=0
+PUSH_DOCKER_IMAGE=0
 DST_BUCKET=""
 
 while getopts bpcd: arg ; do


### PR DESCRIPTION
**What this PR does / why we need it**:
wasm gen container is too slow to build and could slows down iteration for envoy sha update PR. This change makes ci push container during presubmit, so that it will only be built once during envoy sha update.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
