### PR TITLE
Partial Revert of STS changes after Istio 1.4.5 variant 2

### DIFF
--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -17,11 +17,6 @@
 
 licenses(["notice"])
 
-load(
-    "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_cc_library",
-)
-
 cc_library(
     name = "constants",
     hdrs = [
@@ -35,7 +30,7 @@ cc_library(
     ],
 )
 
-envoy_cc_library(
+cc_library(
     name = "utils",
     srcs = [
         "utils.cc",
@@ -43,11 +38,8 @@ envoy_cc_library(
     hdrs = [
         "utils.h",
     ],
-    external_deps = ["grpc"],
-    repository = "@envoy",
     visibility = [
         "//extensions/stackdriver:__pkg__",
-        "//extensions/stackdriver/edges:__pkg__",
         "//extensions/stackdriver/log:__pkg__",
         "//extensions/stackdriver/metric:__pkg__",
     ],

--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -64,7 +64,6 @@ constexpr char kGCPGCEInstanceIDKey[] = "gcp_gce_instance_id";
 // Misc
 constexpr char kIstioProxyContainerName[] = "istio-proxy";
 constexpr double kNanosecondsPerMillisecond = 1000000.0;
-constexpr char kDefaultRootCertFile[] = "/etc/ssl/certs/ca-certificates.crt";
 
 // Stackdriver root context id.
 constexpr char kOutboundRootContextId[] = "stackdriver_outbound";
@@ -77,14 +76,6 @@ constexpr char kMeshTelemetryEndpointKey[] =
     "STACKDRIVER_MESH_TELEMETRY_ENDPOINT";
 constexpr char kMonitoringExportIntervalKey[] =
     "STACKDRIVER_MONITORING_EXPORT_INTERVAL_SECS";
-
-// Port of security token exchange server (STS).
-constexpr char kSTSPortKey[] = "STS_PORT";
-
-// STS credentials
-constexpr char kSTSSubjectTokenPath[] = "/var/run/secrets/tokens/istio-token";
-constexpr char kSTSSubjectTokenType[] = "urn:ietf:params:oauth:token-type:jwt";
-constexpr char kSTSScope[] = "https://www.googleapis.com/auth/cloud-platform";
 
 }  // namespace Common
 }  // namespace Stackdriver

--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -85,7 +85,6 @@ constexpr char kSTSPortKey[] = "STS_PORT";
 constexpr char kSTSSubjectTokenPath[] = "/var/run/secrets/tokens/istio-token";
 constexpr char kSTSSubjectTokenType[] = "urn:ietf:params:oauth:token-type:jwt";
 constexpr char kSTSScope[] = "https://www.googleapis.com/auth/cloud-platform";
-constexpr char kGoogleUserProjectHeaderKey[] = "x-goog-user-project";
 
 }  // namespace Common
 }  // namespace Stackdriver

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -16,7 +16,6 @@
 #include "extensions/stackdriver/common/utils.h"
 
 #include "extensions/stackdriver/common/constants.h"
-#include "grpcpp/grpcpp.h"
 
 namespace Extensions {
 namespace Stackdriver {
@@ -62,33 +61,6 @@ void getMonitoredResource(const std::string &monitored_resource_type,
           kIstioProxyContainerName;
     }
   }
-}
-
-void setSTSCallCredentialOptions(
-    ::envoy::api::v2::core::GrpcService_GoogleGrpc_CallCredentials_StsService
-        *sts_service,
-    const std::string &sts_port) {
-  if (!sts_service) {
-    return;
-  }
-  sts_service->set_token_exchange_service_uri("http://localhost:" + sts_port +
-                                              "/token");
-  sts_service->set_subject_token_path(kSTSSubjectTokenPath);
-  sts_service->set_subject_token_type(kSTSSubjectTokenType);
-  sts_service->set_scope(kSTSScope);
-}
-
-void setSTSCallCredentialOptions(
-    ::grpc::experimental::StsCredentialsOptions *sts_options,
-    const std::string &sts_port) {
-  if (!sts_options) {
-    return;
-  }
-  sts_options->token_exchange_service_uri =
-      "http://localhost:" + sts_port + "/token";
-  sts_options->subject_token_path = kSTSSubjectTokenPath;
-  sts_options->subject_token_type = kSTSSubjectTokenType;
-  sts_options->scope = kSTSScope;
 }
 
 }  // namespace Common

