### PR TITLE
If istio.operationId is present us it Stackdriver metrics.

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -285,9 +285,12 @@ void populateHTTPRequestInfo(bool outbound, bool use_host_header_fallback,
     request_info->request_protocol = kProtocolHTTP;
   }
 
+  std::string operation_id;
   request_info->request_operation =
-      getHeaderMapValue(HeaderMapType::RequestHeaders, kMethodHeaderKey)
-          ->toString();
+      getValue({::Wasm::Common::kRequestOperationKey}, &operation_id)
+          ? operation_id
+          : getHeaderMapValue(HeaderMapType::RequestHeaders, kMethodHeaderKey)
+                ->toString();
 
   if (!outbound) {
     uint64_t destination_port = 0;

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -39,6 +39,7 @@ const std::string kMetadataNotFoundValue =
     "envoy.wasm.metadata_exchange.peer_unknown";
 
 constexpr StringView kAccessLogPolicyKey = "istio.access_log_policy";
+constexpr StringView kRequestOperationKey = "istio.operationId";
 
 // Header keys
 constexpr StringView kAuthorityHeaderKey = ":authority";


### PR DESCRIPTION
**Release note**:

```release-note
If `istio.operationId` attibute is set in the filter state, it will be used to populate the `request_operation` dimension of the Stackdriver metric.
```
