### PR TITLE
Request classification proto

### DIFF
--- a/extensions/classify/config.proto
+++ b/extensions/classify/config.proto
@@ -1,0 +1,158 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package classify;
+
+
+// Configuration to classify http traffic.
+// Traffic classification can be done on mutiple dimensions using request and
+// response headers and other measurements. 
+// The plugin must be configured as request, response or log based on
+// which other plugins need to consume the classfication results.
+// For exmaple: If Stats plugin uses `operation` dimension produced by the classification
+// plugin, then it must be executed in LOG phase *before* the Stats plugin.
+message PluginConfig {
+  // next id: 3
+  // Plugin phase when classification is done.
+  PluginPhase phase = 1;
+
+  // Request classification along multiple dimensions.
+  repeated Dimension dimensions = 2;
+}
+
+// Dimension configuration produces the named dimension with a value based
+// on the match clause in the value. 
+// The value matches are processed sequentially and the first value to match is assigned.
+message Dimension {
+  // For example `operation` is a dimension.
+  string name = 1;
+
+  // At most one of the following values is assigned to the dimension. 
+  repeated Value values = 2;
+}
+
+// Value assigned to the dimension if the request matches.
+message Value {
+  // Assign `value` to the enclosing dimension if match is true.
+  string value = 1;
+
+  // Match specification.
+  // Empty match always matches, which can be used to specify a default value when placed
+  // at the end of the list.
+  Match match = 2;
+}
+
+// Match condition based on request and response information.
+// Every match condition must match for the result to be true.
+message Match {
+  // invert the match condition.
+  bool invert = 1;
+
+  // Match uri.
+  StringMatch uri = 2;
+
+  // Match scheme: http or https.
+  string scheme = 3;
+
+  // Match method: GET, POST, HEAD, PUT, DELETE, ...
+  string method = 4;
+
+  // Match request headers.
+  // Not implemented.
+  // $hide_from_docs
+  map<string, StringMatch> request_headers = 5;
+  
+  // Match response headers.
+  // Not implemented.
+  // $hide_from_docs
+  map<string, StringMatch> response_headers = 6;
+
+  // Match query parameters.
+  // Not implemented.
+  // $hide_from_docs
+  map<string, StringMatch> query_params = 7;
+
+  // Match response code.
+  IntMatch response_code = 8;
+
+  // Match request size.
+  // Not implemented.
+  // $hide_from_docs
+  IntMatch request_size = 9;
+
+  // Match response size.
+  // Not implemented.
+  // $hide_from_docs
+  IntMatch response_size = 10;
+}
+
+// Describes how to match a given string.
+message StringMatch {
+  // default is case sensitive.
+  bool case_insensitive = 1;
+
+  oneof match_type {
+
+    // exact string match
+    string exact = 2;
+
+    // prefix-based match
+    string prefix = 3;
+
+    // RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+    string regex = 4;
+  }
+}
+
+// Describes how to match a given Integer.
+message IntMatch {
+  oneof match_type {
+
+    // exact Int match
+    int64 exact = 1;
+
+    // Range match
+    IntRange range = 2;
+  }
+}
+
+// IntRange matches a range of integers.
+message IntRange {
+  // Greater than or equal to this number.
+  int64 ge = 1;
+
+  // Less than or equal to this number.
+  int64 le = 2;
+}
+
+// PluginPhase determines when the classification is performed.
+enum PluginPhase {
+  // Classification is performed after the response is sent back to the client.
+  // All information about the request is available in this phase,
+  // and classification does not add to the latency observed by the client.
+  LOG = 0;
+  // Classification is performed during request processing, and adds to
+  // the request latency as observed by the client.
+  // Only request related information can be used in this phase.
+  // For example: you may not use response headers here.
+  // Attemping to use response headers in request phase will never result in a match.
+  // Not Implemented
+  // $hide_from_docs
+  REQUEST = 1;
+
+  // ADD RESPONSE=2 if there is a need.
+}

