### PR TITLE
fix(stackdriver): map grpc status codes into http domain for metrics

### DIFF
--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -169,6 +169,49 @@ TagKeyValueList getInboundTagMap(
   return inboundMap;
 }
 
+// See:
+// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+uint32_t httpCodeFromGrpc(uint32_t grpc_status) {
+  switch (grpc_status) {
+    case 0:
+      return 200;
+    case 1:
+      return 499;
+    case 2:
+      return 500;
+    case 3:
+      return 400;
+    case 4:
+      return 504;
+    case 5:
+      return 404;
+    case 6:
+      return 409;
+    case 7:
+      return 403;
+    case 8:
+      return 429;
+    case 9:
+      return 400;
+    case 10:
+      return 409;
+    case 11:
+      return 400;
+    case 12:
+      return 501;
+    case 13:
+      return 500;
+    case 14:
+      return 503;
+    case 15:
+      return 500;
+    case 16:
+      return 401;
+    default:
+      return 500;
+  }
+}
+
 void addHttpSpecificTags(const ::Wasm::Common::RequestInfo& request_info,
                          TagKeyValueList& tag_map) {
   const auto& operation =
@@ -176,8 +219,13 @@ void addHttpSpecificTags(const ::Wasm::Common::RequestInfo& request_info,
           ? request_info.request_url_path
           : request_info.request_operation;
   tag_map.emplace_back(Metric::requestOperationKey(), operation);
+
+  const auto& response_code =
+      request_info.request_protocol == ::Wasm::Common::kProtocolGRPC
+          ? httpCodeFromGrpc(request_info.grpc_status)
+          : request_info.response_code;
   tag_map.emplace_back(Metric::responseCodeKey(),
-                       std::to_string(request_info.response_code));
+                       std::to_string(response_code));
 }
 
 }  // namespace

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -173,39 +173,39 @@ TagKeyValueList getInboundTagMap(
 // https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 uint32_t httpCodeFromGrpc(uint32_t grpc_status) {
   switch (grpc_status) {
-    case 0: // OK
+    case 0:  // OK
       return 200;
-    case 1: // CANCELLED
+    case 1:  // CANCELLED
       return 499;
-    case 2: // UNKNOWN
+    case 2:  // UNKNOWN
       return 500;
-    case 3: // INVALID_ARGUMENT
+    case 3:  // INVALID_ARGUMENT
       return 400;
-    case 4: // DEADLINE_EXCEEDED
+    case 4:  // DEADLINE_EXCEEDED
       return 504;
-    case 5: // NOT_FOUND
+    case 5:  // NOT_FOUND
       return 404;
-    case 6: // ALREADY_EXISTS
+    case 6:  // ALREADY_EXISTS
       return 409;
-    case 7: // PERMISSION_DENIED
+    case 7:  // PERMISSION_DENIED
       return 403;
-    case 8: // RESOURCE_EXHAUSTED
+    case 8:  // RESOURCE_EXHAUSTED
       return 429;
-    case 9: // FAILED_PRECONDITION
+    case 9:  // FAILED_PRECONDITION
       return 400;
-    case 10: // ABORTED
+    case 10:  // ABORTED
       return 409;
-    case 11: // OUT_OF_RANGE
+    case 11:  // OUT_OF_RANGE
       return 400;
-    case 12: // UNIMPLEMENTED
+    case 12:  // UNIMPLEMENTED
       return 501;
-    case 13: // INTERNAL
+    case 13:  // INTERNAL
       return 500;
-    case 14: // UNAVAILABLE
+    case 14:  // UNAVAILABLE
       return 503;
-    case 15: // DATA_LOSS
+    case 15:  // DATA_LOSS
       return 500;
-    case 16: // UNAUTHENTICATED
+    case 16:  // UNAUTHENTICATED
       return 401;
     default:
       return 500;

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -173,39 +173,39 @@ TagKeyValueList getInboundTagMap(
 // https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
 uint32_t httpCodeFromGrpc(uint32_t grpc_status) {
   switch (grpc_status) {
-    case 0:
+    case 0: // OK
       return 200;
-    case 1:
+    case 1: // CANCELLED
       return 499;
-    case 2:
+    case 2: // UNKNOWN
       return 500;
-    case 3:
+    case 3: // INVALID_ARGUMENT
       return 400;
-    case 4:
+    case 4: // DEADLINE_EXCEEDED
       return 504;
-    case 5:
+    case 5: // NOT_FOUND
       return 404;
-    case 6:
+    case 6: // ALREADY_EXISTS
       return 409;
-    case 7:
+    case 7: // PERMISSION_DENIED
       return 403;
-    case 8:
+    case 8: // RESOURCE_EXHAUSTED
       return 429;
-    case 9:
+    case 9: // FAILED_PRECONDITION
       return 400;
-    case 10:
+    case 10: // ABORTED
       return 409;
-    case 11:
+    case 11: // OUT_OF_RANGE
       return 400;
-    case 12:
+    case 12: // UNIMPLEMENTED
       return 501;
-    case 13:
+    case 13: // INTERNAL
       return 500;
-    case 14:
+    case 14: // UNAVAILABLE
       return 503;
-    case 15:
+    case 15: // DATA_LOSS
       return 500;
-    case 16:
+    case 16: // UNAUTHENTICATED
       return 401;
     default:
       return 500;


### PR DESCRIPTION
Adds logic for stackdriver metrics reporting to handle gRPC status codes by translating to HTTP response codes. This should allow monitoring of gRPC services to work seamlessly in HTTP-focused dashboards and alerting.
