### PR TITLE
authn: change json processing strategy to protobuf

### DIFF
--- a/src/envoy/http/authn/BUILD
+++ b/src/envoy/http/authn/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//src/envoy/utils:filter_names_lib",
         "//src/envoy/utils:utils_lib",
         "//src/istio/authn:context_proto_cc_proto",
+        "@com_google_protobuf//:protobuf",
         "@envoy//source/common/http:headers_lib",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Change json processing strategy to protobuf from envoy native json loader.
In WebAssembly context, emscripten don't support pthread on standalone wasm mode, so we should eliminate what depend on them. Envoy (and the dependencies of them) have that.