### PR TITLE
Improve Wasm plugins stats

### DIFF
--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -61,6 +61,9 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "metrics",
+    srcs = [
+        "metrics.cc",
+    ],
     hdrs = [
         "metrics.h",
     ],
@@ -68,5 +71,8 @@ envoy_cc_library(
     visibility = [
         "//extensions/stackdriver/edges:__pkg__",
         "//extensions/stackdriver/log:__pkg__",
+    ],
+    deps = [
+        "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
     ],
 )

--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -58,3 +58,15 @@ envoy_cc_library(
         "@com_google_googleapis//google/monitoring/v3:monitoring_cc_proto",
     ],
 )
+
+envoy_cc_library(
+    name = "metrics",
+    hdrs = [
+        "metrics.h",
+    ],
+    repository = "@envoy",
+    visibility = [
+        "//extensions/stackdriver/edges:__pkg__",
+        "//extensions/stackdriver/log:__pkg__",
+    ],
+)

--- a/extensions/stackdriver/common/metrics.cc
+++ b/extensions/stackdriver/common/metrics.cc
@@ -1,0 +1,59 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/stackdriver/common/metrics.h"
+
+#ifdef NULL_PLUGIN
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace Wasm {
+namespace Null {
+namespace Plugin {
+
+#endif
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Common {
+
+// NOTE: every call to this function will alloc a new metric object. Though this
+// object is the same in all calls, it cannot be extracted out to a global variable.
+// The metric object caches all fully resolved metrics and won't make define
+// metrics abi call when the same resolved metrics are defined. In Null VM case,
+// since global objects are shared between root contexts in base VM and in thread
+// local VM, and the same metrics definition code path will excercised in both VMs (we don't really have a way to distinguish base VM and thread local VM), the cache will make thread local root context miss metric definition
+// at host side. In real Wasm VM, this can be extracted to a global var.
+uint32_t newExportCallMetric(const std::string& type, bool success) {
+  Metric export_call(MetricType::Counter, "stackdriver_export_call",
+                    {MetricTag{"wasm_filter", MetricTag::TagType::String},
+                      MetricTag{"type", MetricTag::TagType::String},
+                      MetricTag{"success", MetricTag::TagType::Bool}});
+
+  return export_call.resolve("stackdriver_filter", type, success);
+}
+
+}  // namespace Common
+}  // namespace Stackdriver
+}  // namespace Extensions
+
+#ifdef NULL_PLUGIN
+}  // namespace Plugin
+}  // namespace Null
+}  // namespace Wasm
+}  // namespace Common
+}  // namespace Extensions
+}  // namespace Envoy
+#endif

