### PR TITLE
fix(stackdriver): improve uids for GCE VMs

### DIFF
--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -80,35 +80,62 @@ void buildEnvoyGrpcService(
   }
 }
 
+bool isRawGCEInstance(const ::Wasm::Common::FlatNode &node) {
+  auto platform_metadata = node.platform_metadata();
+  if (!platform_metadata) {
+    return false;
+  }
+  auto instance_id = platform_metadata->LookupByKey(kGCPGCEInstanceIDKey);
+  auto cluster_name = platform_metadata->LookupByKey(kGCPClusterNameKey);
+  return instance_id && !cluster_name;
+}
+
+std::string getGCEInstanceUID(const ::Wasm::Common::FlatNode &node) {
+  auto platform_metadata = node.platform_metadata();
+  if (!platform_metadata) {
+    return "";
+  }
+
+  auto project = platform_metadata->LookupByKey(kGCPProjectKey);
+  auto location = platform_metadata->LookupByKey(kGCPLocationKey);
+  auto instance_id = platform_metadata->LookupByKey(kGCPGCEInstanceIDKey);
+
+  auto name = node.name() ? node.name()->string_view() : absl::string_view();
+  if (name.size() == 0 && instance_id) {
+    name = instance_id->value()->string_view();
+  }
+
+  if (name.size() > 0 && project && location) {
+    return absl::StrCat("//compute.googleapis.com/projects/",
+                        project->value()->string_view(), "/zones/",
+                        location->value()->string_view(), "/instances/", name);
+  }
+
+  return "";
+}
+
 std::string getOwner(const ::Wasm::Common::FlatNode &node) {
   // do not override supplied owner
   if (node.owner()) {
     return flatbuffers::GetString(node.owner());
   }
 
-  auto platform_metadata = node.platform_metadata();
-  if (!platform_metadata) {
-    return "";
-  }
+  // only attempt for GCE Instances at this point. Support for other
+  // platforms will have to be added later. We also don't try to discover
+  // owners for GKE workload instances, as those should be handled by the
+  // sidecar injector.
+  if (isRawGCEInstance(node)) {
+    auto platform_metadata = node.platform_metadata();
+    if (!platform_metadata) {
+      return "";
+    }
+    auto created_by = platform_metadata->LookupByKey(kGCECreatedByKey.data());
+    if (created_by) {
+      return absl::StrCat("//compute.googleapis.com/",
+                          created_by->value()->string_view());
+    }
 
-  // only attempt for GCE Instances at this point, first check for MIG.
-  auto created_by = platform_metadata->LookupByKey(kGCECreatedByKey.data());
-  if (created_by) {
-    return absl::StrCat("//compute.googleapis.com/",
-                        created_by->value()->string_view());
-  }
-
-  // then handle unmanaged GCE Instance case
-  auto instance_id = platform_metadata->LookupByKey(kGCPGCEInstanceIDKey);
-  auto project = platform_metadata->LookupByKey(kGCPProjectNumberKey.data());
-  auto location = platform_metadata->LookupByKey(kGCPLocationKey);
-  if (instance_id && project && location) {
-    // Should be of the form:
-    // //compute.googleapis.com/projects/%s/zones/%s/instances/%s
-    return absl::StrCat("//compute.googleapis.com/projects/",
-                        project->value()->string_view(), "/zones/",
-                        location->value()->string_view(), "/instances/",
-                        instance_id->value()->string_view());
+    return getGCEInstanceUID(node);
   }
 
   return "";

--- a/extensions/stackdriver/common/utils.h
+++ b/extensions/stackdriver/common/utils.h
@@ -43,6 +43,16 @@ void buildEnvoyGrpcService(
     const StackdriverStubOption &option,
     ::envoy::config::core::v3::GrpcService *grpc_service);
 
+// Determines if the proxy is running directly on GCE instance (VM).
+// If the proxy is running on GKE-managed VM, this will return false.
+// The determination is made based on available `platform_metadata`
+// for the node.
+bool isRawGCEInstance(const ::Wasm::Common::FlatNode &node);
+
+// Returns the unique identifier for a Raw GCE Instance. If the node
+// is not a GCE Instance, the empty string will be returned.
+std::string getGCEInstanceUID(const ::Wasm::Common::FlatNode &node);
+
 // Returns "owner" information for a node. If that information
 // has been directly set, that value is returned. If not, and the owner
 // can be entirely derived from platform metadata, this will derive the

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -49,10 +49,16 @@ void instanceFromMetadata(const ::Wasm::Common::FlatNode& node_info,
   auto namespace_ = node_info.namespace_()
                         ? node_info.namespace_()->string_view()
                         : absl::string_view();
-  if (name.size() > 0 && namespace_.size() > 0) {
-    absl::StrAppend(instance->mutable_uid(), "kubernetes://", name, ".",
-                    namespace_);
+
+  if (Common::isRawGCEInstance(node_info)) {
+    instance->set_uid(Common::getGCEInstanceUID(node_info));
+  } else {
+    if (name.size() > 0 && namespace_.size() > 0) {
+      absl::StrAppend(instance->mutable_uid(), "kubernetes://", name, ".",
+                      namespace_);
+    }
   }
+
   // TODO(douglas-reid): support more than just GCP ?
   const auto platform_metadata = node_info.platform_metadata();
   if (platform_metadata) {

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -52,11 +52,9 @@ void instanceFromMetadata(const ::Wasm::Common::FlatNode& node_info,
 
   if (Common::isRawGCEInstance(node_info)) {
     instance->set_uid(Common::getGCEInstanceUID(node_info));
-  } else {
-    if (name.size() > 0 && namespace_.size() > 0) {
-      absl::StrAppend(instance->mutable_uid(), "kubernetes://", name, ".",
-                      namespace_);
-    }
+  } else if (name.size() > 0 && namespace_.size() > 0) {
+    absl::StrAppend(instance->mutable_uid(), "kubernetes://", name, ".",
+                    namespace_);
   }
 
   // TODO(douglas-reid): support more than just GCP ?

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -312,7 +312,7 @@ func TestStackdriverGCEInstances(t *testing.T) {
 			sd.Check(params,
 				[]string{"testdata/stackdriver/gce_client_request_count.yaml.tmpl", "testdata/stackdriver/gce_server_request_count.yaml.tmpl"},
 				nil,
-				nil,
+				[]string{"testdata/stackdriver/gce_traffic_assertion.yaml.tmpl"},
 			),
 		},
 	}).Run(params); err != nil {

--- a/testdata/gce_client_node_metadata.json.tmpl
+++ b/testdata/gce_client_node_metadata.json.tmpl
@@ -12,7 +12,7 @@
     "service.istio.io/canonical-revision": "version-1"
 },
 "MESH_ID": "mesh",
-"NAME": "productpage-v1-84975bc778-pxz2w",
+"NAME": "productpage-vm",
 "NAMESPACE": "default",
 "PLATFORM_METADATA": {
     "gcp_gce_instance_id": "234215124341324123",

--- a/testdata/stackdriver/gce_client_request_count.yaml.tmpl
+++ b/testdata/stackdriver/gce_client_request_count.yaml.tmpl
@@ -18,7 +18,7 @@ metric:
     source_canonical_revision: version-1
     source_canonical_service_name: productpage-v1
     source_canonical_service_namespace: default
-    source_owner: //compute.googleapis.com/projects/23412341234/zones/us-east4-b/instances/234215124341324123
+    source_owner: //compute.googleapis.com/projects/test-project/zones/us-east4-b/instances/productpage-vm
     source_principal: "{{ .Vars.SourcePrincipal }}"
     source_workload_name: productpage-v1
     source_workload_namespace: default

--- a/testdata/stackdriver/gce_server_request_count.yaml.tmpl
+++ b/testdata/stackdriver/gce_server_request_count.yaml.tmpl
@@ -18,7 +18,7 @@ metric:
     source_canonical_revision: version-1
     source_canonical_service_name: productpage-v1
     source_canonical_service_namespace: default
-    source_owner: //compute.googleapis.com/projects/23412341234/zones/us-east4-b/instances/234215124341324123
+    source_owner: //compute.googleapis.com/projects/test-project/zones/us-east4-b/instances/productpage-vm
     source_principal: "{{ .Vars.SourcePrincipal }}"
     source_workload_name: productpage-v1
     source_workload_namespace: default

--- a/testdata/stackdriver/gce_traffic_assertion.yaml.tmpl
+++ b/testdata/stackdriver/gce_traffic_assertion.yaml.tmpl
@@ -1,0 +1,23 @@
+parent: projects/test-project
+mesh_uid: mesh
+traffic_assertions:
+- protocol: PROTOCOL_HTTP
+  destination_service_name: server
+  destination_service_namespace: default
+  source:
+    uid: //compute.googleapis.com/projects/test-project/zones/us-east4-b/instances/productpage-vm
+    location: us-east4-b
+    owner_uid: //compute.googleapis.com/projects/test-project/zones/us-east4-b/instances/productpage-vm
+    workload_name: productpage-v1
+    workload_namespace: default
+    canonical_service: productpage-v1
+    canonical_revision: version-1
+  destination:
+    uid: //compute.googleapis.com/projects/test-project/zones/us-east4-b/instances/ratings-v1-vm
+    location: us-east4-b
+    owner_uid: //compute.googleapis.com/projects/23412341234/instanceGroupManagers/324234
+    workload_name: ratings-v1
+    workload_namespace: default
+    canonical_service: ratings
+    canonical_revision: version-1
+


### PR DESCRIPTION
This PR corrects a number of small data issues observed on GCE VMs with Stackdriver telemetry (in particular, meshtelemetry service calls):

- prefer instance names to numbers in UIDs
- use GCE UIDs for workload instances (instead of `kubernetes://...` uids).

It also adds tests to validate traffic assertions for GCE. 