### PR TITLE
Fix flaky integration test

### DIFF
--- a/src/envoy/http/jwt_auth/integration_test/http_filter_integration_test.cc
+++ b/src/envoy/http/jwt_auth/integration_test/http_filter_integration_test.cc
@@ -420,9 +420,9 @@ TEST_P(JwtVerificationFilterIntegrationTestWithInjectedJwtResult,
   EXPECT_TRUE(request_stream_backend->complete());
 
   response->waitForEndStream();
-  codec_client->close();
   ASSERT_TRUE(fake_upstream_connection_backend->close());
   ASSERT_TRUE(fake_upstream_connection_backend->waitForDisconnect());
+  codec_client->close();
 }
 
 }  // namespace Envoy


### PR DESCRIPTION
Co-authored-by: Kevin Conner <kconner@redhat.com>
Signed-off-by: Dmitri Dolguikh <dmitri@appliedlogic.ca>

**What this PR does / why we need it**: Fixes intermittent failures in src/envoy/http/jwt_auth/integration_test/http_filter_integration_test