--- a/extensions/classify/config.proto
+++ b/extensions/classify/config.proto
@@ -17,18 +17,19 @@ syntax = "proto3";
 
 package classify;
 
+import "google/protobuf/duration.proto";
 
 // Configuration to classify http traffic.
 // Traffic classification can be done on mutiple dimensions using request and
 // response headers and other measurements. 
 // The plugin must be configured as request, response or log based on
 // which other plugins need to consume the classfication results.
-// For exmaple: If Stats plugin uses `operation` dimension produced by the classification
+// For example: If Stats plugin uses `operation` dimension produced by the classification
 // plugin, then it must be executed in LOG phase *before* the Stats plugin.
 message PluginConfig {
   // next id: 3
   // Plugin phase when classification is done.
-  PluginPhase phase = 1;
+  Phase phase = 1;
 
   // Request classification along multiple dimensions.
   repeated Dimension dimensions = 2;
@@ -62,14 +63,14 @@ message Match {
   // invert the match condition.
   bool invert = 1;
 
-  // Match uri.
-  StringMatch uri = 2;
+  // Match path.
+  repeated StringMatch path = 2;
 
-  // Match scheme: http or https.
-  string scheme = 3;
+  // Match scheme: http, https or unset.
+  Scheme scheme = 3;
 
   // Match method: GET, POST, HEAD, PUT, DELETE, ...
-  string method = 4;
+  repeated string method = 4;
 
   // Match request headers.
   // Not implemented.
@@ -87,17 +88,22 @@ message Match {
   map<string, StringMatch> query_params = 7;
 
   // Match response code.
-  IntMatch response_code = 8;
+  repeated IntMatch response_code = 8;
 
   // Match request size.
   // Not implemented.
   // $hide_from_docs
-  IntMatch request_size = 9;
+  repeated IntMatch request_size = 9;
 
   // Match response size.
   // Not implemented.
   // $hide_from_docs
-  IntMatch response_size = 10;
+  repeated IntMatch response_size = 10;
+
+  // Match response duration.
+  // Not implemented.
+  // $hide_from_docs
+  repeated DurationMatch response_duration = 11;
 }
 
 // Describes how to match a given string.
@@ -130,21 +136,55 @@ message IntMatch {
   }
 }
 
+// Describes how to match a Duration.
+message DurationMatch {
+  oneof match_type {
+
+    // exact duration match.
+    google.protobuf.Duration exact = 1;
+
+    // Range match for duration.
+    DurationRange range = 2;
+  }
+}
+
 // IntRange matches a range of integers.
 message IntRange {
   // Greater than or equal to this number.
-  int64 ge = 1;
+  // Default is 0.
+  int64 min = 1;
 
   // Less than or equal to this number.
-  int64 le = 2;
+  // Default is INT_MAX.
+  int64 max = 2;
 }
 
-// PluginPhase determines when the classification is performed.
-enum PluginPhase {
+// DurationRange matches a range of integers.
+message DurationRange {
+  // Greater than or equal to this duration.
+  // Default is 0.
+  google.protobuf.Duration min = 1;
+
+  // Less than or equal to this duration.
+  // Default is INT_MAX.
+  google.protobuf.Duration max = 2;
+}
+
+enum Scheme {
+  // Matches any
+  UNSPECIFIED = 0;
+  HTTP = 1;
+  HTTPS = 2;
+}
+
+// Phase determines when the classification is performed.
+enum Phase {
+  option allow_alias = true;
   // Classification is performed after the response is sent back to the client.
   // All information about the request is available in this phase,
   // and classification does not add to the latency observed by the client.
-  LOG = 0;
+  PHASE_UNSPECIFIED = 0;
+  AFTER_RESPONSE = 0;
   // Classification is performed during request processing, and adds to
   // the request latency as observed by the client.
   // Only request related information can be used in this phase.
@@ -152,7 +192,7 @@ enum PluginPhase {
   // Attemping to use response headers in request phase will never result in a match.
   // Not Implemented
   // $hide_from_docs
-  REQUEST = 1;
+  ON_REQUEST = 1;
 
-  // ADD RESPONSE=2 if there is a need.
+  // ADD ON_RESPONSE=2 if there is a need.
 }

--- a/extensions/classify/config1.proto
+++ b/extensions/classify/config1.proto
@@ -1,0 +1,98 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package istioclassify;
+
+// Configuration to classify traffic.
+message PluginConfig {
+  // next id: 2
+  // Multiple independent classification configurations.
+  repeated Classification classifications = 1;
+}
+
+// Classification uses [well known attributes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/rbac_filter#condition) as inputs and produces
+// a new attribute that denotes a specific classification.
+// The new attribute can be used by a downstream plugin.
+//
+// Example: A classifier may produce an attribute called `istio.operationId` which is analogous to the `operationId` in the OpenAPI Spec.
+// The Stats plugin will run after the classifier and use `istio.operationId` to populate a dimension. 
+message Classification {
+  // Phase denotes plugin lifecycle phase when the classification is evaluated. 
+  Phase phase = 1;
+
+  // The following attribute is populated on successfully running the classification.
+  // Example: `istio.operationId`
+  string output_attribute = 2;
+
+  // A Classification may fail to evaluate when an attribute is not available.
+  // Example: `response.code` may not be available when a request ends abruptly.
+  // When evalution failes, the plugin will return an error to the client.
+  // This is the correct behaviour if the result of the classification is used by an authz plugin.
+  // If the result of the classifier is used by stats, you may just want to log an error but not
+  // fail the request. If `ignore_errors=true` then the classifier plugin will not fail the request.
+  bool ignore_errors = 3;
+ 
+  // Matches are evaluated in order until the first successful match.
+  // The value specified by the successful match is assgined to the output_attribute. 
+  repeated Match match = 4;
+}
+
+// If the condition evaluates to true then the Match returns the specified value. 
+message Match {
+  // Condition is a [CEL expressions](https://github.com/google/cel-spec/blob/master/doc/langdef.md)
+  // You may use [well known attributes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/rbac_filter#condition) in the CEL expression.
+  //
+  // Examples:
+  //
+  // a GET on /books
+  // { value: ListBooks,
+  //   condition: request.url_path == "/books" && request.method == "GET" }
+  //
+  // a GET on /shelves/{id1}/books/{id2}
+  // { value: GetBook,
+  //   condition: request.url_path.matches("^/shelves/\d*/books/\d*$") && request.method == "GET" }
+  // Note: Use anchors {^, $} to ensure that the regex evaluates efficiently.
+  // Note: request.url_path is normalized and stripped of query params.
+  //
+  // a Read only operation on books
+  // { value: ReadOnlyBooks, 
+  //   condition: request.url_path.startsWith("/books/") && in(request.method, ["GET", "HEAD"])}
+  string condition = 1;
+
+  // If condition evaluates to true, return the `value`.
+  string value = 2;
+}
+
+// Phase determines when the classification is performed.
+enum Phase {
+  option allow_alias = true;
+  // Classification is performed after the response is sent back to the client.
+  // All information about the request is available in this phase,
+  // and classification does not add to the latency observed by the client.
+  PHASE_UNSPECIFIED = 0;
+  AFTER_RESPONSE = 0;
+  // Classification is performed during request processing, and adds to
+  // the request latency as observed by the client.
+  // Only request related information can be used in this phase.
+  // For example: you may not use response headers here.
+  // Attemping to use response headers in request phase will never result in a match.
+  // Not Implemented
+  // $hide_from_docs
+  ON_REQUEST = 1;
+
+  // ADD ON_RESPONSE=2 if there is a need.
+}

--- a/extensions/classify/testdata/operation.json
+++ b/extensions/classify/testdata/operation.json
@@ -8,7 +8,7 @@
           "value": "GetReview",
           "match": {
             "uri": {
-              "regex": "^/reviews/\d*"
+              "regex": "^/reviews/\d*/lines/\d*"
             },
             "method": "GET"
           }

--- a/extensions/classify/testdata/operation.json
+++ b/extensions/classify/testdata/operation.json
@@ -1,0 +1,37 @@
+{
+  "phase": "LOG",
+  "dimensions": [
+    {
+      "name": "operation",
+      "values": [
+        {
+          "value": "GetReview",
+          "match": {
+            "uri": {
+              "regex": "^/reviews/\d*"
+            },
+            "method": "GET"
+          }
+        },
+        {
+          "value": "ListReviews",
+          "match": {
+            "uri": {
+              "exact": "/reviews/"
+            },
+            "method": "GET"
+          }
+        },
+        {
+          "value": "CreateReview",
+          "match": {
+            "uri": {
+              "exact": "/reviews/"
+            },
+            "method": "POST"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/extensions/classify/testdata/operation.yaml
+++ b/extensions/classify/testdata/operation.yaml
@@ -1,0 +1,23 @@
+- output_attribute: istio.responseClass
+  phase: LOG
+  ignore_errors: true
+  match:
+  - value: 2xx
+    condition: response.code >= 200 && response.code <= 299
+  - value: 3xx
+    condition: response.code >= 300 && response.code <= 399
+  - value: "404"
+    condition: response.code == 404
+  - value: "401"
+    condition: response.code == 401
+  - value: "403"
+    condition: response.code == 403
+  - value: "429"
+    condition: response.code == 429
+  - value: "503"
+    condition: response.code == 503
+  - value: 5xx
+    condition: response.code >= 500 && response.code <= 599
+  - value: 4xx
+    condition: response.code >= 400 && response.code <= 499
+

--- a/extensions/classify/testdata/responseCode.json
+++ b/extensions/classify/testdata/responseCode.json
@@ -1,0 +1,74 @@
+{
+  "phase": "LOG",
+  "dimensions": [
+    {
+      "name": "responseCode",
+      "values": [
+        {
+          "value": "2xx",
+          "match": {
+            "response_code": {
+              "range": {"ge": 200, "le": 299 }
+            }
+          }
+        },
+        {
+          "value": "3xx",
+          "match": {
+            "response_code": {
+              "range": {"ge": 300, "le": 399 }
+            }
+          }
+        },
+        {
+          "value": "404",
+          "match": {
+            "response_code": {
+              "exact": 404
+            }
+          }
+        },
+        {
+          "value": "401",
+          "match": {
+            "response_code": {
+              "exact": 401
+            }
+          }
+        },
+        {
+          "value": "403",
+          "match": {
+            "response_code": {
+              "exact": 403
+            }
+          }
+        },
+        {
+          "value": "4xx",
+          "match": {
+            "response_code": {
+              "range": {"ge": 400, "le": 499 }
+            }
+          }
+        },
+        {
+          "value": "503",
+          "match": {
+            "response_code": {
+              "exact": 503
+            }
+          }
+        },
+        {
+          "value": "5xx",
+          "match": {
+            "response_code": {
+              "range": {"ge": 500, "le": 599 }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/extensions/classify/testdata/responseCode.yaml
+++ b/extensions/classify/testdata/responseCode.yaml
@@ -1,0 +1,11 @@
+- output_attribute: istio.operationId 
+  phase: LOG
+  ignore_errors: true
+  match:
+  - value: ListBooks
+    condition: request.url_path == "/books" && request.method == "GET"
+  - value: GetBook
+    condition: request.url_path.matches("^/shelves/\d*/books/\d*$") && request.method == "GET"
+  - value: CreateBook
+    condition: request.url_path == "/books/" && request.method == "POST"
+


### PR DESCRIPTION
Add: proto definition for request classification.
Add: two examples for use.

Note: the configuration must be json at the point of delivery, not yaml.
Implementation not done yet.