--- a/extensions/stackdriver/common/utils.h
+++ b/extensions/stackdriver/common/utils.h
@@ -13,10 +13,8 @@
  * limitations under the License.
  */
 
-#include "envoy/api/v2/core/grpc_service.pb.h"
 #include "extensions/common/context.h"
 #include "google/api/monitored_resource.pb.h"
-#include "grpcpp/grpcpp.h"
 
 namespace Extensions {
 namespace Stackdriver {
@@ -28,15 +26,6 @@ namespace Common {
 void getMonitoredResource(const std::string &monitored_resource_type,
                           const ::wasm::common::NodeInfo &local_node_info,
                           google::api::MonitoredResource *monitored_resource);
-
-// Set secure exchange service gRPC call credential.
-void setSTSCallCredentialOptions(
-    ::envoy::api::v2::core::GrpcService_GoogleGrpc_CallCredentials_StsService
-        *sts_service,
-    const std::string &sts_port);
-void setSTSCallCredentialOptions(
-    ::grpc::experimental::StsCredentialsOptions *sts_options,
-    const std::string &sts_port);
 
 }  // namespace Common
 }  // namespace Stackdriver

--- a/extensions/stackdriver/edges/BUILD
+++ b/extensions/stackdriver/edges/BUILD
@@ -63,7 +63,6 @@ envoy_cc_library(
     deps = [
         ":edges_cc_proto",
         "//extensions/common:context",
-        "//extensions/stackdriver/common:utils",
         "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
     ],
 )

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -16,7 +16,6 @@
 
 #include "extensions/stackdriver/edges/mesh_edges_service_client.h"
 
-#include "extensions/stackdriver/common/utils.h"
 #include "google/protobuf/util/time_util.h"
 
 #ifdef NULL_PLUGIN
@@ -50,8 +49,7 @@ using google::cloud::meshtelemetry::v1alpha1::ReportTrafficAssertionsRequest;
 using google::protobuf::util::TimeUtil;
 
 MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
-    RootContext* root_context, const std::string& edges_endpoint,
-    const std::string& sts_port)
+    RootContext* root_context, std::string edges_endpoint)
     : context_(root_context) {
   success_callback_ = [](google::protobuf::Empty&&) {
     // TODO(douglas-reid): improve logging message.
@@ -71,18 +69,9 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
   if (edges_endpoint.empty()) {
     // use application default creds and default target
     grpc_service.mutable_google_grpc()->set_target_uri(kMeshTelemetryService);
-    if (sts_port.empty()) {
-      // Security token exchange is not enabled. Use default GCE credential.
-      grpc_service.mutable_google_grpc()
-          ->add_call_credentials()
-          ->mutable_google_compute_engine();
-    } else {
-      ::Extensions::Stackdriver::Common::setSTSCallCredentialOptions(
-          grpc_service.mutable_google_grpc()
-              ->add_call_credentials()
-              ->mutable_sts_service(),
-          sts_port);
-    }
+    grpc_service.mutable_google_grpc()
+        ->add_call_credentials()
+        ->mutable_google_compute_engine();
     grpc_service.mutable_google_grpc()
         ->mutable_channel_credentials()
         ->mutable_ssl_credentials()

--- a/extensions/stackdriver/edges/mesh_edges_service_client.h
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.h
@@ -57,8 +57,7 @@ class MeshEdgesServiceClientImpl : public MeshEdgesServiceClient {
   // edges_endpoint is an optional param used to specify alternative service
   // address.
   MeshEdgesServiceClientImpl(RootContext* root_context,
-                             const std::string& edges_endpoint,
-                             const std::string& sts_port = "");
+                             std::string edges_endpoint);
 
   void reportTrafficAssertions(
       const ReportTrafficAssertionsRequest& request) const override;

--- a/extensions/stackdriver/edges/mesh_edges_service_client.h
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.h
@@ -58,7 +58,6 @@ class MeshEdgesServiceClientImpl : public MeshEdgesServiceClient {
   // address.
   MeshEdgesServiceClientImpl(RootContext* root_context,
                              const std::string& edges_endpoint,
-                             const std::string& project_id,
                              const std::string& sts_port = "");
 
   void reportTrafficAssertions(
@@ -71,7 +70,9 @@ class MeshEdgesServiceClientImpl : public MeshEdgesServiceClient {
   // edges service endpoint.
   std::string grpc_service_;
 
-  std::string project_id_;
+  // callbacks for the client
+  std::function<void(google::protobuf::Empty&&)> success_callback_;
+  std::function<void(GrpcStatus, StringView)> failure_callback_;
 };
 
 }  // namespace Edges

--- a/extensions/stackdriver/log/BUILD
+++ b/extensions/stackdriver/log/BUILD
@@ -56,7 +56,6 @@ envoy_cc_library(
         "//extensions/stackdriver:__pkg__",
     ],
     deps = [
-        "//extensions/stackdriver/common:utils",
         "@com_google_googleapis//google/logging/v2:logging_cc_proto",
         "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
     ],

--- a/extensions/stackdriver/log/exporter.cc
+++ b/extensions/stackdriver/log/exporter.cc
@@ -43,64 +43,28 @@ namespace Extensions {
 namespace Stackdriver {
 namespace Log {
 
-namespace {
-
-// StackdriverLoggingHandler is used to inject x-goog-user-project header into
-// gRPC initial metadata. This is a work around since gRPC library is not yet
-// able to add that header automatically based on quota project from STS token.
-// This should not be needed after https://github.com/grpc/grpc/issues/21225 is
-// ready.
-class StackdriverLoggingHandler
-    : public GrpcCallHandler<google::logging::v2::WriteLogEntriesResponse> {
- public:
-  StackdriverLoggingHandler(uint32_t success_counter, uint32_t failure_counter,
-                            const std::string& project_id)
-      : GrpcCallHandler(),
-        success_counter_(success_counter),
-        failure_counter_(failure_counter),
-        project_id_(project_id) {}
-
-  void onCreateInitialMetadata() override {
-    addHeaderMapValue(
-        HeaderMapType::GrpcCreateInitialMetadata,
-        ::Extensions::Stackdriver::Common::kGoogleUserProjectHeaderKey,
-        project_id_);
-  }
-
-  void onSuccess(google::logging::v2::WriteLogEntriesResponse&&) override {
-    // TODO(bianpengyuan): replace this with envoy's generic gRPC counter.
-    incrementMetric(success_counter_, 1);
-    logDebug("successfully sent Stackdriver logging request");
-  }
-
-  void onFailure(GrpcStatus status,
-                 std::unique_ptr<WasmData> message) override {
-    // TODO(bianpengyuan): add retry.
-    // TODO(bianpengyuan): replace this with envoy's generic gRPC counter.
-    incrementMetric(failure_counter_, 1);
-    logWarn("Stackdriver logging api call error: " +
-            std::to_string(static_cast<int>(status)) + message->toString());
-  }
-
- private:
-  uint32_t success_counter_;
-  uint32_t failure_counter_;
-  const std::string& project_id_;
-};
-
-}  // namespace
-
 ExporterImpl::ExporterImpl(RootContext* root_context,
                            const std::string& logging_service_endpoint,
-                           const std::string& project_id,
                            const std::string& sts_port) {
   context_ = root_context;
   Metric export_call(MetricType::Counter, "stackdriver_filter",
                      {MetricTag{"type", MetricTag::TagType::String},
                       MetricTag{"success", MetricTag::TagType::Bool}});
-  success_counter_ = export_call.resolve("logging", true);
-  failure_counter_ = export_call.resolve("logging", false);
-  project_id_ = project_id;
+  auto success_counter = export_call.resolve("logging", true);
+  auto failure_counter = export_call.resolve("logging", false);
+  success_callback_ = [success_counter](google::protobuf::Empty&&) {
+    // TODO(bianpengyuan): replace this with envoy's generic gRPC counter.
+    incrementMetric(success_counter, 1);
+    logDebug("successfully sent Stackdriver logging request");
+  };
+
+  failure_callback_ = [failure_counter](GrpcStatus status, StringView message) {
+    // TODO(bianpengyuan): add retry.
+    // TODO(bianpengyuan): replace this with envoy's generic gRPC counter.
+    incrementMetric(failure_counter, 1);
+    logWarn("Stackdriver logging api call error: " +
+            std::to_string(static_cast<int>(status)) + std::string(message));
+  };
 
   // Construct grpc_service for the Stackdriver gRPC call.
   GrpcService grpc_service;
@@ -139,11 +103,10 @@ void ExporterImpl::exportLogs(
         std::unique_ptr<const google::logging::v2::WriteLogEntriesRequest>>&
         requests) const {
   for (const auto& req : requests) {
-    auto handler = std::make_unique<StackdriverLoggingHandler>(
-        success_counter_, failure_counter_, project_id_);
-    context_->grpcCallHandler(grpc_service_string_, kGoogleLoggingService,
-                              kGoogleWriteLogEntriesMethod, *req,
-                              kDefaultTimeoutMillisecond, std::move(handler));
+    context_->grpcSimpleCall(grpc_service_string_, kGoogleLoggingService,
+                             kGoogleWriteLogEntriesMethod, *req,
+                             kDefaultTimeoutMillisecond, success_callback_,
+                             failure_callback_);
   }
 }
 

--- a/extensions/stackdriver/log/exporter.h
+++ b/extensions/stackdriver/log/exporter.h
@@ -57,7 +57,7 @@ class ExporterImpl : public Exporter {
   // only.
   ExporterImpl(RootContext* root_context,
                const std::string& logging_service_endpoint,
-               const std::string& project_id, const std::string& sts_port = "");
+               const std::string& sts_port = "");
 
   // exportLogs exports the given log request to Stackdriver.
   void exportLogs(
@@ -75,12 +75,6 @@ class ExporterImpl : public Exporter {
   // Callbacks for gRPC calls.
   std::function<void(google::protobuf::Empty&&)> success_callback_;
   std::function<void(GrpcStatus, StringView)> failure_callback_;
-
-  // Stats to count successful and failed logging gRPC call.
-  uint32_t success_counter_;
-  uint32_t failure_counter_;
-
-  std::string project_id_;
 };
 
 }  // namespace Log

--- a/extensions/stackdriver/log/exporter.h
+++ b/extensions/stackdriver/log/exporter.h
@@ -56,8 +56,7 @@ class ExporterImpl : public Exporter {
   // logging_service_endpoint is an optional param which should be used for test
   // only.
   ExporterImpl(RootContext* root_context,
-               const std::string& logging_service_endpoint,
-               const std::string& sts_port = "");
+               const std::string& logging_service_endpoint);
 
   // exportLogs exports the given log request to Stackdriver.
   void exportLogs(

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -28,7 +28,7 @@ namespace Metric {
 void record(bool is_outbound, const ::wasm::common::NodeInfo &local_node_info,
             const ::wasm::common::NodeInfo &peer_node_info,
             const ::Wasm::Common::RequestInfo &request_info) {
-  double latency_ms = request_info.duration / absl::Milliseconds(1);
+  double latency_ms = request_info.duration / absl::Nanoseconds(1) / 1000.0;
   const auto &operation =
       request_info.request_protocol == ::Wasm::Common::kProtocolGRPC
           ? request_info.request_url_path

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -29,12 +29,10 @@ using namespace opencensus::exporters::stats;
 using namespace opencensus::stats;
 using wasm::common::NodeInfo;
 
-constexpr char kStackdriverStatsAddress[] = "monitoring.googleapis.com";
-
 // Gets opencensus stackdriver exporter options.
 StackdriverOptions getStackdriverOptions(
     const NodeInfo &local_node_info,
-    const std::string &test_monitoring_endpoint, const std::string &sts_port) {
+    const std::string &test_monitoring_endpoint) {
   StackdriverOptions options;
   auto platform_metadata = local_node_info.platform_metadata();
   options.project_id = platform_metadata[kGCPProjectKey];
@@ -42,19 +40,6 @@ StackdriverOptions getStackdriverOptions(
   if (!test_monitoring_endpoint.empty()) {
     auto channel = grpc::CreateChannel(test_monitoring_endpoint,
                                        grpc::InsecureChannelCredentials());
-    options.metric_service_stub =
-        google::monitoring::v3::MetricService::NewStub(channel);
-  } else if (!sts_port.empty()) {
-    ::grpc::experimental::StsCredentialsOptions sts_options;
-    ::Extensions::Stackdriver::Common::setSTSCallCredentialOptions(&sts_options,
-                                                                   sts_port);
-    auto call_creds = grpc::experimental::StsCredentials(sts_options);
-    auto ssl_creds_options = grpc::SslCredentialsOptions();
-    ssl_creds_options.pem_root_certs = kDefaultRootCertFile;
-    auto channel_creds = grpc::SslCredentials(ssl_creds_options);
-    auto channel = ::grpc::CreateChannel(
-        kStackdriverStatsAddress,
-        grpc::CompositeChannelCredentials(channel_creds, call_creds));
     options.metric_service_stub =
         google::monitoring::v3::MetricService::NewStub(channel);
   }

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -15,9 +15,6 @@
 
 #include "extensions/stackdriver/metric/registry.h"
 
-#include <fstream>
-#include <sstream>
-
 #include "extensions/stackdriver/common/constants.h"
 #include "extensions/stackdriver/common/utils.h"
 #include "google/api/monitored_resource.pb.h"
@@ -26,47 +23,6 @@
 namespace Extensions {
 namespace Stackdriver {
 namespace Metric {
-
-namespace {
-
-class GoogleUserProjHeaderInterceptor : public grpc::experimental::Interceptor {
- public:
-  GoogleUserProjHeaderInterceptor(const std::string& project_id)
-      : project_id_(project_id) {}
-
-  virtual void Intercept(grpc::experimental::InterceptorBatchMethods* methods) {
-    if (methods->QueryInterceptionHookPoint(
-            grpc::experimental::InterceptionHookPoints::
-                PRE_SEND_INITIAL_METADATA)) {
-      auto* metadata_map = methods->GetSendInitialMetadata();
-      if (metadata_map != nullptr) {
-        metadata_map->insert(
-            std::make_pair("x-goog-user-project", project_id_));
-      }
-    }
-    methods->Proceed();
-  }
-
- private:
-  const std::string& project_id_;
-};
-
-class GoogleUserProjHeaderInterceptorFactory
-    : public grpc::experimental::ClientInterceptorFactoryInterface {
- public:
-  GoogleUserProjHeaderInterceptorFactory(const std::string& project_id)
-      : project_id_(project_id) {}
-
-  virtual grpc::experimental::Interceptor* CreateClientInterceptor(
-      grpc::experimental::ClientRpcInfo*) override {
-    return new GoogleUserProjHeaderInterceptor(project_id_);
-  }
-
- private:
-  std::string project_id_;
-};
-
-}  // namespace
 
 using namespace Extensions::Stackdriver::Common;
 using namespace opencensus::exporters::stats;
@@ -77,8 +33,8 @@ constexpr char kStackdriverStatsAddress[] = "monitoring.googleapis.com";
 
 // Gets opencensus stackdriver exporter options.
 StackdriverOptions getStackdriverOptions(
-    const NodeInfo& local_node_info,
-    const std::string& test_monitoring_endpoint, const std::string& sts_port) {
+    const NodeInfo &local_node_info,
+    const std::string &test_monitoring_endpoint, const std::string &sts_port) {
   StackdriverOptions options;
   auto platform_metadata = local_node_info.platform_metadata();
   options.project_id = platform_metadata[kGCPProjectKey];
@@ -94,25 +50,11 @@ StackdriverOptions getStackdriverOptions(
                                                                    sts_port);
     auto call_creds = grpc::experimental::StsCredentials(sts_options);
     auto ssl_creds_options = grpc::SslCredentialsOptions();
-    std::ifstream file(kDefaultRootCertFile);
-    if (!file.fail()) {
-      std::stringstream file_string;
-      file_string << file.rdbuf();
-      ssl_creds_options.pem_root_certs = file_string.str();
-    }
+    ssl_creds_options.pem_root_certs = kDefaultRootCertFile;
     auto channel_creds = grpc::SslCredentials(ssl_creds_options);
-    grpc::ChannelArguments args;
-    std::vector<
-        std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
-        creators;
-    auto header_factory =
-        std::make_unique<GoogleUserProjHeaderInterceptorFactory>(
-            options.project_id);
-    creators.push_back(std::move(header_factory));
-    auto channel = ::grpc::experimental::CreateCustomChannelWithInterceptors(
+    auto channel = ::grpc::CreateChannel(
         kStackdriverStatsAddress,
-        grpc::CompositeChannelCredentials(channel_creds, call_creds), args,
-        std::move(creators));
+        grpc::CompositeChannelCredentials(channel_creds, call_creds));
     options.metric_service_stub =
         google::monitoring::v3::MetricService::NewStub(channel);
   }

--- a/extensions/stackdriver/metric/registry.h
+++ b/extensions/stackdriver/metric/registry.h
@@ -34,8 +34,7 @@ namespace Metric {
 // Returns Stackdriver exporter config option based on node metadata.
 opencensus::exporters::stats::StackdriverOptions getStackdriverOptions(
     const wasm::common::NodeInfo& local_node_info,
-    const std::string& test_monitoring_endpoint = "",
-    const std::string& sts_port = "");
+    const std::string& test_monitoring_endpoint = "");
 
 // registers Opencensus views
 void registerViews();

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -115,7 +115,7 @@ int getExportInterval() {
 // provided or "0" is provided, emtpy will be returned.
 std::string getSTSPort() {
   std::string sts_port;
-  if (getStringValue({"node", "metadata", kSTSPortKey}, &sts_port) &&
+  if (getValue({"node", "metadata", kSTSPortKey}, &sts_port) &&
       sts_port != "0") {
     return sts_port;
   }
@@ -146,17 +146,11 @@ bool StackdriverRootContext::onConfigure(
   direction_ = ::Wasm::Common::getTrafficDirection();
   use_host_header_fallback_ = !config_.disable_host_header_fallback();
   std::string sts_port = getSTSPort();
-  std::string project_id;
-  const auto& platform_metadata = local_node_info_.platform_metadata();
-  const auto project_iter = platform_metadata.find(kGCPProjectKey);
-  if (project_iter != platform_metadata.end()) {
-    project_id = project_iter->second;
-  }
   if (!logger_) {
     // logger should only be initiated once, for now there is no reason to
     // recreate logger because of config update.
-    auto exporter = std::make_unique<ExporterImpl>(this, getLoggingEndpoint(),
-                                                   project_id, sts_port);
+    auto exporter =
+        std::make_unique<ExporterImpl>(this, getLoggingEndpoint(), sts_port);
     // logger takes ownership of exporter.
     logger_ = std::make_unique<Logger>(local_node_info_, std::move(exporter));
   }
@@ -166,6 +160,7 @@ bool StackdriverRootContext::onConfigure(
     // to recreate edge reporter because of config update.
     auto edges_client = std::make_unique<MeshEdgesServiceClientImpl>(
         this, getMeshTelemetryEndpoint(), project_id, sts_port);
+
     if (config_.max_edges_batch_size() > 0 &&
         config_.max_edges_batch_size() <= 1000) {
       edge_reporter_ = std::make_unique<EdgeReporter>(

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -111,17 +111,6 @@ int getExportInterval() {
   return 60;
 }
 
-// Get port of security token exchange server from node metadata, if not
-// provided or "0" is provided, emtpy will be returned.
-std::string getSTSPort() {
-  std::string sts_port;
-  if (getValue({"node", "metadata", kSTSPortKey}, &sts_port) &&
-      sts_port != "0") {
-    return sts_port;
-  }
-  return "";
-}
-
 }  // namespace
 
 bool StackdriverRootContext::onConfigure(
@@ -145,12 +134,11 @@ bool StackdriverRootContext::onConfigure(
 
   direction_ = ::Wasm::Common::getTrafficDirection();
   use_host_header_fallback_ = !config_.disable_host_header_fallback();
-  std::string sts_port = getSTSPort();
+
   if (!logger_) {
     // logger should only be initiated once, for now there is no reason to
     // recreate logger because of config update.
-    auto exporter =
-        std::make_unique<ExporterImpl>(this, getLoggingEndpoint(), sts_port);
+    auto exporter = std::make_unique<ExporterImpl>(this, getLoggingEndpoint());
     // logger takes ownership of exporter.
     logger_ = std::make_unique<Logger>(local_node_info_, std::move(exporter));
   }
@@ -199,8 +187,7 @@ bool StackdriverRootContext::onConfigure(
 
   setSharedData(kStackdriverExporter, kExporterRegistered);
   opencensus::exporters::stats::StackdriverExporter::Register(
-      getStackdriverOptions(local_node_info_, getMonitoringEndpoint(),
-                            sts_port));
+      getStackdriverOptions(local_node_info_, getMonitoringEndpoint()));
   opencensus::stats::StatsExporter::SetInterval(
       absl::Seconds(getExportInterval()));
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-cloud.google.com/go v0.26.0 h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -7,18 +6,13 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
-github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263 h1:Ot817IZ8L+/ZlkfVJ0ZnngYA6GnmcvcxR7lrIz/iZDc=
 github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/envoyproxy/go-control-plane v0.9.0 h1:67WMNTvGrl7V1dWdKCeTwxDr7nio9clKoTlLhwIPnT4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -26,7 +20,6 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -74,7 +67,6 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -85,9 +77,7 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -96,17 +86,13 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
-google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/test/envoye2e/driver/stackdriver.go
+++ b/test/envoye2e/driver/stackdriver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	logging "google.golang.org/genproto/googleapis/logging/v2"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
-
 	fs "istio.io/proxy/test/envoye2e/stackdriver_plugin/fake_stackdriver"
 )
 

--- a/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_plugin_test.go
@@ -76,8 +76,6 @@ const inboundStackdriverFilter = `- name: envoy.filters.http.wasm
           "meshEdgesReportingDuration": "1s"
         }`
 
-const ResponseLatencyMetricName = "istio.io/service/server/response_latencies"
-
 func compareTimeSeries(got, want *monitoringpb.TimeSeries) error {
 	// ignore time difference
 	got.Points[0].Interval = nil
@@ -125,37 +123,6 @@ func verifyCreateTimeSeriesReq(got *monitoringpb.CreateTimeSeriesRequest) (error
 	}
 	// at least one time series should match either client side request count or server side request count.
 	return fmt.Errorf("cannot find expected request count from creat time series request %v", got), isClient
-}
-
-// Check that response latency is within a reasonable range (less than 256 milliseconds).
-func verifyResponseLatency(got *monitoringpb.CreateTimeSeriesRequest) (bool, error) {
-	for _, t := range got.TimeSeries {
-		if t.Metric.Type != ResponseLatencyMetricName {
-			continue
-		}
-		p := t.Points[0]
-		d := p.Value.GetDistributionValue()
-		bo := d.GetBucketOptions()
-		if bo == nil {
-			return true, fmt.Errorf("expect response latency metrics bucket option not to be empty: %v", got)
-		}
-		eb := bo.GetExplicitBuckets()
-		if eb == nil {
-			return true, fmt.Errorf("explicit response latency metrics buckets should not be empty: %v", got)
-		}
-		bounds := eb.GetBounds()
-		maxLatencyInMilli := 0.0
-		for i, b := range d.GetBucketCounts() {
-			if b != 0 {
-				maxLatencyInMilli = bounds[i]
-			}
-		}
-		if maxLatencyInMilli > 256 {
-			return true, fmt.Errorf("latency metric is too large (>256ms) %v", maxLatencyInMilli)
-		}
-		return true, nil
-	}
-	return false, nil
 }
 
 func verifyWriteLogEntriesReq(got *logging.WriteLogEntriesRequest) error {
@@ -231,13 +198,12 @@ func TestStackdriverPlugin(t *testing.T) {
 	}
 	srvMetricRcv := false
 	cltMetricRcv := false
-	latencyMetricRcv := false
 	logRcv := false
 	edgeRcv := false
 
 	to := time.NewTimer(20 * time.Second)
 
-	for !(srvMetricRcv && cltMetricRcv && latencyMetricRcv && logRcv && edgeRcv) {
+	for !(srvMetricRcv && cltMetricRcv && logRcv && edgeRcv) {
 		select {
 		case req := <-fsdm.RcvMetricReq:
 			err, isClient := verifyCreateTimeSeriesReq(req)
@@ -248,13 +214,6 @@ func TestStackdriverPlugin(t *testing.T) {
 				cltMetricRcv = true
 			} else {
 				srvMetricRcv = true
-			}
-			if hasResponseLatency, err := verifyResponseLatency(req); hasResponseLatency {
-				if err != nil {
-					t.Errorf("Latency metric is not expected: %v", err)
-				} else {
-					latencyMetricRcv = true
-				}
 			}
 		case req := <-fsdl.RcvLoggingReq:
 			if err := verifyWriteLogEntriesReq(req); err != nil {


### PR DESCRIPTION
A variant of https://github.com/istio/proxy/pull/2769 that doesn't revert the WORKSPACE istio/envoy SHA.

So this would revert:

#2683  #2679

but keep:

#2721 #2719 #2694