### PR TITLE
fix(edges): increase timeout for meshtelemetry API calls

### DIFF
--- a/extensions/stackdriver/edges/mesh_edges_service_client.cc
+++ b/extensions/stackdriver/edges/mesh_edges_service_client.cc
@@ -38,7 +38,7 @@ using Envoy::Extensions::Common::Wasm::Null::Plugin::StringView;
 constexpr char kMeshEdgesService[] =
     "google.cloud.meshtelemetry.v1alpha1.MeshEdgesService";
 constexpr char kReportTrafficAssertions[] = "ReportTrafficAssertions";
-constexpr int kDefaultTimeoutMillisecond = 10000;  // 10 seconds
+constexpr int kDefaultTimeoutMillisecond = 60000;  // 60 seconds
 
 namespace Extensions {
 namespace Stackdriver {


### PR DESCRIPTION
Move the default timeout for gRPC calls into meshtelemetry to `60s` from `10s`.

Reports of `DEADLINE_EXCEEDED` returned from the service under moderate load indicate that `10s` is not adequate. Calls to meshtelemetry are not user-facing, and they consist of batches of data that need to be processed. Given that the calls are every `1m` and every `10m`, having a longer deadline seems reasonable.