### PR TITLE
fix(stackdriver): support turning off http size metrics

### DIFF
--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -20,7 +20,7 @@ package stackdriver.config.v1alpha1;
 import "google/protobuf/duration.proto";
 
 message PluginConfig {
-  // next id: 8
+  // next id: 10
 
   // Optional. Controls whether to export server access log.
   bool disable_server_access_logging = 1;
@@ -56,4 +56,13 @@ message PluginConfig {
   // Optional. Allows configuration of the number of traffic assertions to batch
   // into a single request. Default is 100. Max is 1000.
   int32 max_edges_batch_size = 7;
+
+  // Optional. Allows disabling of reporting of client-side metrics (outgoing)
+  // traffic. Defaults to false (client-side metrics enabled).
+  bool disable_client_metrics = 8;
+
+  // Optional. Allows disabling of reporting of the request and response size
+  // metrics for HTTP traffic. Defaults to false (request and response size
+  // metrics are enabled).
+  bool disable_http_size_metrics = 9;
 }

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -20,7 +20,7 @@ package stackdriver.config.v1alpha1;
 import "google/protobuf/duration.proto";
 
 message PluginConfig {
-  // next id: 10
+  // next id: 9
 
   // Optional. Controls whether to export server access log.
   bool disable_server_access_logging = 1;
@@ -57,12 +57,8 @@ message PluginConfig {
   // into a single request. Default is 100. Max is 1000.
   int32 max_edges_batch_size = 7;
 
-  // Optional. Allows disabling of reporting of client-side metrics (outgoing)
-  // traffic. Defaults to false (client-side metrics enabled).
-  bool disable_client_metrics = 8;
-
   // Optional. Allows disabling of reporting of the request and response size
   // metrics for HTTP traffic. Defaults to false (request and response size
   // metrics are enabled).
-  bool disable_http_size_metrics = 9;
+  bool disable_http_size_metrics = 8;
 }

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -66,107 +66,108 @@ void record(bool is_outbound, const ::Wasm::Common::FlatNode& local_node_info,
       peer_rev_iter ? peer_rev_iter->value() : nullptr;
 
   if (is_outbound) {
-    std::initializer_list<opencensus::stats::Measurement> measurements = {
-        {clientRequestCountMeasure(), 1},
-        {clientRoundtripLatenciesMeasure(), latency_ms}};
+    opencensus::tags::TagMap tagMap = {
+        {meshUIDKey(), flatbuffers::GetString(local_node_info.mesh_id())},
+        {requestOperationKey(), operation},
+        {requestProtocolKey(), request_info.request_protocol},
+        {serviceAuthenticationPolicyKey(),
+         ::Wasm::Common::AuthenticationPolicyString(
+             request_info.service_auth_policy)},
+        {destinationServiceNameKey(), request_info.destination_service_name},
+        {destinationServiceNamespaceKey(),
+         flatbuffers::GetString(peer_node_info.namespace_())},
+        {destinationPortKey(), std::to_string(request_info.destination_port)},
+        {responseCodeKey(), std::to_string(request_info.response_code)},
+        {sourcePrincipalKey(), request_info.source_principal},
+        {sourceWorkloadNameKey(),
+         flatbuffers::GetString(local_node_info.workload_name())},
+        {sourceWorkloadNamespaceKey(),
+         flatbuffers::GetString(local_node_info.namespace_())},
+        {sourceOwnerKey(), flatbuffers::GetString(local_node_info.owner())},
+        {destinationPrincipalKey(), request_info.destination_principal},
+        {destinationWorkloadNameKey(),
+         flatbuffers::GetString(peer_node_info.workload_name())},
+        {destinationWorkloadNamespaceKey(),
+         flatbuffers::GetString(peer_node_info.namespace_())},
+        {destinationOwnerKey(), flatbuffers::GetString(peer_node_info.owner())},
+        {destinationCanonicalServiceNameKey(),
+         flatbuffers::GetString(peer_canonical_name)},
+        {destinationCanonicalServiceNamespaceKey(),
+         flatbuffers::GetString(peer_node_info.namespace_())},
+        {destinationCanonicalRevisionKey(),
+         peer_canonical_rev ? peer_canonical_rev->str() : kLatest},
+        {sourceCanonicalServiceNameKey(),
+         flatbuffers::GetString(local_canonical_name)},
+        {sourceCanonicalServiceNamespaceKey(),
+         flatbuffers::GetString(local_node_info.namespace_())},
+        {sourceCanonicalRevisionKey(),
+         local_canonical_rev ? local_canonical_rev->str() : kLatest}};
 
     if (record_http_size_metrics) {
-      measurements = {
-          {clientRequestCountMeasure(), 1},
-          {clientRoundtripLatenciesMeasure(), latency_ms},
-          {clientRequestBytesMeasure(), request_info.request_size},
-          {clientResponseBytesMeasure(), request_info.response_size}};
+      opencensus::stats::Record(
+          {{clientRequestCountMeasure(), 1},
+           {clientRoundtripLatenciesMeasure(), latency_ms},
+           {clientRequestBytesMeasure(), request_info.request_size},
+           {clientResponseBytesMeasure(), request_info.response_size}},
+          tagMap);
+    } else {
+      opencensus::stats::Record(
+          {{clientRequestCountMeasure(), 1},
+           {clientRoundtripLatenciesMeasure(), latency_ms}},
+          tagMap);
     }
-
-    opencensus::stats::Record(
-        measurements,
-        {{meshUIDKey(), flatbuffers::GetString(local_node_info.mesh_id())},
-         {requestOperationKey(), operation},
-         {requestProtocolKey(), request_info.request_protocol},
-         {serviceAuthenticationPolicyKey(),
-          ::Wasm::Common::AuthenticationPolicyString(
-              request_info.service_auth_policy)},
-         {destinationServiceNameKey(), request_info.destination_service_name},
-         {destinationServiceNamespaceKey(),
-          flatbuffers::GetString(peer_node_info.namespace_())},
-         {destinationPortKey(), std::to_string(request_info.destination_port)},
-         {responseCodeKey(), std::to_string(request_info.response_code)},
-         {sourcePrincipalKey(), request_info.source_principal},
-         {sourceWorkloadNameKey(),
-          flatbuffers::GetString(local_node_info.workload_name())},
-         {sourceWorkloadNamespaceKey(),
-          flatbuffers::GetString(local_node_info.namespace_())},
-         {sourceOwnerKey(), flatbuffers::GetString(local_node_info.owner())},
-         {destinationPrincipalKey(), request_info.destination_principal},
-         {destinationWorkloadNameKey(),
-          flatbuffers::GetString(peer_node_info.workload_name())},
-         {destinationWorkloadNamespaceKey(),
-          flatbuffers::GetString(peer_node_info.namespace_())},
-         {destinationOwnerKey(),
-          flatbuffers::GetString(peer_node_info.owner())},
-         {destinationCanonicalServiceNameKey(),
-          flatbuffers::GetString(peer_canonical_name)},
-         {destinationCanonicalServiceNamespaceKey(),
-          flatbuffers::GetString(peer_node_info.namespace_())},
-         {destinationCanonicalRevisionKey(),
-          peer_canonical_rev ? peer_canonical_rev->str() : kLatest},
-         {sourceCanonicalServiceNameKey(),
-          flatbuffers::GetString(local_canonical_name)},
-         {sourceCanonicalServiceNamespaceKey(),
-          flatbuffers::GetString(local_node_info.namespace_())},
-         {sourceCanonicalRevisionKey(),
-          local_canonical_rev ? local_canonical_rev->str() : kLatest}});
     return;
   }
 
-  std::initializer_list<opencensus::stats::Measurement> measurements = {
-      {serverRequestCountMeasure(), 1},
-      {serverResponseLatenciesMeasure(), latency_ms}};
+  opencensus::tags::TagMap tagMap = {
+      {meshUIDKey(), flatbuffers::GetString(local_node_info.mesh_id())},
+      {requestOperationKey(), operation},
+      {requestProtocolKey(), request_info.request_protocol},
+      {serviceAuthenticationPolicyKey(),
+       ::Wasm::Common::AuthenticationPolicyString(
+           request_info.service_auth_policy)},
+      {destinationServiceNameKey(), request_info.destination_service_name},
+      {destinationServiceNamespaceKey(),
+       flatbuffers::GetString(local_node_info.namespace_())},
+      {destinationPortKey(), std::to_string(request_info.destination_port)},
+      {responseCodeKey(), std::to_string(request_info.response_code)},
+      {sourcePrincipalKey(), request_info.source_principal},
+      {sourceWorkloadNameKey(),
+       flatbuffers::GetString(peer_node_info.workload_name())},
+      {sourceWorkloadNamespaceKey(),
+       flatbuffers::GetString(peer_node_info.namespace_())},
+      {sourceOwnerKey(), flatbuffers::GetString(peer_node_info.owner())},
+      {destinationPrincipalKey(), request_info.destination_principal},
+      {destinationWorkloadNameKey(),
+       flatbuffers::GetString(local_node_info.workload_name())},
+      {destinationWorkloadNamespaceKey(),
+       flatbuffers::GetString(local_node_info.namespace_())},
+      {destinationOwnerKey(), flatbuffers::GetString(local_node_info.owner())},
+      {destinationCanonicalServiceNameKey(),
+       flatbuffers::GetString(local_canonical_name)},
+      {destinationCanonicalServiceNamespaceKey(),
+       flatbuffers::GetString(local_node_info.namespace_())},
+      {destinationCanonicalRevisionKey(),
+       local_canonical_rev ? local_canonical_rev->str() : kLatest},
+      {sourceCanonicalServiceNameKey(),
+       flatbuffers::GetString(peer_canonical_name)},
+      {sourceCanonicalServiceNamespaceKey(),
+       flatbuffers::GetString(peer_node_info.namespace_())},
+      {sourceCanonicalRevisionKey(),
+       peer_canonical_rev ? peer_canonical_rev->str() : kLatest}};
 
   if (record_http_size_metrics) {
-    measurements = {{serverRequestCountMeasure(), 1},
-                    {serverResponseLatenciesMeasure(), latency_ms},
-                    {serverRequestBytesMeasure(), request_info.request_size},
-                    {serverResponseBytesMeasure(), request_info.response_size}};
+    opencensus::stats::Record(
+        {{serverRequestCountMeasure(), 1},
+         {serverResponseLatenciesMeasure(), latency_ms},
+         {serverRequestBytesMeasure(), request_info.request_size},
+         {serverResponseBytesMeasure(), request_info.response_size}},
+        tagMap);
+  } else {
+    opencensus::stats::Record({{serverRequestCountMeasure(), 1},
+                               {serverResponseLatenciesMeasure(), latency_ms}},
+                              tagMap);
   }
-
-  opencensus::stats::Record(
-      measurements,
-      {{meshUIDKey(), flatbuffers::GetString(local_node_info.mesh_id())},
-       {requestOperationKey(), operation},
-       {requestProtocolKey(), request_info.request_protocol},
-       {serviceAuthenticationPolicyKey(),
-        ::Wasm::Common::AuthenticationPolicyString(
-            request_info.service_auth_policy)},
-       {destinationServiceNameKey(), request_info.destination_service_name},
-       {destinationServiceNamespaceKey(),
-        flatbuffers::GetString(local_node_info.namespace_())},
-       {destinationPortKey(), std::to_string(request_info.destination_port)},
-       {responseCodeKey(), std::to_string(request_info.response_code)},
-       {sourcePrincipalKey(), request_info.source_principal},
-       {sourceWorkloadNameKey(),
-        flatbuffers::GetString(peer_node_info.workload_name())},
-       {sourceWorkloadNamespaceKey(),
-        flatbuffers::GetString(peer_node_info.namespace_())},
-       {sourceOwnerKey(), flatbuffers::GetString(peer_node_info.owner())},
-       {destinationPrincipalKey(), request_info.destination_principal},
-       {destinationWorkloadNameKey(),
-        flatbuffers::GetString(local_node_info.workload_name())},
-       {destinationWorkloadNamespaceKey(),
-        flatbuffers::GetString(local_node_info.namespace_())},
-       {destinationOwnerKey(), flatbuffers::GetString(local_node_info.owner())},
-       {destinationCanonicalServiceNameKey(),
-        flatbuffers::GetString(local_canonical_name)},
-       {destinationCanonicalServiceNamespaceKey(),
-        flatbuffers::GetString(local_node_info.namespace_())},
-       {destinationCanonicalRevisionKey(),
-        local_canonical_rev ? local_canonical_rev->str() : kLatest},
-       {sourceCanonicalServiceNameKey(),
-        flatbuffers::GetString(peer_canonical_name)},
-       {sourceCanonicalServiceNamespaceKey(),
-        flatbuffers::GetString(peer_node_info.namespace_())},
-       {sourceCanonicalRevisionKey(),
-        peer_canonical_rev ? peer_canonical_rev->str() : kLatest}});
 }
 
 }  // namespace Metric

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -32,7 +32,7 @@ constexpr char kLatest[] = "latest";
 
 void record(bool is_outbound, const ::Wasm::Common::FlatNode& local_node_info,
             const ::Wasm::Common::FlatNode& peer_node_info,
-            const ::Wasm::Common::RequestInfo &request_info,
+            const ::Wasm::Common::RequestInfo& request_info,
             bool record_http_size_metrics) {
   double latency_ms = request_info.duration /* in nanoseconds */ / 1000000.0;
   const auto& operation =

--- a/extensions/stackdriver/metric/record.h
+++ b/extensions/stackdriver/metric/record.h
@@ -26,7 +26,8 @@ namespace Metric {
 // Reporter kind deceides the type of metrics to record.
 void record(bool is_outbound, const ::Wasm::Common::FlatNode& local_node_info,
             const ::Wasm::Common::FlatNode& peer_node_info,
-            const ::Wasm::Common::RequestInfo& request_info);
+            const ::Wasm::Common::RequestInfo &request_info,
+            bool record_http_size_metrics);
 
 }  // namespace Metric
 }  // namespace Stackdriver