--- a/extensions/stackdriver/common/metrics.cc
+++ b/extensions/stackdriver/common/metrics.cc
@@ -30,15 +30,18 @@ namespace Stackdriver {
 namespace Common {
 
 // NOTE: every call to this function will alloc a new metric object. Though this
-// object is the same in all calls, it cannot be extracted out to a global variable.
-// The metric object caches all fully resolved metrics and won't make define
-// metrics abi call when the same resolved metrics are defined. In Null VM case,
-// since global objects are shared between root contexts in base VM and in thread
-// local VM, and the same metrics definition code path will excercised in both VMs (we don't really have a way to distinguish base VM and thread local VM), the cache will make thread local root context miss metric definition
-// at host side. In real Wasm VM, this can be extracted to a global var.
+// object is the same in all calls, it cannot be extracted out to a global
+// variable. The metric object caches all fully resolved metrics and won't make
+// define metrics abi call when the same resolved metrics are defined. In Null
+// VM case, since global objects are shared between root contexts in base VM and
+// in thread local VM, and the same metrics definition code path will excercised
+// in both VMs (we don't really have a way to distinguish base VM and thread
+// local VM), the cache will make thread local root context miss metric
+// definition at host side. In real Wasm VM, this can be extracted to a global
+// var.
 uint32_t newExportCallMetric(const std::string& type, bool success) {
   Metric export_call(MetricType::Counter, "stackdriver_export_call",
-                    {MetricTag{"wasm_filter", MetricTag::TagType::String},
+                     {MetricTag{"wasm_filter", MetricTag::TagType::String},
                       MetricTag{"type", MetricTag::TagType::String},
                       MetricTag{"success", MetricTag::TagType::Bool}});
 

--- a/extensions/stackdriver/common/metrics.cc
+++ b/extensions/stackdriver/common/metrics.cc
@@ -40,7 +40,7 @@ namespace Common {
 // definition at host side. In real Wasm VM, this can be extracted to a global
 // var.
 uint32_t newExportCallMetric(const std::string& type, bool success) {
-  Metric export_call(MetricType::Counter, "stackdriver_export_call",
+  Metric export_call(MetricType::Counter, "export_call",
                      {MetricTag{"wasm_filter", MetricTag::TagType::String},
                       MetricTag{"type", MetricTag::TagType::String},
                       MetricTag{"success", MetricTag::TagType::Bool}});

--- a/extensions/stackdriver/common/metrics.h
+++ b/extensions/stackdriver/common/metrics.h
@@ -33,16 +33,10 @@ namespace Extensions {
 namespace Stackdriver {
 namespace Common {
 
-// Tracks gRPC export call made by the plugin.
-static Metric export_call(MetricType::Counter, "export_call",
-                          {MetricTag{"wasm_filter", MetricTag::TagType::String},
-                           MetricTag{"type", MetricTag::TagType::String},
-                           MetricTag{"success", MetricTag::TagType::Bool}});
-
-// Partially resolve the export call metrics by setting wasm_filter tag as
-// stackdriver_filter.
-static Metric stackdriver_export_call =
-    export_call.partiallyResolve("stackdriver_filter");
+// newExportCallMetric create a fully resolved metric based on the given type
+// and a boolean which indicates whether the call succeeds or not. Current type
+// could only be logging or edge.
+uint32_t newExportCallMetric(const std::string& type, bool success);
 
 }  // namespace Common
 }  // namespace Stackdriver

--- a/extensions/stackdriver/common/metrics.h
+++ b/extensions/stackdriver/common/metrics.h
@@ -1,0 +1,58 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef NULL_PLUGIN
+#include "api/wasm/cpp/proxy_wasm_intrinsics.h"
+#else
+#include "extensions/common/wasm/null/null_plugin.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Common {
+namespace Wasm {
+namespace Null {
+namespace Plugin {
+
+#endif
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Common {
+
+// Tracks gRPC export call made by the plugin.
+static Metric export_call(MetricType::Counter, "export_call",
+                          {MetricTag{"wasm_filter", MetricTag::TagType::String},
+                           MetricTag{"type", MetricTag::TagType::String},
+                           MetricTag{"success", MetricTag::TagType::Bool}});
+
+// Partially resolve the export call metrics by setting wasm_filter tag as
+// stackdriver_filter.
+static Metric stackdriver_export_call =
+    export_call.partiallyResolve("stackdriver_filter");
+
+}  // namespace Common
+}  // namespace Stackdriver
+}  // namespace Extensions
+
+#ifdef NULL_PLUGIN
+}  // namespace Plugin
+}  // namespace Null
+}  // namespace Wasm
+}  // namespace Common
+}  // namespace Extensions
+}  // namespace Envoy
+#endif

--- a/extensions/stackdriver/edges/BUILD
+++ b/extensions/stackdriver/edges/BUILD
@@ -64,6 +64,7 @@ envoy_cc_library(
         ":edges_cc_proto",
         "//extensions/common:context",
         "//extensions/stackdriver/common:constants",
+        "//extensions/stackdriver/common:metrics",
         "//extensions/stackdriver/common:utils",
         "@envoy//source/extensions/common/wasm/null:null_plugin_lib",
     ],

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -51,8 +51,8 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
     RootContext* root_context,
     const ::Extensions::Stackdriver::Common::StackdriverStubOption& stub_option)
     : context_(root_context) {
-  auto success_counter = Common::stackdriver_export_call.resolve("edge", true);
-  auto failure_counter = Common::stackdriver_export_call.resolve("edge", false);
+  auto success_counter = Common::newExportCallMetric("edge", true);
+  auto failure_counter = Common::newExportCallMetric("edge", false);
   success_callback_ = [success_counter](size_t) {
     incrementMetric(success_counter, 1);
     // TODO(douglas-reid): improve logging message.

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -50,13 +50,21 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
     RootContext* root_context,
     const ::Extensions::Stackdriver::Common::StackdriverStubOption& stub_option)
     : context_(root_context) {
-  success_callback_ = [](size_t) {
+  Metric export_call(MetricType::Counter, "export_call",
+                     {MetricTag{"wasm_filter", MetricTag::TagType::String},
+                      MetricTag{"type", MetricTag::TagType::String},
+                      MetricTag{"success", MetricTag::TagType::Bool}});
+  auto success_counter = export_call.resolve("stackdriver_filter", "edge", true);
+  auto failure_counter = export_call.resolve("stackdriver_filter", "edge", false);
+  success_callback_ = [success_counter](size_t) {
+    incrementMetric(success_counter, 1);
     // TODO(douglas-reid): improve logging message.
     logDebug(
         "successfully sent MeshEdgesService ReportTrafficAssertionsRequest");
   };
 
-  failure_callback_ = [](GrpcStatus status) {
+  failure_callback_ = [failure_counter](GrpcStatus status) {
+    incrementMetric(failure_counter, 1);
     // TODO(douglas-reid): add retry (and other) logic
     logWarn("MeshEdgesService ReportTrafficAssertionsRequest failure: " +
             std::to_string(static_cast<int>(status)) + " " +

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -17,6 +17,7 @@
 #include "extensions/stackdriver/edges/mesh_edges_service_client.h"
 
 #include "extensions/stackdriver/common/constants.h"
+#include "extensions/stackdriver/common/metrics.h"
 #include "google/protobuf/util/time_util.h"
 
 #ifdef NULL_PLUGIN
@@ -50,14 +51,8 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
     RootContext* root_context,
     const ::Extensions::Stackdriver::Common::StackdriverStubOption& stub_option)
     : context_(root_context) {
-  Metric export_call(MetricType::Counter, "export_call",
-                     {MetricTag{"wasm_filter", MetricTag::TagType::String},
-                      MetricTag{"type", MetricTag::TagType::String},
-                      MetricTag{"success", MetricTag::TagType::Bool}});
-  auto success_counter =
-      export_call.resolve("stackdriver_filter", "edge", true);
-  auto failure_counter =
-      export_call.resolve("stackdriver_filter", "edge", false);
+  auto success_counter = Common::stackdriver_export_call.resolve("edge", true);
+  auto failure_counter = Common::stackdriver_export_call.resolve("edge", false);
   success_callback_ = [success_counter](size_t) {
     incrementMetric(success_counter, 1);
     // TODO(douglas-reid): improve logging message.

--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -54,8 +54,10 @@ MeshEdgesServiceClientImpl::MeshEdgesServiceClientImpl(
                      {MetricTag{"wasm_filter", MetricTag::TagType::String},
                       MetricTag{"type", MetricTag::TagType::String},
                       MetricTag{"success", MetricTag::TagType::Bool}});
-  auto success_counter = export_call.resolve("stackdriver_filter", "edge", true);
-  auto failure_counter = export_call.resolve("stackdriver_filter", "edge", false);
+  auto success_counter =
+      export_call.resolve("stackdriver_filter", "edge", true);
+  auto failure_counter =
+      export_call.resolve("stackdriver_filter", "edge", false);
   success_callback_ = [success_counter](size_t) {
     incrementMetric(success_counter, 1);
     // TODO(douglas-reid): improve logging message.

--- a/extensions/stackdriver/edges/mesh_edges_service_client.h
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "extensions/stackdriver/common/metrics.h"
 #include "extensions/stackdriver/common/utils.h"
 #include "extensions/stackdriver/edges/edges.pb.h"
 

--- a/extensions/stackdriver/log/BUILD
+++ b/extensions/stackdriver/log/BUILD
@@ -56,6 +56,7 @@ envoy_cc_library(
         "//extensions/stackdriver:__pkg__",
     ],
     deps = [
+        "//extensions/stackdriver/common:metrics",
         "//extensions/stackdriver/common:utils",
         "@com_google_googleapis//google/logging/v2:logging_cc_proto",
         "@envoy//source/extensions/common/wasm/null:null_plugin_lib",

--- a/extensions/stackdriver/log/exporter.cc
+++ b/extensions/stackdriver/log/exporter.cc
@@ -47,10 +47,8 @@ ExporterImpl::ExporterImpl(
     const ::Extensions::Stackdriver::Common::StackdriverStubOption&
         stub_option) {
   context_ = root_context;
-  auto success_counter =
-      Common::stackdriver_export_call.resolve("logging", true);
-  auto failure_counter =
-      Common::stackdriver_export_call.resolve("logging", false);
+  auto success_counter = Common::newExportCallMetric("logging", true);
+  auto failure_counter = Common::newExportCallMetric("logging", false);
   success_callback_ = [this, success_counter](size_t) {
     incrementMetric(success_counter, 1);
     logDebug("successfully sent Stackdriver logging request");

--- a/extensions/stackdriver/log/exporter.cc
+++ b/extensions/stackdriver/log/exporter.cc
@@ -50,8 +50,10 @@ ExporterImpl::ExporterImpl(
                      {MetricTag{"wasm_filter", MetricTag::TagType::String},
                       MetricTag{"type", MetricTag::TagType::String},
                       MetricTag{"success", MetricTag::TagType::Bool}});
-  auto success_counter = export_call.resolve("stackdriver_filter", "logging", true);
-  auto failure_counter = export_call.resolve("stackdriver_filter", "logging", false);
+  auto success_counter =
+      export_call.resolve("stackdriver_filter", "logging", true);
+  auto failure_counter =
+      export_call.resolve("stackdriver_filter", "logging", false);
   success_callback_ = [this, success_counter](size_t) {
     incrementMetric(success_counter, 1);
     logDebug("successfully sent Stackdriver logging request");

--- a/extensions/stackdriver/log/exporter.cc
+++ b/extensions/stackdriver/log/exporter.cc
@@ -16,6 +16,7 @@
 #include "extensions/stackdriver/log/exporter.h"
 
 #include "extensions/stackdriver/common/constants.h"
+#include "extensions/stackdriver/common/metrics.h"
 
 #ifdef NULL_PLUGIN
 namespace Envoy {
@@ -46,14 +47,10 @@ ExporterImpl::ExporterImpl(
     const ::Extensions::Stackdriver::Common::StackdriverStubOption&
         stub_option) {
   context_ = root_context;
-  Metric export_call(MetricType::Counter, "export_call",
-                     {MetricTag{"wasm_filter", MetricTag::TagType::String},
-                      MetricTag{"type", MetricTag::TagType::String},
-                      MetricTag{"success", MetricTag::TagType::Bool}});
   auto success_counter =
-      export_call.resolve("stackdriver_filter", "logging", true);
+      Common::stackdriver_export_call.resolve("logging", true);
   auto failure_counter =
-      export_call.resolve("stackdriver_filter", "logging", false);
+      Common::stackdriver_export_call.resolve("logging", false);
   success_callback_ = [this, success_counter](size_t) {
     incrementMetric(success_counter, 1);
     logDebug("successfully sent Stackdriver logging request");

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -181,7 +181,7 @@ bool StackdriverRootContext::onConfigure(size_t) {
     stub_option.project_id = project_iter->second;
   }
 
-  if (!logger_) {
+  if (!logger_ && enableServerAccessLog()) {
     // logger should only be initiated once, for now there is no reason to
     // recreate logger because of config update.
     auto logging_stub_option = stub_option;
@@ -191,7 +191,7 @@ bool StackdriverRootContext::onConfigure(size_t) {
     logger_ = std::make_unique<Logger>(local_node_info_, std::move(exporter));
   }
 
-  if (!edge_reporter_) {
+  if (!edge_reporter_ && enableEdgeReporting()) {
     // edge reporter should only be initiated once, for now there is no reason
     // to recreate edge reporter because of config update.
     auto edge_stub_option = stub_option;

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -226,7 +226,7 @@ class PluginRootContext : public RootContext {
  public:
   PluginRootContext(uint32_t id, StringView root_id)
       : RootContext(id, root_id) {
-    Metric cache_count(MetricType::Counter, "node_info_cache_count",
+    Metric cache_count(MetricType::Counter, "metric_cache_count",
                        {MetricTag{"wasm_filter", MetricTag::TagType::String},
                         MetricTag{"cache", MetricTag::TagType::String}});
     cache_hits_ = cache_count.resolve("stats_filter", "hit");

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -226,10 +226,11 @@ class PluginRootContext : public RootContext {
  public:
   PluginRootContext(uint32_t id, StringView root_id)
       : RootContext(id, root_id) {
-    Metric cache_count(MetricType::Counter, "statsfilter",
-                       {MetricTag{"cache", MetricTag::TagType::String}});
-    cache_hits_ = cache_count.resolve("hit");
-    cache_misses_ = cache_count.resolve("miss");
+    Metric cache_count(MetricType::Counter, "node_info_cache_count",
+                      {MetricTag{"wasm_filter", MetricTag::TagType::String},
+                       MetricTag{"cache", MetricTag::TagType::Bool}});
+    cache_hits_ = cache_count.resolve("stats_filter", "hit");
+    cache_misses_ = cache_count.resolve("stats_filter", "miss");
   }
 
   ~PluginRootContext() = default;

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -227,8 +227,8 @@ class PluginRootContext : public RootContext {
   PluginRootContext(uint32_t id, StringView root_id)
       : RootContext(id, root_id) {
     Metric cache_count(MetricType::Counter, "node_info_cache_count",
-                      {MetricTag{"wasm_filter", MetricTag::TagType::String},
-                       MetricTag{"cache", MetricTag::TagType::Bool}});
+                       {MetricTag{"wasm_filter", MetricTag::TagType::String},
+                        MetricTag{"cache", MetricTag::TagType::Bool}});
     cache_hits_ = cache_count.resolve("stats_filter", "hit");
     cache_misses_ = cache_count.resolve("stats_filter", "miss");
   }

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -228,7 +228,7 @@ class PluginRootContext : public RootContext {
       : RootContext(id, root_id) {
     Metric cache_count(MetricType::Counter, "node_info_cache_count",
                        {MetricTag{"wasm_filter", MetricTag::TagType::String},
-                        MetricTag{"cache", MetricTag::TagType::Bool}});
+                        MetricTag{"cache", MetricTag::TagType::String}});
     cache_hits_ = cache_count.resolve("stats_filter", "hit");
     cache_misses_ = cache_count.resolve("stats_filter", "miss");
   }

--- a/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
@@ -195,6 +195,7 @@ func TestStackdriverPayloadGateway(t *testing.T) {
 			"RequestPath":           "echo",
 			"StackdriverRootCAFile": driver.TestPath("testdata/certs/stackdriver.pem"),
 			"StackdriverTokenFile":  driver.TestPath("testdata/certs/access-token"),
+			"StatsConfig":           driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 		},
 		XDS: int(ports.XDSPort),
 	}
@@ -217,6 +218,9 @@ func TestStackdriverPayloadGateway(t *testing.T) {
 				nil,
 				[]string{"testdata/stackdriver/gateway_access_log.yaml.tmpl"},
 			),
+			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
+				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+			}},
 		},
 	}).Run(params); err != nil {
 		t.Fatal(err)
@@ -264,6 +268,9 @@ func TestStackdriverPayloadWithTLS(t *testing.T) {
 				[]string{"testdata/stackdriver/client_request_count.yaml.tmpl", "testdata/stackdriver/server_request_count.yaml.tmpl"},
 				[]string{"testdata/stackdriver/server_access_log.yaml.tmpl"},
 			),
+			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
+				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+			}},
 		},
 	}).Run(params); err != nil {
 		t.Fatal(err)
@@ -312,6 +319,9 @@ func TestStackdriverReload(t *testing.T) {
 				[]string{"testdata/stackdriver/client_request_count.yaml.tmpl", "testdata/stackdriver/server_request_count.yaml.tmpl"},
 				[]string{"testdata/stackdriver/server_access_log.yaml.tmpl"},
 			),
+			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
+				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+			}},
 		},
 	}).Run(params); err != nil {
 		t.Fatal(err)

--- a/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
@@ -152,6 +152,7 @@ func TestStackdriverPayload(t *testing.T) {
 			"ServiceAuthenticationPolicy": "NONE",
 			"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 			"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
+			"StatsConfig":                 driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 		},
 		XDS: int(ports.XDSPort),
 	}
@@ -175,6 +176,9 @@ func TestStackdriverPayload(t *testing.T) {
 				[]string{"testdata/stackdriver/client_request_count.yaml.tmpl", "testdata/stackdriver/server_request_count.yaml.tmpl"},
 				[]string{"testdata/stackdriver/server_access_log.yaml.tmpl"},
 			),
+			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
+				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+			}},
 		},
 	}).Run(params); err != nil {
 		t.Fatal(err)
@@ -243,6 +247,7 @@ func TestStackdriverPayloadWithTLS(t *testing.T) {
 			"DestinationPrincipal":        "spiffe://cluster.local/ns/default/sa/server",
 			"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 			"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
+			"StatsConfig":                 driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 		},
 		XDS: int(ports.XDSPort),
 	}
@@ -319,9 +324,6 @@ func TestStackdriverReload(t *testing.T) {
 				[]string{"testdata/stackdriver/client_request_count.yaml.tmpl", "testdata/stackdriver/server_request_count.yaml.tmpl"},
 				[]string{"testdata/stackdriver/server_access_log.yaml.tmpl"},
 			),
-			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
-				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
-			}},
 		},
 	}).Run(params); err != nil {
 		t.Fatal(err)

--- a/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_xds_test.go
@@ -177,7 +177,7 @@ func TestStackdriverPayload(t *testing.T) {
 				[]string{"testdata/stackdriver/server_access_log.yaml.tmpl"},
 			),
 			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
-				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+				"envoy_type_logging_success_true_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
 			}},
 		},
 	}).Run(params); err != nil {
@@ -223,7 +223,7 @@ func TestStackdriverPayloadGateway(t *testing.T) {
 				[]string{"testdata/stackdriver/gateway_access_log.yaml.tmpl"},
 			),
 			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
-				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+				"envoy_type_logging_success_true_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
 			}},
 		},
 	}).Run(params); err != nil {
@@ -274,7 +274,7 @@ func TestStackdriverPayloadWithTLS(t *testing.T) {
 				[]string{"testdata/stackdriver/server_access_log.yaml.tmpl"},
 			),
 			&driver.Stats{ports.ServerAdminPort, map[string]driver.StatMatcher{
-				"envoy_type_logging_success_true_stackdriver_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+				"envoy_type_logging_success_true_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
 			}},
 		},
 	}).Run(params); err != nil {

--- a/testdata/bootstrap/stats.yaml.tmpl
+++ b/testdata/bootstrap/stats.yaml.tmpl
@@ -63,3 +63,5 @@ stats_config:
     regex: "(component\\.(.*?)\\.)"
   - tag_name: "tag"
     regex: "(tag\\.(.*?);\\.)"
+  - tag_name: "wasm_filter"
+    regex: "(wasm_filter\\.(.*?)\\.)"

--- a/testdata/metric/stackdriver_callout_metric.yaml.tmpl
+++ b/testdata/metric/stackdriver_callout_metric.yaml.tmpl
@@ -1,0 +1,8 @@
+name: envoy_type_logging_success_true_stackdriver_export_call
+type: COUNTER
+metric:
+- counter:
+    value: 1
+  label:
+  - name: wasm_filter
+    value: stackdriver_filter

--- a/testdata/metric/stackdriver_callout_metric.yaml.tmpl
+++ b/testdata/metric/stackdriver_callout_metric.yaml.tmpl
@@ -1,4 +1,4 @@
-name: envoy_type_logging_success_true_stackdriver_export_call
+name: envoy_type_logging_success_true_export_call
 type: COUNTER
 metric:
 - counter:


### PR DESCRIPTION
Several improvements to stats from Wasm plugins:
* Add stats for sd edge report call.
* Add back stats of sd plugin filter logging call out, which is removed by https://github.com/istio/proxy/pull/2780. I thought gRPC native stats is already available, but turns out it is actually not.
* Make `wasm_filter` the first tag for all stats.

After this PR merged, I will add `wasm` prefix to default stats match and add `wasm_filter` to tag match, so that stats in this PR and ones from upstream (wasm_vm, etc) could be exposed by default.