### PR TITLE
Fix telemetry v2 for blackhole and passthrough clusters

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -45,6 +45,8 @@ namespace Common {
 
 const char kBlackHoleCluster[] = "BlackHoleCluster";
 const char kPassThroughCluster[] = "PassthroughCluster";
+const char kBlackHoleRouteName[] = "black_hole_route";
+const char kPassThroughRouteName[] = "pass_through_route";
 const char kInboundPassthroughClusterIpv4[] = "InboundPassthroughClusterIpv4";
 const char kInboundPassthroughClusterIpv6[] = "InboundPassthroughClusterIpv6";
 
@@ -105,6 +107,16 @@ void getDestinationService(const std::string& dest_namespace,
                                            kAuthorityHeaderKey)
                              ->toString()
                        : "unknown";
+
+  // override the cluster name if this is being sent to the
+  // blackhole or passthrough cluster
+  std::string route_name;
+  getValue({"route_name"}, &route_name);
+  if (route_name == kBlackHoleRouteName) {
+      cluster_name = kBlackHoleCluster;
+  } else if (route_name == kPassThroughRouteName) {
+      cluster_name = kPassThroughCluster;
+  }
 
   if (cluster_name == kBlackHoleCluster ||
       cluster_name == kPassThroughCluster ||

--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -113,9 +113,9 @@ void getDestinationService(const std::string& dest_namespace,
   std::string route_name;
   getValue({"route_name"}, &route_name);
   if (route_name == kBlackHoleRouteName) {
-      cluster_name = kBlackHoleCluster;
+    cluster_name = kBlackHoleCluster;
   } else if (route_name == kPassThroughRouteName) {
-      cluster_name = kPassThroughCluster;
+    cluster_name = kPassThroughCluster;
   }
 
   if (cluster_name == kBlackHoleCluster ||

--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -45,8 +45,8 @@ namespace Common {
 
 const char kBlackHoleCluster[] = "BlackHoleCluster";
 const char kPassThroughCluster[] = "PassthroughCluster";
-const char kBlackHoleRouteName[] = "black_hole_route";
-const char kPassThroughRouteName[] = "pass_through_route";
+const char kBlackHoleRouteName[] = "block_all";
+const char kPassThroughRouteName[] = "allow_any";
 const char kInboundPassthroughClusterIpv4[] = "InboundPassthroughClusterIpv4";
 const char kInboundPassthroughClusterIpv6[] = "InboundPassthroughClusterIpv6";
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix blackhole and passthrough telemetry regression introduced in telemetry v2.

Make sure the destination_service_name label for istio_request metrics are set apppropriately to BlackHoleCluster and PassthroughCluster

Check the name of the route to see if it is associated with blackhole
and passthrough clusters. Change the destination_service_name
label appropriately

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/istio/istio/issues/21385

**Special notes for your reviewer**:

Associated with https://github.com/istio/istio/pull/22693

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix http blackhole and passthrough regression for telemetry v2
```
