### PR TITLE
Fix error during doc generation

### DIFF
--- a/extensions/attributegen/config.pb.html
+++ b/extensions/attributegen/config.pb.html
@@ -184,7 +184,7 @@ value.</p>
 expression</a>
 that may use <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/rbac_filter#condition">builtin attributes</a>.</p>
 
-<p>Example:
+<p>{{<tabset category-name="example">}} Example:
 {{<tab name="attribute-match" >}}</p>
 
 <pre><code class="language-yaml">   {
@@ -208,7 +208,8 @@ efficiently.</p>
   in(request.method, ['GET', 'HEAD'])&quot;}
 </code></pre>
 
-<p>{{</tab>}}</p>
+<p>{{</tab>}}
+{{</tabset>}}</p>
 
 <p>An empty condition evaluates to <code>true</code> and should be used to provide a
 default value.</p>

--- a/extensions/attributegen/config.pb.html
+++ b/extensions/attributegen/config.pb.html
@@ -46,8 +46,9 @@ named <code>istio.operationId</code> using <code>request.url_path</code> and <co
 </code></pre>
 
 <p>{{</tab>}}
-{{</tabset>}}
-If the Stats plugin runs after AttributeGen, it can use <code>istio.operationId</code>
+{{</tabset>}}</p>
+
+<p>If the Stats plugin runs after AttributeGen, it can use <code>istio.operationId</code>
 to populate a dimension on a metric.</p>
 
 <p>The following is an example of response codes being mapped into a smaller
@@ -103,6 +104,47 @@ example, all response codes in 200s are mapped to <code>2xx</code>.</p>
 <p>If multiple AttributeGene configurations produce the same attribute, the
 result of the last configuration will be visible to downstream filters.</p>
 
+<h2 id="PluginConfig">PluginConfig</h2>
+<section>
+<p>Top level configuration to generate new attributes based on attributes of the
+proxied traffic.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+<th>Required</th>
+</tr>
+</thead>
+<tbody>
+<tr id="PluginConfig-debug">
+<td><code>debug</code></td>
+<td><code>bool</code></td>
+<td>
+<p>The following settings should be rarely used.
+Enable debug for this filter.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="PluginConfig-attributes">
+<td><code>attributes</code></td>
+<td><code><a href="#AttributeGeneration">AttributeGeneration[]</a></code></td>
+<td>
+<p>Multiple independent attribute generation configurations.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
+</tbody>
+</table>
+</section>
 <h2 id="AttributeGeneration">AttributeGeneration</h2>
 <section>
 <p>AttributeGeneration define generation of one attribute.</p>
@@ -184,7 +226,9 @@ value.</p>
 expression</a>
 that may use <a href="https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/rbac_filter#condition">builtin attributes</a>.</p>
 
