### PR TITLE
Decide unhealthy connection on presence of no response flags

### DIFF
--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -44,8 +44,6 @@ namespace Plugin {
 namespace Stats {
 
 constexpr long long kDefaultTCPReportDurationMilliseconds = 15000;  // 15s
-// No healthy upstream.
-constexpr uint64_t kNoHealthyUpstream = 0x2;
 
 namespace {
 
@@ -468,13 +466,13 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
     // For TCP, if peer metadata is not available, peer id is set as not found.
     // Otherwise, we wait for metadata exchange to happen before we report  any
     // metric.
-    // We skip this wait  if upstream is unhealthy as we won't get peer metadata
-    // in that case.
+    // We keep waiting if response flags is zero, as that implies, there has
+    // been no error in connection.
     uint64_t response_flags = 0;
     getValue({"response", "flags"}, &response_flags);
     if (peer_node_ptr == nullptr &&
         peer_id != ::Wasm::Common::kMetadataNotFoundValue &&
-        !(response_flags & kNoHealthyUpstream)) {
+        response_flags == 0) {
       return false;
     }
     if (!request_info.is_populated) {


### PR DESCRIPTION
Decide unhealthy connection on presence of no response flags as compared to just unhealthyhost in stats filter for TCP V2 telemetry