### PR TITLE
Add configurable monitoring endpoint

### DIFF
--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -74,6 +74,7 @@ constexpr char kInboundRootContextId[] = "stackdriver_inbound";
 constexpr char kSecureStackdriverEndpointKey[] = "SECURE_STACKDRIVER_ENDPOINT";
 constexpr char kInsecureStackdriverEndpointKey[] =
     "INSECURE_STACKDRIVER_ENDPOINT";
+constexpr char kMonitoringEndpointKey[] = "STACKDRIVER_MONITORING_ENDPOINT";
 constexpr char kMonitoringExportIntervalKey[] =
     "STACKDRIVER_MONITORING_EXPORT_INTERVAL_SECS";
 constexpr char kTokenFile[] = "STACKDRIVER_TOKEN_FILE";

--- a/extensions/stackdriver/common/utils.h
+++ b/extensions/stackdriver/common/utils.h
@@ -33,6 +33,7 @@ struct StackdriverStubOption {
   std::string test_root_pem_path;
   std::string secure_endpoint;
   std::string insecure_endpoint;
+  std::string monitoring_endpoint;
   std::string project_id;
 };
 

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -125,6 +125,11 @@ StackdriverOptions getStackdriverOptions(
                                        grpc::InsecureChannelCredentials());
     options.metric_service_stub =
         google::monitoring::v3::MetricService::NewStub(channel);
+  } else if (!stub_option.monitoring_endpoint.empty()) {
+    auto channel = ::grpc::CreateChannel(stub_option.monitoring_endpoint,
+                                         ::grpc::GoogleDefaultCredentials());
+    options.metric_service_stub =
+        google::monitoring::v3::MetricService::NewStub(channel);
   }
 
   std::string server_type = kContainerMonitoredResource;

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -123,6 +123,18 @@ std::string getInsecureEndpoint() {
   return insecure_endpoint;
 }
 
+// Get GCP monitoring endpoint. When this is provided, it will override the
+// default production endpoint. This should be used to test staging monitoring
+// endpoint.
+std::string getMonitoringEndpoint() {
+  std::string monitoring_endpoint;
+  if (!getValue({"node", "metadata", kMonitoringEndpointKey},
+                &monitoring_endpoint)) {
+    return "";
+  }
+  return monitoring_endpoint;
+}
+
 }  // namespace
 
 bool StackdriverRootContext::onConfigure(size_t) {
@@ -162,6 +174,7 @@ bool StackdriverRootContext::onConfigure(size_t) {
   stub_option.test_root_pem_path = getCACertFile();
   stub_option.secure_endpoint = getSecureEndpoint();
   stub_option.insecure_endpoint = getInsecureEndpoint();
+  stub_option.monitoring_endpoint = getMonitoringEndpoint();
   const auto& platform_metadata = local_node_info_.platform_metadata();
   const auto project_iter = platform_metadata.find(kGCPProjectKey);
   if (project_iter != platform_metadata.end()) {


### PR DESCRIPTION
Add an option to override default SD monitoring endpoint. There are two ways to use it:

1) Use [bootstrap customization](https://github.com/istio/istio/tree/master/samples/custom-bootstrap). This is suitable for per pod enablement. Specifically apply a bootstrap customization configmap similar to [this example](https://github.com/istio/istio/blob/018d5f92acdc19481d505637ca70c3174a338888/tests/integration/telemetry/stackdriver/testdata/custom_bootstrap.yaml.tmpl), with metadata section being
```
"metadata": {
    "STACKDRIVER_MONITORING_ENDPOINT": "staging_endpoint",
}
```
Then add override annotation to a pod: `sidecar.istio.io/bootstrapOverride: "stackdriver-bootstrap-config"`

2) To apply this option globally, a more involved approach is to edit side injection config map and add `ISTIO_META_STACKDRIVER_MONITORING_ENDPOINT` env var to sidecar template, which will be relayed to sidecar node metadata, then restart sidecar injector and workload pod to pick the sidecar spec.