### PR TITLE
Update Envoy SHA to latest and enable TLSv1.3 in sni_verifier. (#17)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,26 +37,19 @@ bind(
 # 1. Determine SHA256 `wget https://github.com/istio/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelrc and .bazelversion files.
 #
-# envoy commit date: 02/13/2020
-ENVOY_SHA = "3eb21010f9a72ab254742646f7e13385f21552d9"
+# envoy commit date: 02/20/2020
+ENVOY_SHA = "f8ee9ce9785b46425ce34c94a8e741d386acc3f2"
 
-ENVOY_SHA256 = "e7144c2dcb501f5dda217f42f012d42cd00c0e824a369016731ba6fb70af2720"
+ENVOY_SHA256 = "b7745d5324e646447614ca87f8081db7a8be5b52f8027c37fa179767a01cb303"
 
-LOCAL_ENVOY_PROJECT = "/PATH/TO/ENVOY"
-
+# To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
+# persist the option in `user.bazelrc`.
 http_archive(
     name = "envoy",
     sha256 = ENVOY_SHA256,
     strip_prefix = "envoy-" + ENVOY_SHA,
     url = "https://github.com/istio/envoy/archive/" + ENVOY_SHA + ".tar.gz",
 )
-
-# TODO(silentdai) Use bazel args to select envoy between local or http
-# Uncomment below and comment above http_archive to depends on local envoy.
-#local_repository(
-#     name = "envoy",
-#     path = LOCAL_ENVOY_PROJECT,
-#)
 
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")
 

--- a/src/envoy/tcp/sni_verifier/sni_verifier.cc
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.cc
@@ -30,6 +30,10 @@ namespace Envoy {
 namespace Tcp {
 namespace SniVerifier {
 
+// Min/max TLS version recognized by the underlying TLS/SSL library.
+const unsigned Config::TLS_MIN_SUPPORTED_VERSION = TLS1_VERSION;
+const unsigned Config::TLS_MAX_SUPPORTED_VERSION = TLS1_3_VERSION;
+
 Config::Config(Stats::Scope& scope, size_t max_client_hello_size)
     : stats_{SNI_VERIFIER_STATS(POOL_COUNTER_PREFIX(scope, "sni_verifier."))},
       ssl_ctx_(SSL_CTX_new(TLS_with_buffers_method())),
@@ -40,6 +44,8 @@ Config::Config(Stats::Scope& scope, size_t max_client_hello_size)
         max_client_hello_size_, size_t(TLS_MAX_CLIENT_HELLO)));
   }
 
+  SSL_CTX_set_min_proto_version(ssl_ctx_.get(), TLS_MIN_SUPPORTED_VERSION);
+  SSL_CTX_set_max_proto_version(ssl_ctx_.get(), TLS_MAX_SUPPORTED_VERSION);
   SSL_CTX_set_options(ssl_ctx_.get(), SSL_OP_NO_TICKET);
   SSL_CTX_set_session_cache_mode(ssl_ctx_.get(), SSL_SESS_CACHE_OFF);
   SSL_CTX_set_tlsext_servername_callback(

--- a/src/envoy/tcp/sni_verifier/sni_verifier.h
+++ b/src/envoy/tcp/sni_verifier/sni_verifier.h
@@ -55,6 +55,8 @@ class Config {
   size_t maxClientHelloSize() const { return max_client_hello_size_; }
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
+  static const unsigned TLS_MIN_SUPPORTED_VERSION;
+  static const unsigned TLS_MAX_SUPPORTED_VERSION;
 
  private:
   SniVerifierStats stats_;


### PR DESCRIPTION
Previously, SNI verifier didn't support TLSv1.3 and clients configured
to use only TLSv1.3 were not recognized as TLS clients.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