--- a/extensions/stackdriver/metric/record.h
+++ b/extensions/stackdriver/metric/record.h
@@ -26,7 +26,7 @@ namespace Metric {
 // Reporter kind deceides the type of metrics to record.
 void record(bool is_outbound, const ::Wasm::Common::FlatNode& local_node_info,
             const ::Wasm::Common::FlatNode& peer_node_info,
-            const ::Wasm::Common::RequestInfo &request_info,
+            const ::Wasm::Common::RequestInfo& request_info,
             bool record_http_size_metrics);
 
 }  // namespace Metric

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -313,8 +313,11 @@ void StackdriverRootContext::record() {
   ::Wasm::Common::populateHTTPRequestInfo(
       isOutbound(), useHostHeaderFallback(), &request_info,
       flatbuffers::GetString(destination_node_info.namespace_()));
-  ::Extensions::Stackdriver::Metric::record(isOutbound(), local_node, peer_node,
-                                            request_info);
+  if (!isOutbound() || (isOutbound() && !config_.disable_client_metrics())) {
+    ::Extensions::Stackdriver::Metric::record(
+        isOutbound(), local_node, peer_node, request_info,
+        !config_.disable_http_size_metrics());
+  }
   if (enableServerAccessLog() && shouldLogThisRequest()) {
     ::Wasm::Common::populateExtendedHTTPRequestInfo(&request_info);
     logger_->addLogEntry(request_info, peer_node);

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -314,7 +314,7 @@ void StackdriverRootContext::record() {
       isOutbound(), useHostHeaderFallback(), &request_info,
       flatbuffers::GetString(destination_node_info.namespace_()));
   ::Extensions::Stackdriver::Metric::record(
-      isOutbound(), local_node_info_, peer_node_info, request_info,
+      isOutbound(), local_node, peer_node, request_info,
       !config_.disable_http_size_metrics());
   if (enableServerAccessLog() && shouldLogThisRequest()) {
     ::Wasm::Common::populateExtendedHTTPRequestInfo(&request_info);

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -313,11 +313,9 @@ void StackdriverRootContext::record() {
   ::Wasm::Common::populateHTTPRequestInfo(
       isOutbound(), useHostHeaderFallback(), &request_info,
       flatbuffers::GetString(destination_node_info.namespace_()));
-  if (!isOutbound() || (isOutbound() && !config_.disable_client_metrics())) {
-    ::Extensions::Stackdriver::Metric::record(
-        isOutbound(), local_node, peer_node, request_info,
-        !config_.disable_http_size_metrics());
-  }
+  ::Extensions::Stackdriver::Metric::record(
+      isOutbound(), local_node_info_, peer_node_info, request_info,
+      !config_.disable_http_size_metrics());
   if (enableServerAccessLog() && shouldLogThisRequest()) {
     ::Wasm::Common::populateExtendedHTTPRequestInfo(&request_info);
     logger_->addLogEntry(request_info, peer_node);


### PR DESCRIPTION
This PR adds configurability to the Stackdriver metrics plugin. It allows disabling of all request/response bytes metrics.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>
