### PR TITLE
fix(stackdriver): use more appropriate buckets for bytes

### DIFF
--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -141,7 +141,7 @@ StackdriverOptions getStackdriverOptions(
             .set_name(k##_v##View)                                  \
             .set_measure(k##_v##Measure)                            \
             .set_aggregation(Aggregation::Distribution(             \
-                BucketBoundaries::Exponential(8, 1, 10))) ADD_TAGS; \
+                BucketBoundaries::Exponential(7, 1, 10))) ADD_TAGS; \
     View view(view_descriptor);                                     \
     view_descriptor.RegisterForExport();                            \
   }

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -134,6 +134,18 @@ StackdriverOptions getStackdriverOptions(
     view_descriptor.RegisterForExport();                            \
   }
 
+#define REGISTER_BYTES_DISTRIBUTION_VIEW(_v)                        \
+  void register##_v##View() {                                       \
+    const ViewDescriptor view_descriptor =                          \
+        ViewDescriptor()                                            \
+            .set_name(k##_v##View)                                  \
+            .set_measure(k##_v##Measure)                            \
+            .set_aggregation(Aggregation::Distribution(             \
+                BucketBoundaries::Exponential(8, 1, 10))) ADD_TAGS; \
+    View view(view_descriptor);                                     \
+    view_descriptor.RegisterForExport();                            \
+  }
+
 #define ADD_TAGS                                             \
   .add_column(requestOperationKey())                         \
       .add_column(requestProtocolKey())                      \
@@ -160,12 +172,12 @@ StackdriverOptions getStackdriverOptions(
 
 // Functions to register opencensus views to export.
 REGISTER_COUNT_VIEW(ServerRequestCount)
-REGISTER_DISTRIBUTION_VIEW(ServerRequestBytes)
-REGISTER_DISTRIBUTION_VIEW(ServerResponseBytes)
+REGISTER_BYTES_DISTRIBUTION_VIEW(ServerRequestBytes)
+REGISTER_BYTES_DISTRIBUTION_VIEW(ServerResponseBytes)
 REGISTER_DISTRIBUTION_VIEW(ServerResponseLatencies)
 REGISTER_COUNT_VIEW(ClientRequestCount)
-REGISTER_DISTRIBUTION_VIEW(ClientRequestBytes)
-REGISTER_DISTRIBUTION_VIEW(ClientResponseBytes)
+REGISTER_BYTES_DISTRIBUTION_VIEW(ClientRequestBytes)
+REGISTER_BYTES_DISTRIBUTION_VIEW(ClientResponseBytes)
 REGISTER_DISTRIBUTION_VIEW(ClientRoundtripLatencies)
 
 /*


### PR DESCRIPTION
This PR attempts to separate the bucket definitions used for bytes distributions from the definitions used for latency measurements. Instead of 20 buckets with a scale factor of 1 and a growth factor of 2, the bytes metrics will now use 7 buckets with a scale factor of 1 and growth factor of 10.

That should lead to the following buckets:

[-Inf, 0)
[0, 10)
[10, 100)
[100, 1000)
[1000, 10000)
[10000, 100000)
[100000, 1000000)
[1000000, 10000000)
[10000000, Inf]

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>
