### PR TITLE
Remove directional root context in metadata exchange filter

### DIFF
--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -64,14 +64,6 @@ bool serializeToStringDeterministic(const google::protobuf::Message& metadata,
 static RegisterContextFactory register_MetadataExchange(
     CONTEXT_FACTORY(PluginContext), ROOT_FACTORY(PluginRootContext));
 
-static RegisterContextFactory register_StatsOutbound(
-    CONTEXT_FACTORY(PluginContext), ROOT_FACTORY(PluginRootContextOutbound),
-    "mx_outbound");
-
-static RegisterContextFactory register_StatsInbound(
-    CONTEXT_FACTORY(PluginContext), ROOT_FACTORY(PluginRootContextInbound),
-    "mx_inbound");
-
 void PluginRootContext::updateMetadataValue() {
   google::protobuf::Struct node_metadata;
   if (!getMessageValue({"node", "metadata"}, &node_metadata)) {

--- a/extensions/metadata_exchange/plugin.h
+++ b/extensions/metadata_exchange/plugin.h
@@ -76,18 +76,6 @@ class PluginRootContext : public RootContext {
   uint32_t max_peer_cache_size_{DefaultNodeCacheMaxSize};
 };
 
-class PluginRootContextOutbound : public PluginRootContext {
- public:
-  PluginRootContextOutbound(uint32_t id, StringView root_id)
-      : PluginRootContext(id, root_id){};
-};
-
-class PluginRootContextInbound : public PluginRootContext {
- public:
-  PluginRootContextInbound(uint32_t id, StringView root_id)
-      : PluginRootContext(id, root_id){};
-};
-
 // Per-stream context.
 class PluginContext : public Context {
  public:

--- a/test/envoye2e/stats_plugin/stats_xds_test.go
+++ b/test/envoye2e/stats_plugin/stats_xds_test.go
@@ -51,7 +51,6 @@ filter_chains:
           type_url: envoy.extensions.filters.http.wasm.v3.Wasm
           value:
             config:
-              root_id: "mx_outbound"
               vm_config:
                 runtime: {{ .Vars.WasmRuntime }}
                 code:
@@ -109,7 +108,6 @@ filter_chains:
           type_url: envoy.extensions.filters.http.wasm.v3.Wasm
           value:
             config:
-              root_id: "mx_inbound"
               vm_config:
                 runtime: {{ .Vars.WasmRuntime }}
                 code:


### PR DESCRIPTION
Not sure why metadata exchange filter has directional root context defined. If there is indeed some reason to have it, we need to fix the name of static global variable (s/register_Stats/register_MetadataExchange).