-<p>{{<tabset category-name="example">}} Example:
+<p>Example:</p>
+
+<p>{{<tabset category-name="example">}}
 {{<tab name="attribute-match" >}}</p>
 
 <pre><code class="language-yaml">   {
@@ -224,47 +268,6 @@ No
 <td><code>string</code></td>
 <td>
 <p>If condition evaluates to true, return the <code>value</code>.</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
-</tbody>
-</table>
-</section>
-<h2 id="PluginConfig">PluginConfig</h2>
-<section>
-<p>Top level configuration to generate new attributes based on attributes of the
-proxied traffic.</p>
-
-<table class="message-fields">
-<thead>
-<tr>
-<th>Field</th>
-<th>Type</th>
-<th>Description</th>
-<th>Required</th>
-</tr>
-</thead>
-<tbody>
-<tr id="PluginConfig-debug">
-<td><code>debug</code></td>
-<td><code>bool</code></td>
-<td>
-<p>The following settings should be rarely used.
-Enable debug for this filter.</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
-<tr id="PluginConfig-attributes">
-<td><code>attributes</code></td>
-<td><code><a href="#AttributeGeneration">AttributeGeneration[]</a></code></td>
-<td>
-<p>Multiple independent attribute generation configurations.</p>
 
 </td>
 <td>

--- a/extensions/attributegen/config.proto
+++ b/extensions/attributegen/config.proto
@@ -60,6 +60,7 @@ syntax = "proto3";
 // ```
 // {{</tab>}}
 // {{</tabset>}}
+//
 // If the Stats plugin runs after AttributeGen, it can use `istio.operationId`
 // to populate a dimension on a metric.
 //
@@ -169,6 +170,8 @@ message Match {
   // (https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/rbac_filter#condition).
   //
   // Example:
+  //
+  // {{<tabset category-name="example">}}
   // {{<tab name="attribute-match" >}}
   // ```yaml
   //    {
@@ -191,6 +194,7 @@ message Match {
   //   in(request.method, ['GET', 'HEAD'])"}
   // ```
   // {{</tab>}}
+  // {{</tabset>}}
   //
   // An empty condition evaluates to `true` and should be used to provide a
   // default value.

--- a/extensions/metadata_exchange/declare_property.pb.html
+++ b/extensions/metadata_exchange/declare_property.pb.html
@@ -1,0 +1,188 @@
+---
+title: envoy.source.extensions.common.wasm
+layout: protoc-gen-docs
+generator: protoc-gen-docs
+number_of_entries: 5
+---
+<h2 id="DeclarePropertyArguments">DeclarePropertyArguments</h2>
+<section>
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+<th>Required</th>
+</tr>
+</thead>
+<tbody>
+<tr id="DeclarePropertyArguments-name">
+<td><code>name</code></td>
+<td><code>string</code></td>
+<td>
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="DeclarePropertyArguments-readonly">
+<td><code>readonly</code></td>
+<td><code>bool</code></td>
+<td>
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="DeclarePropertyArguments-type">
+<td><code>type</code></td>
+<td><code><a href="#WasmType">WasmType</a></code></td>
+<td>
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="DeclarePropertyArguments-schema">
+<td><code>schema</code></td>
+<td><code>bytes</code></td>
+<td>
+</td>
+<td>
+No
+</td>
+</tr>
+<tr id="DeclarePropertyArguments-span">
+<td><code>span</code></td>
+<td><code><a href="#LifeSpan">LifeSpan</a></code></td>
+<td>
+</td>
+<td>
+No
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="WasmType">WasmType</h2>
+<section>
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="WasmType-Bytes">
+<td><code>Bytes</code></td>
+<td>
+</td>
+</tr>
+<tr id="WasmType-String">
+<td><code>String</code></td>
+<td>
+</td>
+</tr>
+<tr id="WasmType-FlatBuffers">
+<td><code>FlatBuffers</code></td>
+<td>
+</td>
+</tr>
+<tr id="WasmType-Protobuf">
+<td><code>Protobuf</code></td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="LifeSpan">LifeSpan</h2>
+<section>
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="LifeSpan-FilterChain">
+<td><code>FilterChain</code></td>
+<td>
+</td>
+</tr>
+<tr id="LifeSpan-DownstreamRequest">
+<td><code>DownstreamRequest</code></td>
+<td>
+</td>
+</tr>
+<tr id="LifeSpan-DownstreamConnection">
+<td><code>DownstreamConnection</code></td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="WasmType">WasmType</h2>
+<section>
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="WasmType-Bytes">
+<td><code>Bytes</code></td>
+<td>
+</td>
+</tr>
+<tr id="WasmType-String">
+<td><code>String</code></td>
+<td>
+</td>
+</tr>
+<tr id="WasmType-FlatBuffers">
+<td><code>FlatBuffers</code></td>
+<td>
+</td>
+</tr>
+<tr id="WasmType-Protobuf">
+<td><code>Protobuf</code></td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="LifeSpan">LifeSpan</h2>
+<section>
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="LifeSpan-FilterChain">
+<td><code>FilterChain</code></td>
+<td>
+</td>
+</tr>
+<tr id="LifeSpan-DownstreamRequest">
+<td><code>DownstreamRequest</code></td>
+<td>
+</td>
+</tr>
+<tr id="LifeSpan-DownstreamConnection">
+<td><code>DownstreamConnection</code></td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</section>


### PR DESCRIPTION
**What this PR does / why we need it**:

During the `make lint` in the _istio.io_ repo, there is an error:
```
ERROR 2020/04/26 13:13:39 Missing surrounding tabset for tab ("/work/content/en/docs/reference/config/attributegen/index.html:190:1")
```
(note the line number is slightly different as the update doc code in the _istio.io_ repo adds a few header lines.

This change fixes the error. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
