### PR TITLE
Add request host header to metric dimension.

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -99,7 +99,8 @@ void extractServiceName(const std::string& host,
 //   part as destination service name. Otherwise, fallback to use destination
 //   host for destination service name.
 void getDestinationService(const std::string& dest_namespace,
-                           bool use_host_header, std::string* dest_svc_host,
+                           bool use_host_header, std::string* request_host,
+                           std::string* dest_svc_host,
                            std::string* dest_svc_name) {
   std::string cluster_name;
   getValue({"cluster_name"}, &cluster_name);
@@ -108,6 +109,7 @@ void getDestinationService(const std::string& dest_namespace,
                                            kAuthorityHeaderKey)
                              ->toString()
                        : "unknown";
+  *request_host = *dest_svc_host;
 
   // override the cluster name if this is being sent to the
   // blackhole or passthrough cluster
@@ -143,6 +145,7 @@ void populateRequestInfo(bool outbound, bool use_host_header_fallback,
   // Get destination service name and host based on cluster name and host
   // header.
   getDestinationService(destination_namespace, use_host_header_fallback,
+                        &request_info->request_host,
                         &request_info->destination_service_host,
                         &request_info->destination_service_name);
 
@@ -348,7 +351,6 @@ void populateExtendedHTTPRequestInfo(RequestInfo* request_info) {
   }
 
   getValue({"request", "url_path"}, &request_info->url_path);
-  getValue({"request", "host"}, &request_info->url_host);
   getValue({"request", "scheme"}, &request_info->url_scheme);
 }
 

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -113,6 +113,9 @@ struct RequestInfo {
   // The path portion of the URL without the query string.
   std::string request_url_path;
 
+  // Request host header.
+  std::string request_host;
+
   // Service authentication policy (NONE, MUTUAL_TLS)
   ServiceAuthenticationPolicy service_auth_policy =
       ServiceAuthenticationPolicy::Unspecified;
@@ -137,7 +140,6 @@ struct RequestInfo {
 
   // HTTP URL related attributes.
   std::string url_path;
-  std::string url_host;
   std::string url_scheme;
 
   // TCP variables.

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -165,7 +165,7 @@ void Logger::addLogEntry(const ::Wasm::Common::RequestInfo& request_info,
   auto http_request = new_entry->mutable_http_request();
   http_request->set_request_method(request_info.request_operation);
   http_request->set_request_url(request_info.url_scheme + "://" +
-                                request_info.url_host + request_info.url_path);
+                                request_info.request_host + request_info.url_path);
   http_request->set_request_size(request_info.request_size);
   http_request->set_status(request_info.response_code);
   http_request->set_response_size(request_info.response_size);

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -165,7 +165,8 @@ void Logger::addLogEntry(const ::Wasm::Common::RequestInfo& request_info,
   auto http_request = new_entry->mutable_http_request();
   http_request->set_request_method(request_info.request_operation);
   http_request->set_request_url(request_info.url_scheme + "://" +
-                                request_info.request_host + request_info.url_path);
+                                request_info.request_host +
+                                request_info.url_path);
   http_request->set_request_size(request_info.request_size);
   http_request->set_status(request_info.response_code);
   http_request->set_response_size(request_info.response_size);

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -112,7 +112,7 @@ const ::Wasm::Common::FlatNode& peerNodeInfo(
       ::Wasm::Common::ServiceAuthenticationPolicy::MutualTLS;
   request_info.duration = 10000000000;  // 10s in nanoseconds
   request_info.url_scheme = "http";
-  request_info.url_host = "httpbin.org";
+  request_info.request_host = "httpbin.org";
   request_info.url_path = "/headers";
   request_info.request_id = "123";
   request_info.b3_trace_id = "123abc";

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -157,6 +157,7 @@ void map_request(IstioDimensions& instance,
   instance[response_flags] = request.response_flag;
   instance[connection_security_policy] = absl::AsciiStrToLower(std::string(
       ::Wasm::Common::AuthenticationPolicyString(request.service_auth_policy)));
+  instance[request_host] = request.request_host;
 }
 
 // maps peer_node and request to dimensions.

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -95,7 +95,8 @@ using google::protobuf::util::Status;
   FIELD_FUNC(response_code)                  \
   FIELD_FUNC(grpc_response_status)           \
   FIELD_FUNC(response_flags)                 \
-  FIELD_FUNC(connection_security_policy)
+  FIELD_FUNC(connection_security_policy)     \
+  FIELD_FUNC(request_host)
 
 // Aggregate metric values in a shared and reusable bag.
 using IstioDimensions = std::vector<std::string>;

--- a/test/envoye2e/stats_plugin/stats_xds_test.go
+++ b/test/envoye2e/stats_plugin/stats_xds_test.go
@@ -246,6 +246,7 @@ var TestCases = []struct {
 
 func TestStatsPayload(t *testing.T) {
 	env.SkipTSanASan(t)
+	t.Parallel()
 	for _, testCase := range TestCases {
 		for _, runtime := range Runtimes {
 			t.Run(testCase.Name+"/"+runtime.WasmRuntime, func(t *testing.T) {
@@ -290,6 +291,7 @@ func TestStatsPayload(t *testing.T) {
 
 func TestStatsParallel(t *testing.T) {
 	env.SkipTSanASan(t)
+	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
 		"RequestCount":               "1",
 		"MetadataExchangeFilterCode": "inline_string: \"envoy.wasm.metadata_exchange\"",
@@ -351,6 +353,7 @@ func TestStatsParallel(t *testing.T) {
 }
 
 func TestStatsGrpc(t *testing.T) {
+	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
 		"RequestCount":               "10",
 		"MetadataExchangeFilterCode": "inline_string: \"envoy.wasm.metadata_exchange\"",

--- a/test/envoye2e/tcp_metadata_exchange/tcp_metadata_exchange_test.go
+++ b/test/envoye2e/tcp_metadata_exchange/tcp_metadata_exchange_test.go
@@ -100,6 +100,7 @@ const ServerTransportSocket = `transport_socket:
       require_client_certificate: true`
 
 func TestTCPMetadataExchange(t *testing.T) {
+	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
 		"ServerNetworkFilters":     ServerMXFilter + ServerStatsFilter,
 		"ClientNetworkFilters":     ClientStatsFilter,
@@ -157,6 +158,7 @@ func TestTCPMetadataExchange(t *testing.T) {
 }
 
 func TestTCPMetadataExchangeNoAlpn(t *testing.T) {
+	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
 		"ServerNetworkFilters":     ServerMXFilter + ServerStatsFilter,
 		"DisableDirectResponse":    "true",

--- a/testdata/bootstrap/stats.yaml.tmpl
+++ b/testdata/bootstrap/stats.yaml.tmpl
@@ -51,6 +51,8 @@ stats_config:
     regex: "(response_flags=\\.=(.*?);\\.;)"
   - tag_name: "connection_security_policy"
     regex: "(connection_security_policy=\\.=(.*?);\\.;)"
+  - tag_name: "request_host"
+    regex: "(request_host=\\.=(.*?);\\.;)"
 # Extra regexes used for configurable metrics
   - tag_name: "configurable_metric_a"
     regex: "(configurable_metric_a=\\.=(.*?);\\.;)"

--- a/testdata/metric/client_request_total.yaml.tmpl
+++ b/testdata/metric/client_request_total.yaml.tmpl
@@ -54,6 +54,8 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: 127.0.0.1:{{ .Ports.ClientPort }}
   - name: configurable_metric_a
     value: localhost:server
   - name: configurable_metric_b

--- a/testdata/metric/client_request_total_customized.yaml.tmpl
+++ b/testdata/metric/client_request_total_customized.yaml.tmpl
@@ -44,5 +44,7 @@ metric:
     value: "200"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: 127.0.0.1:{{ .Ports.ClientPort }}
   - name: configurable_metric_a
     value: gateway

--- a/testdata/metric/disable_host_header_fallback.yaml.tmpl
+++ b/testdata/metric/disable_host_header_fallback.yaml.tmpl
@@ -50,6 +50,8 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: unknown
   - name: configurable_metric_a
     value: localhost:server
   - name: configurable_metric_b

--- a/testdata/metric/host_header_fallback.yaml.tmpl
+++ b/testdata/metric/host_header_fallback.yaml.tmpl
@@ -50,6 +50,8 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: 127.0.0.1:{{ .Ports.ClientPort }}
   - name: configurable_metric_a
     value: localhost:server
   - name: configurable_metric_b

--- a/testdata/metric/server_request_total.yaml.tmpl
+++ b/testdata/metric/server_request_total.yaml.tmpl
@@ -54,3 +54,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: none
+  - name: request_host
+    value: 127.0.0.1:{{ .Ports.ClientPort }}

--- a/testdata/metric/tcp_client_connection_close.yaml.tmpl
+++ b/testdata/metric/tcp_client_connection_close.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_client_connection_open.yaml.tmpl
+++ b/testdata/metric/tcp_client_connection_open.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_client_received_bytes.yaml.tmpl
+++ b/testdata/metric/tcp_client_received_bytes.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_client_sent_bytes.yaml.tmpl
+++ b/testdata/metric/tcp_client_sent_bytes.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: unknown
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_server_connection_close.yaml.tmpl
+++ b/testdata/metric/tcp_server_connection_close.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: mutual_tls
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_server_connection_open.yaml.tmpl
+++ b/testdata/metric/tcp_server_connection_open.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: mutual_tls
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_server_connection_open_without_mx.yaml.tmpl
+++ b/testdata/metric/tcp_server_connection_open_without_mx.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: mutual_tls
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_server_received_bytes.yaml.tmpl
+++ b/testdata/metric/tcp_server_received_bytes.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: mutual_tls
+  - name: request_host
+    value: unknown

--- a/testdata/metric/tcp_server_sent_bytes.yaml.tmpl
+++ b/testdata/metric/tcp_server_sent_bytes.yaml.tmpl
@@ -46,3 +46,5 @@ metric:
     value: "-"
   - name: connection_security_policy
     value: mutual_tls
+  - name: request_host
+    value: unknown


### PR DESCRIPTION
Add request host header to metric tag. It follows `use_host_header` option, and set to `unknown` when host header fallback is disabled.

@jshaughn

ref: https://github.com/istio/istio/issues/21820