### PR TITLE
Fix seg fault in mixer tcp after upgrading envoy-wasm sha

### DIFF
--- a/src/envoy/tcp/mixer/filter.cc
+++ b/src/envoy/tcp/mixer/filter.cc
@@ -219,7 +219,8 @@ bool Filter::GetDestinationIpPort(std::string *str_ip, int *port) const {
 }
 
 bool Filter::GetDestinationUID(std::string *uid) const {
-  if (filter_callbacks_->upstreamHost()) {
+  if (filter_callbacks_->upstreamHost() &&
+      filter_callbacks_->upstreamHost()->metadata()) {
     return Utils::GetDestinationUID(
         *filter_callbacks_->upstreamHost()->metadata(), uid);
   }


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

**What this PR does / why we need it**:
After upgrading proxy with latest envoy-wasm, tcp unit tests failed in istio/istio: https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22145/unit-tests_istio/10189.
This PR fixes that.
