### PR TITLE
jwt_authn: replace json processing strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
           keys:
             - macos_fastbuild-bazel-cache-{{ checksum "WORKSPACE" }}-{{ checksum ".bazelrc" }}
       - run: rm ~/.gitconfig
-      - run: make build_envoy
+      - run:
+          command: make build_envoy
+          no_output_timeout: "60m"
       - save_cache:
           key: macos_fastbuild-bazel-cache-{{ checksum "WORKSPACE" }}-{{ checksum ".bazelrc" }}
           paths:

--- a/extensions/common/json_util.cc
+++ b/extensions/common/json_util.cc
@@ -22,7 +22,7 @@ namespace Common {
 
 absl::optional<JsonObject> JsonParse(absl::string_view str) {
   const auto result = JsonObject::parse(str, nullptr, false);
-  if (result.empty() || result.is_discarded() || !result.is_object()) {
+  if (result.is_discarded() || !result.is_object()) {
     return absl::nullopt;
   }
   return result;

--- a/extensions/common/json_util.cc
+++ b/extensions/common/json_util.cc
@@ -85,7 +85,8 @@ template <>
 std::pair<absl::optional<std::string>, JsonParserResultDetail>
 JsonValueAs<std::string>(const JsonObject& j) {
   if (j.is_string()) {
-    return std::make_pair(j.get<std::string>(), JsonParserResultDetail::OK);
+    return std::make_pair(j.get_ref<std::string const&>(),
+                          JsonParserResultDetail::OK);
   }
   return std::make_pair(absl::nullopt, JsonParserResultDetail::TYPE_ERROR);
 }

--- a/extensions/common/json_util.cc
+++ b/extensions/common/json_util.cc
@@ -20,21 +20,12 @@
 namespace Wasm {
 namespace Common {
 
-void JsonParser::parse(absl::string_view str) {
-  reset();
+std::pair<JsonObject, JsonParserResultDetail> JsonParse(absl::string_view str) {
   const auto result = JsonObject::parse(str, nullptr, false);
   if (result.empty() || result.is_discarded()) {
-    detail_ = JsonParserResultDetail::PARSE_ERROR;
-    return;
+    return std::make_pair(result, JsonParserResultDetail::PARSE_ERROR);
   }
-  detail_ = JsonParserResultDetail::OK;
-  object_ = result;
-  return;
-}
-
-void JsonParser::reset() {
-  object_ = JsonObject{};
-  detail_ = JsonParserResultDetail::EMPTY;
+  return std::make_pair(result, JsonParserResultDetail::OK);
 }
 
 template <>

--- a/extensions/common/json_util.cc
+++ b/extensions/common/json_util.cc
@@ -20,12 +20,12 @@
 namespace Wasm {
 namespace Common {
 
-::nlohmann::json JsonParse(absl::string_view str, const bool allow_exceptions) {
-  return ::nlohmann::json::parse(str, nullptr, allow_exceptions);
+JsonObject JsonParse(absl::string_view str, const bool allow_exceptions) {
+  return JsonObject::parse(str, nullptr, allow_exceptions);
 }
 
 template <>
-absl::optional<int64_t> JsonValueAs<int64_t>(const ::nlohmann::json& j,
+absl::optional<int64_t> JsonValueAs<int64_t>(const JsonObject& j,
                                              const bool allow_exception) {
   if (j.is_number()) {
     return j.get<int64_t>();
@@ -43,7 +43,7 @@ absl::optional<int64_t> JsonValueAs<int64_t>(const ::nlohmann::json& j,
 }
 
 template <>
-absl::optional<uint64_t> JsonValueAs<uint64_t>(const ::nlohmann::json& j,
+absl::optional<uint64_t> JsonValueAs<uint64_t>(const JsonObject& j,
                                                const bool allow_exception) {
   if (j.is_number()) {
     return j.get<uint64_t>();
@@ -62,7 +62,7 @@ absl::optional<uint64_t> JsonValueAs<uint64_t>(const ::nlohmann::json& j,
 
 template <>
 absl::optional<absl::string_view> JsonValueAs<absl::string_view>(
-    const ::nlohmann::json& j, const bool allow_exception) {
+    const JsonObject& j, const bool allow_exception) {
   if (j.is_string()) {
     return absl::string_view(j.get_ref<std::string const&>());
   }
@@ -74,7 +74,7 @@ absl::optional<absl::string_view> JsonValueAs<absl::string_view>(
 
 template <>
 absl::optional<std::string> JsonValueAs<std::string>(
-    const ::nlohmann::json& j, const bool allow_exception) {
+    const JsonObject& j, const bool allow_exception) {
   if (j.is_string()) {
     return j.get<std::string>();
   }
@@ -85,7 +85,7 @@ absl::optional<std::string> JsonValueAs<std::string>(
 }
 
 template <>
-absl::optional<bool> JsonValueAs<bool>(const ::nlohmann::json& j,
+absl::optional<bool> JsonValueAs<bool>(const JsonObject& j,
                                        const bool allow_exception) {
   if (j.is_boolean()) {
     return j.get<bool>();
@@ -107,8 +107,8 @@ absl::optional<bool> JsonValueAs<bool>(const ::nlohmann::json& j,
 
 template <>
 bool JsonArrayIterate(
-    const ::nlohmann::json& j, absl::string_view field,
-    const std::function<bool(const ::nlohmann::json& elt)>& visitor) {
+    const JsonObject& j, absl::string_view field,
+    const std::function<bool(const JsonObject& elt)>& visitor) {
   auto it = j.find(field);
   if (it == j.end()) {
     return true;
@@ -127,7 +127,7 @@ bool JsonArrayIterate(
 
 template <>
 bool JsonArrayIterate(
-    const ::nlohmann::json& j, absl::string_view field,
+    const JsonObject& j, absl::string_view field,
     const std::function<bool(const std::string& elt)>& visitor) {
   auto it = j.find(field);
   if (it == j.end()) {
@@ -145,7 +145,7 @@ bool JsonArrayIterate(
   return true;
 }
 
-bool JsonObjectIterate(const ::nlohmann::json& j, absl::string_view field,
+bool JsonObjectIterate(const JsonObject& j, absl::string_view field,
                        const std::function<bool(std::string key)>& visitor) {
   auto it = j.find(field);
   if (it == j.end()) {

--- a/extensions/common/json_util.cc
+++ b/extensions/common/json_util.cc
@@ -20,12 +20,12 @@
 namespace Wasm {
 namespace Common {
 
-std::pair<JsonObject, JsonParserResultDetail> JsonParse(absl::string_view str) {
+absl::optional<JsonObject> JsonParse(absl::string_view str) {
   const auto result = JsonObject::parse(str, nullptr, false);
-  if (result.empty() || result.is_discarded()) {
-    return std::make_pair(result, JsonParserResultDetail::PARSE_ERROR);
+  if (result.empty() || result.is_discarded() || !result.is_object()) {
+    return absl::nullopt;
   }
-  return std::make_pair(result, JsonParserResultDetail::OK);
+  return result;
 }
 
 template <>

--- a/extensions/common/json_util.cc
+++ b/extensions/common/json_util.cc
@@ -110,7 +110,6 @@ std::pair<absl::optional<bool>, JsonParserResultDetail> JsonValueAs<bool>(
   return std::make_pair(absl::nullopt, JsonParserResultDetail::TYPE_ERROR);
 }
 
-template <>
 bool JsonArrayIterate(
     const JsonObject& j, absl::string_view field,
     const std::function<bool(const JsonObject& elt)>& visitor) {
@@ -122,27 +121,6 @@ bool JsonArrayIterate(
     return false;
   }
   for (const auto& elt : it.value().items()) {
-    assert(elt.value().is_object());
-    if (!visitor(elt.value())) {
-      return false;
-    }
-  }
-  return true;
-}
-
-template <>
-bool JsonArrayIterate(
-    const JsonObject& j, absl::string_view field,
-    const std::function<bool(const std::string& elt)>& visitor) {
-  auto it = j.find(field);
-  if (it == j.end()) {
-    return true;
-  }
-  if (!it.value().is_array()) {
-    return false;
-  }
-  for (const auto& elt : it.value().items()) {
-    assert(elt.value().is_string());
     if (!visitor(elt.value())) {
       return false;
     }

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -36,18 +36,7 @@ enum JsonParserResultDetail {
   INVALID_VALUE,
 };
 
-class JsonParser {
- public:
-  void parse(absl::string_view str);
-  JsonObject object() { return object_; };
-  const JsonParserResultDetail& detail() { return detail_; }
-
- private:
-  void reset();
-
-  JsonParserResultDetail detail_{JsonParserResultDetail::EMPTY};
-  JsonObject object_{};
-};
+std::pair<JsonObject, JsonParserResultDetail> JsonParse(absl::string_view str);
 
 template <typename T>
 std::pair<absl::optional<T>, JsonParserResultDetail> JsonValueAs(

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -15,8 +15,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "extensions/common/nlohmann_json.hpp"
@@ -27,43 +25,47 @@
 namespace Wasm {
 namespace Common {
 
+using JsonObject = ::nlohmann::json;
+using JsonParserException = ::nlohmann::detail::exception;
+using JsonParserOutOfRangeException = ::nlohmann::detail::out_of_range;
+using JsonParserTypeErrorException = ::nlohmann::detail::type_error;
+
 // Parse JSON. Returns the discarded value if fails.
-::nlohmann::json JsonParse(absl::string_view str,
-                           const bool allow_exceptions = false);
+JsonObject JsonParse(absl::string_view str,
+                     const bool allow_exceptions = false);
 
 template <typename T>
-absl::optional<T> JsonValueAs(const ::nlohmann::json&, const bool) {
+absl::optional<T> JsonValueAs(const JsonObject&, const bool) {
   static_assert(true, "Unsupported Type");
 }
 
 template <>
 absl::optional<absl::string_view> JsonValueAs<absl::string_view>(
-    const ::nlohmann::json& j, const bool allow_exception);
+    const JsonObject& j, const bool allow_exception);
 
 template <>
 absl::optional<std::string> JsonValueAs<std::string>(
-    const ::nlohmann::json& j, const bool allow_exception);
+    const JsonObject& j, const bool allow_exception);
 
 template <>
-absl::optional<int64_t> JsonValueAs<int64_t>(const ::nlohmann::json& j,
+absl::optional<int64_t> JsonValueAs<int64_t>(const JsonObject& j,
                                              const bool allow_exception);
 
 template <>
-absl::optional<uint64_t> JsonValueAs<uint64_t>(const ::nlohmann::json& j,
+absl::optional<uint64_t> JsonValueAs<uint64_t>(const JsonObject& j,
                                                const bool allow_exception);
 
 template <>
-absl::optional<bool> JsonValueAs<bool>(const ::nlohmann::json& j,
+absl::optional<bool> JsonValueAs<bool>(const JsonObject& j,
                                        const bool allow_exception);
 
 template <typename T>
-absl::optional<T> JsonGetField(const ::nlohmann::json& j,
-                               absl::string_view field,
+absl::optional<T> JsonGetField(const JsonObject& j, absl::string_view field,
                                const bool allow_exception = false) {
   auto it = j.find(field);
   if (it == j.end()) {
     if (allow_exception) {
-      throw ::nlohmann::detail::out_of_range::create(
+      throw JsonParserOutOfRangeException::create(
           403, "Key " + std::string(field) + " is not found");
     }
     return absl::nullopt;
@@ -75,31 +77,26 @@ absl::optional<T> JsonGetField(const ::nlohmann::json& j,
 // Returns false if set and not an array, or any of the visitor calls returns
 // false.
 template <typename T>
-bool JsonArrayIterate(const ::nlohmann::json&, absl::string_view,
+bool JsonArrayIterate(const JsonObject&, absl::string_view,
                       const std::function<bool(const T& elt)>&) {
   static_assert(true, "Unsupported type");
 }
 
 template <>
 bool JsonArrayIterate(
-    const ::nlohmann::json& j, absl::string_view field,
-    const std::function<bool(const ::nlohmann::json& elt)>& visitor);
+    const JsonObject& j, absl::string_view field,
+    const std::function<bool(const JsonObject& elt)>& visitor);
 
 template <>
 bool JsonArrayIterate<std::string>(
-    const ::nlohmann::json& j, absl::string_view field,
+    const JsonObject& j, absl::string_view field,
     const std::function<bool(const std::string& elt)>& visitor);
 
 // Iterate over an optional object field key set.
 // Returns false if set and not an object, or any of the visitor calls returns
 // false.
-bool JsonObjectIterate(const ::nlohmann::json& j, absl::string_view field,
+bool JsonObjectIterate(const JsonObject& j, absl::string_view field,
                        const std::function<bool(std::string key)>& visitor);
-
-using JsonObject = ::nlohmann::json;
-using JsonParserException = ::nlohmann::detail::exception;
-using JsonParserOutOfRangeException = ::nlohmann::detail::out_of_range;
-using JsonParserTypeErrorException = ::nlohmann::detail::type_error;
 
 }  // namespace Common
 }  // namespace Wasm

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "extensions/common/nlohmann_json.hpp"
@@ -26,46 +28,78 @@ namespace Wasm {
 namespace Common {
 
 // Parse JSON. Returns the discarded value if fails.
-::nlohmann::json JsonParse(absl::string_view str);
+::nlohmann::json JsonParse(absl::string_view str,
+                           const bool allow_exceptions = false);
 
 template <typename T>
-absl::optional<T> JsonValueAs(const ::nlohmann::json& j);
+absl::optional<T> JsonValueAs(const ::nlohmann::json&, const bool) {
+  static_assert(true, "Unsupported Type");
+}
 
 template <>
 absl::optional<absl::string_view> JsonValueAs<absl::string_view>(
-    const ::nlohmann::json& j);
+    const ::nlohmann::json& j, const bool allow_exception);
 
 template <>
-absl::optional<std::string> JsonValueAs<std::string>(const ::nlohmann::json& j);
+absl::optional<std::string> JsonValueAs<std::string>(
+    const ::nlohmann::json& j, const bool allow_exception);
 
 template <>
-absl::optional<int64_t> JsonValueAs<int64_t>(const ::nlohmann::json& j);
+absl::optional<int64_t> JsonValueAs<int64_t>(const ::nlohmann::json& j,
+                                             const bool allow_exception);
 
 template <>
-absl::optional<bool> JsonValueAs<bool>(const ::nlohmann::json& j);
+absl::optional<uint64_t> JsonValueAs<uint64_t>(const ::nlohmann::json& j,
+                                               const bool allow_exception);
+
+template <>
+absl::optional<bool> JsonValueAs<bool>(const ::nlohmann::json& j,
+                                       const bool allow_exception);
 
 template <typename T>
 absl::optional<T> JsonGetField(const ::nlohmann::json& j,
-                               absl::string_view field) {
+                               absl::string_view field,
+                               const bool allow_exception = false) {
   auto it = j.find(field);
   if (it == j.end()) {
+    if (allow_exception) {
+      throw ::nlohmann::detail::out_of_range::create(
+          403, "Key " + std::string(field) + " is not found");
+    }
     return absl::nullopt;
   }
-  return JsonValueAs<T>(it.value());
+  return JsonValueAs<T>(it.value(), allow_exception);
 }
 
 // Iterate over an optional array field.
 // Returns false if set and not an array, or any of the visitor calls returns
 // false.
+template <typename T>
+bool JsonArrayIterate(const ::nlohmann::json&, absl::string_view,
+                      const std::function<bool(const T& elt)>&) {
+  static_assert(true, "Unsupported type");
+}
+
+template <>
 bool JsonArrayIterate(
     const ::nlohmann::json& j, absl::string_view field,
     const std::function<bool(const ::nlohmann::json& elt)>& visitor);
+
+template <>
+bool JsonArrayIterate<std::string>(
+    const ::nlohmann::json& j, absl::string_view field,
+    const std::function<bool(const std::string& elt)>& visitor);
 
 // Iterate over an optional object field key set.
 // Returns false if set and not an object, or any of the visitor calls returns
 // false.
 bool JsonObjectIterate(const ::nlohmann::json& j, absl::string_view field,
                        const std::function<bool(std::string key)>& visitor);
+
+using JsonObject = ::nlohmann::json;
+using JsonParserException = ::nlohmann::detail::exception;
+using JsonParserOutOfRangeException = ::nlohmann::detail::out_of_range;
+using JsonParserTypeErrorException = ::nlohmann::detail::type_error;
 
 }  // namespace Common
 }  // namespace Wasm

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -28,15 +28,13 @@ namespace Common {
 using JsonObject = ::nlohmann::json;
 
 enum JsonParserResultDetail {
-  EMPTY,
   OK,
   OUT_OF_RANGE,
   TYPE_ERROR,
-  PARSE_ERROR,
   INVALID_VALUE,
 };
 
-std::pair<JsonObject, JsonParserResultDetail> JsonParse(absl::string_view str);
+absl::optional<JsonObject> JsonParse(absl::string_view str);
 
 template <typename T>
 std::pair<absl::optional<T>, JsonParserResultDetail> JsonValueAs(
@@ -69,8 +67,8 @@ class JsonGetField {
  public:
   JsonGetField(const JsonObject& j, absl::string_view field);
   const JsonParserResultDetail& detail() { return detail_; }
-  T fetch() { return object_; }
-  T fetch_or(T v) {
+  T value() { return object_; }
+  T value_or(T v) {
     if (detail_ != JsonParserResultDetail::OK)
       return v;
     else

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -26,10 +26,6 @@ namespace Wasm {
 namespace Common {
 
 using JsonObject = ::nlohmann::json;
-using JsonObjectValueType = ::nlohmann::detail::value_t;
-using JsonParserException = ::nlohmann::detail::exception;
-using JsonParserOutOfRangeException = ::nlohmann::detail::out_of_range;
-using JsonParserTypeErrorException = ::nlohmann::detail::type_error;
 
 enum JsonParserResultDetail {
   EMPTY,

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -117,21 +117,9 @@ JsonGetField<T>::JsonGetField(const JsonObject& j, absl::string_view field) {
 // Iterate over an optional array field.
 // Returns false if set and not an array, or any of the visitor calls returns
 // false.
-template <typename T>
-bool JsonArrayIterate(const JsonObject&, absl::string_view,
-                      const std::function<bool(const T& elt)>&) {
-  static_assert(true, "Unsupported type");
-}
-
-template <>
 bool JsonArrayIterate(
     const JsonObject& j, absl::string_view field,
     const std::function<bool(const JsonObject& elt)>& visitor);
-
-template <>
-bool JsonArrayIterate<std::string>(
-    const JsonObject& j, absl::string_view field,
-    const std::function<bool(const std::string& elt)>& visitor);
 
 // Iterate over an optional object field key set.
 // Returns false if set and not an object, or any of the visitor calls returns

--- a/extensions/common/json_util.h
+++ b/extensions/common/json_util.h
@@ -15,9 +15,6 @@
 
 #pragma once
 
-#include <string>
-#include <utility>
-
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 #include "extensions/common/nlohmann_json.hpp"

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -127,16 +127,21 @@ bool PluginRootContext::configure(size_t configuration_size) {
                                            0, configuration_size);
   // Parse configuration JSON string.
   auto j = ::Wasm::Common::JsonParse(configuration_data->view());
-  if (!j.is_object()) {
+  if (!j.has_value()) {
     LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
-                          configuration_data->view(), j.dump()));
+                          configuration_data->view()));
+    return false;
+  }
+  if (!j->is_object()) {
+    LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
+                          configuration_data->view(), j->dump()));
     return false;
   }
 
-  auto max_peer_cache_size =
-      ::Wasm::Common::JsonGetField<int64_t>(j, "max_peer_cache_size");
-  if (max_peer_cache_size.has_value()) {
-    max_peer_cache_size_ = max_peer_cache_size.value();
+  auto max_peer_cache_size_result =
+      ::Wasm::Common::JsonGetField<int64_t>(j.value(), "max_peer_cache_size");
+  if (max_peer_cache_size_result.first.has_value()) {
+    max_peer_cache_size_ = max_peer_cache_size_result.first.value();
   }
   return true;
 }

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -127,23 +127,18 @@ bool PluginRootContext::configure(size_t configuration_size) {
                                            0, configuration_size);
   // Parse configuration JSON string.
   auto result = ::Wasm::Common::JsonParse(configuration_data->view());
-  if (result.second != ::Wasm::Common::JsonParserResultDetail::OK) {
+  if (!result.has_value()) {
     LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
                           configuration_data->view()));
     return false;
   }
-  auto j = result.first;
-  if (!j.is_object()) {
-    LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
-                          configuration_data->view(), j.dump()));
-    return false;
-  }
 
+  auto j = result.value();
   auto max_peer_cache_size_field =
       ::Wasm::Common::JsonGetField<int64_t>(j, "max_peer_cache_size");
   if (max_peer_cache_size_field.detail() ==
       Wasm::Common::JsonParserResultDetail::OK) {
-    max_peer_cache_size_ = max_peer_cache_size_field.fetch();
+    max_peer_cache_size_ = max_peer_cache_size_field.value();
   }
   return true;
 }

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -142,7 +142,7 @@ bool PluginRootContext::configure(size_t configuration_size) {
 
   auto max_peer_cache_size_field =
       ::Wasm::Common::JsonGetField<int64_t>(j, "max_peer_cache_size");
-  if (max_peer_cache_size_field.detail() !=
+  if (max_peer_cache_size_field.detail() ==
       Wasm::Common::JsonParserResultDetail::OK) {
     max_peer_cache_size_ = max_peer_cache_size_field.fetch();
   }

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -126,23 +126,25 @@ bool PluginRootContext::configure(size_t configuration_size) {
   auto configuration_data = getBufferBytes(WasmBufferType::PluginConfiguration,
                                            0, configuration_size);
   // Parse configuration JSON string.
-  auto j = ::Wasm::Common::JsonParse(configuration_data->view());
-  if (!j.has_value()) {
+  auto parser = ::Wasm::Common::JsonParser();
+  parser.parse(configuration_data->view());
+  if (parser.detail() != ::Wasm::Common::JsonParserResultDetail::OK) {
     LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
                           configuration_data->view()));
     return false;
   }
-  if (!j->is_object()) {
+  auto j = parser.object();
+  if (!j.is_object()) {
     LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
-                          configuration_data->view(), j->dump()));
+                          configuration_data->view(), j.dump()));
     return false;
   }
 
   auto max_peer_cache_size_field =
-      ::Wasm::Common::JsonGetField<int64_t>(j.value(), "max_peer_cache_size");
-  if (max_peer_cache_size_value.detail() !=
+      ::Wasm::Common::JsonGetField<int64_t>(j, "max_peer_cache_size");
+  if (max_peer_cache_size_field.detail() !=
       Wasm::Common::JsonParserResultDetail::OK) {
-    max_peer_cache_size_ = max_peer_cache_size_value.fetch();
+    max_peer_cache_size_ = max_peer_cache_size_field.fetch();
   }
   return true;
 }

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -138,10 +138,11 @@ bool PluginRootContext::configure(size_t configuration_size) {
     return false;
   }
 
-  auto max_peer_cache_size_result =
+  auto max_peer_cache_size_field =
       ::Wasm::Common::JsonGetField<int64_t>(j.value(), "max_peer_cache_size");
-  if (max_peer_cache_size_result.first.has_value()) {
-    max_peer_cache_size_ = max_peer_cache_size_result.first.value();
+  if (max_peer_cache_size_value.detail() !=
+      Wasm::Common::JsonParserResultDetail::OK) {
+    max_peer_cache_size_ = max_peer_cache_size_value.fetch();
   }
   return true;
 }

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -126,14 +126,13 @@ bool PluginRootContext::configure(size_t configuration_size) {
   auto configuration_data = getBufferBytes(WasmBufferType::PluginConfiguration,
                                            0, configuration_size);
   // Parse configuration JSON string.
-  auto parser = ::Wasm::Common::JsonParser();
-  parser.parse(configuration_data->view());
-  if (parser.detail() != ::Wasm::Common::JsonParserResultDetail::OK) {
+  auto result = ::Wasm::Common::JsonParse(configuration_data->view());
+  if (result.second != ::Wasm::Common::JsonParserResultDetail::OK) {
     LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
                           configuration_data->view()));
     return false;
   }
-  auto j = parser.object();
+  auto j = result.first;
   if (!j.is_object()) {
     LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
                           configuration_data->view(), j.dump()));

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -264,9 +264,9 @@ bool PluginRootContext::initializeDimensions(const json& j) {
 
   // Process the metric definitions (overriding existing).
   if (!JsonArrayIterate(j, "definitions", [&](const json& definition) -> bool {
-        auto name = JsonGetField<std::string>(definition, "name").fetch_or("");
+        auto name = JsonGetField<std::string>(definition, "name").value_or("");
         auto value =
-            JsonGetField<std::string>(definition, "value").fetch_or("");
+            JsonGetField<std::string>(definition, "value").value_or("");
         if (name.empty() || value.empty()) {
           LOG_WARN("empty name or value in  'definitions'");
           return false;
@@ -290,7 +290,7 @@ bool PluginRootContext::initializeDimensions(const json& j) {
         };
         factory.type = MetricType::Counter;
         auto type =
-            JsonGetField<absl::string_view>(definition, "type").fetch_or("");
+            JsonGetField<absl::string_view>(definition, "type").value_or("");
         if (type == "GAUGE") {
           factory.type = MetricType::Gauge;
         } else if (type == "HISTOGRAM") {
@@ -315,7 +315,7 @@ bool PluginRootContext::initializeDimensions(const json& j) {
         }
         std::sort(tags.begin(), tags.end());
 
-        auto name = JsonGetField<std::string>(metric, "name").fetch_or("");
+        auto name = JsonGetField<std::string>(metric, "name").value_or("");
         for (const auto& factory_it : factories) {
           if (!name.empty() && name != factory_it.first) {
             continue;
@@ -381,11 +381,11 @@ bool PluginRootContext::initializeDimensions(const json& j) {
 
   // Instantiate stat factories using the new dimensions
   auto field_separator = JsonGetField<std::string>(j, "field_separator")
-                             .fetch_or(default_field_separator);
+                             .value_or(default_field_separator);
   auto value_separator = JsonGetField<std::string>(j, "value_separator")
-                             .fetch_or(default_value_separator);
+                             .value_or(default_value_separator);
   auto stat_prefix =
-      JsonGetField<std::string>(j, "stat_prefix").fetch_or(default_stat_prefix);
+      JsonGetField<std::string>(j, "stat_prefix").value_or(default_stat_prefix);
 
   // prepend "_" to opt out of automatic namespacing
   // If "_" is not prepended, envoy_ is automatically added by prometheus
@@ -439,13 +439,13 @@ bool PluginRootContext::configure(size_t configuration_size) {
               ::Wasm::Common::getTrafficDirection();
 
   auto result = ::Wasm::Common::JsonParse(configuration_data->view());
-  auto j = result.first;
-  if (!j.is_object()) {
-    LOG_WARN(absl::StrCat("cannot parse configuration as JSON: ",
+  if (!result.has_value()) {
+    LOG_WARN(absl::StrCat("cannot parse plugin configuration JSON string: ",
                           configuration_data->view()));
     return false;
   }
 
+  auto j = result.value();
   if (outbound_) {
     peer_metadata_id_key_ = ::Wasm::Common::kUpstreamMetadataIdKey;
     peer_metadata_key_ = ::Wasm::Common::kUpstreamMetadataKey;
@@ -454,9 +454,9 @@ bool PluginRootContext::configure(size_t configuration_size) {
     peer_metadata_key_ = ::Wasm::Common::kDownstreamMetadataKey;
   }
 
-  debug_ = JsonGetField<bool>(j, "debug").fetch_or(false);
+  debug_ = JsonGetField<bool>(j, "debug").value_or(false);
   use_host_header_fallback_ =
-      !JsonGetField<bool>(j, "disable_host_header_fallback").fetch_or(false);
+      !JsonGetField<bool>(j, "disable_host_header_fallback").value_or(false);
 
   if (!initializeDimensions(j)) {
     return false;
@@ -468,11 +468,11 @@ bool PluginRootContext::configure(size_t configuration_size) {
   absl::Duration duration;
   if (tcp_reporting_duration_field.detail() ==
       ::Wasm::Common::JsonParserResultDetail::OK) {
-    if (absl::ParseDuration(tcp_reporting_duration_field.fetch(), &duration)) {
+    if (absl::ParseDuration(tcp_reporting_duration_field.value(), &duration)) {
       tcp_report_duration_milis = uint32_t(duration / absl::Milliseconds(1));
     } else {
       LOG_WARN(absl::StrCat("failed to parse 'tcp_reporting_duration': ",
-                            tcp_reporting_duration_field.fetch()));
+                            tcp_reporting_duration_field.value()));
     }
   }
   proxy_set_tick_period_milliseconds(tcp_report_duration_milis);

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -263,48 +263,46 @@ bool PluginRootContext::initializeDimensions(const json& j) {
   }
 
   // Process the metric definitions (overriding existing).
-  if (!JsonArrayIterate<json>(
-          j, "definitions", [&](const json& definition) -> bool {
-            auto name =
-                JsonGetField<std::string>(definition, "name").fetch_or("");
-            auto value =
-                JsonGetField<std::string>(definition, "value").fetch_or("");
-            if (name.empty() || value.empty()) {
-              LOG_WARN("empty name or value in  'definitions'");
-              return false;
-            }
-            auto token = addIntExpression(value);
-            if (!token.has_value()) {
-              LOG_WARN(absl::StrCat("failed to construct expression: ", value));
-              return false;
-            }
-            auto& factory = factories[name];
-            factory.name = name;
-            factory.extractor =
-                [token, name,
-                 value](const ::Wasm::Common::RequestInfo&) -> uint64_t {
-              int64_t result = 0;
-              if (!evaluateExpression(token.value(), &result)) {
-                LOG_TRACE(absl::StrCat("Failed to evaluate expression: <",
-                                       value, "> for dimension:<", name, ">"));
-              }
-              return result;
-            };
-            factory.type = MetricType::Counter;
-            auto type = JsonGetField<absl::string_view>(definition, "type")
-                            .fetch_or("");
-            if (type == "GAUGE") {
-              factory.type = MetricType::Gauge;
-            } else if (type == "HISTOGRAM") {
-              factory.type = MetricType::Histogram;
-            }
-            return true;
-          })) {
+  if (!JsonArrayIterate(j, "definitions", [&](const json& definition) -> bool {
+        auto name = JsonGetField<std::string>(definition, "name").fetch_or("");
+        auto value =
+            JsonGetField<std::string>(definition, "value").fetch_or("");
+        if (name.empty() || value.empty()) {
+          LOG_WARN("empty name or value in  'definitions'");
+          return false;
+        }
+        auto token = addIntExpression(value);
+        if (!token.has_value()) {
+          LOG_WARN(absl::StrCat("failed to construct expression: ", value));
+          return false;
+        }
+        auto& factory = factories[name];
+        factory.name = name;
+        factory.extractor =
+            [token, name,
+             value](const ::Wasm::Common::RequestInfo&) -> uint64_t {
+          int64_t result = 0;
+          if (!evaluateExpression(token.value(), &result)) {
+            LOG_TRACE(absl::StrCat("Failed to evaluate expression: <", value,
+                                   "> for dimension:<", name, ">"));
+          }
+          return result;
+        };
+        factory.type = MetricType::Counter;
+        auto type =
+            JsonGetField<absl::string_view>(definition, "type").fetch_or("");
+        if (type == "GAUGE") {
+          factory.type = MetricType::Gauge;
+        } else if (type == "HISTOGRAM") {
+          factory.type = MetricType::Histogram;
+        }
+        return true;
+      })) {
     LOG_WARN("failed to parse 'definitions'");
   }
 
   // Process the dimension overrides.
-  if (!JsonArrayIterate<json>(j, "metrics", [&](const json& metric) -> bool {
+  if (!JsonArrayIterate(j, "metrics", [&](const json& metric) -> bool {
         // Sort tag override tags to keep the order of tags deterministic.
         std::vector<std::string> tags;
         if (!JsonObjectIterate(metric, "dimensions",
@@ -325,7 +323,7 @@ bool PluginRootContext::initializeDimensions(const json& j) {
           auto& indexes = metric_indexes[factory_it.first];
 
           // Process tag deletions.
-          if (!JsonArrayIterate<json>(
+          if (!JsonArrayIterate(
                   metric, "tags_to_remove", [&](const json& tag) -> bool {
                     auto tag_string = JsonValueAs<std::string>(tag);
                     if (tag_string.second !=

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -438,9 +438,8 @@ bool PluginRootContext::configure(size_t configuration_size) {
   outbound_ = ::Wasm::Common::TrafficDirection::Outbound ==
               ::Wasm::Common::getTrafficDirection();
 
-  auto json_parser = ::Wasm::Common::JsonParser();
-  json_parser.parse(configuration_data->view());
-  auto j = json_parser.object();
+  auto result = ::Wasm::Common::JsonParse(configuration_data->view());
+  auto j = result.first;
   if (!j.is_object()) {
     LOG_WARN(absl::StrCat("cannot parse configuration as JSON: ",
                           configuration_data->view()));

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -469,7 +469,8 @@ bool PluginRootContext::configure(size_t configuration_size) {
   auto tcp_reporting_duration_field =
       JsonGetField<std::string>(j, "tcp_reporting_duration");
   absl::Duration duration;
-  if (tcp_reporting_duration_field.detail() == ::Wasm::Common::JsonParserResultDetail::OK) {
+  if (tcp_reporting_duration_field.detail() ==
+      ::Wasm::Common::JsonParserResultDetail::OK) {
     if (absl::ParseDuration(tcp_reporting_duration_field.fetch(), &duration)) {
       tcp_report_duration_milis = uint32_t(duration / absl::Milliseconds(1));
     } else {

--- a/src/envoy/http/jwt_auth/BUILD
+++ b/src/envoy/http/jwt_auth/BUILD
@@ -29,11 +29,11 @@ envoy_cc_library(
     srcs = ["jwt.cc"],
     hdrs = ["jwt.h"],
     external_deps = [
-        "rapidjson",
         "ssl",
     ],
     repository = "@envoy",
     deps = [
+        "//extensions/common:json_util",
         "@envoy//source/exe:envoy_common_lib",
     ],
 )

--- a/src/envoy/http/jwt_auth/jwt.cc
+++ b/src/envoy/http/jwt_auth/jwt.cc
@@ -318,9 +318,14 @@ Jwt::Jwt(const std::string &jwt) {
 
   // "aud" can be either string array or string.
   // Try as string array, read it as empty array if doesn't exist.
-  if (!Wasm::Common::JsonArrayIterate<std::string>(
-          payload_, "aud", [&](const std::string &obj) -> bool {
-            aud_.emplace_back(obj);
+  if (!Wasm::Common::JsonArrayIterate(
+          payload_, "aud", [&](const Wasm::Common::JsonObject &obj) -> bool {
+            auto str_obj_result = Wasm::Common::JsonValueAs<std::string>(obj);
+            if (str_obj_result.second !=
+                Wasm::Common::JsonParserResultDetail::OK) {
+              return false;
+            }
+            aud_.emplace_back(str_obj_result.first.value());
             return true;
           })) {
     auto aud_field = Wasm::Common::JsonGetField<std::string>(payload_, "aud");
@@ -504,7 +509,7 @@ void Pubkeys::CreateFromJwksCore(const std::string &pkey_jwks) {
     return;
   }
 
-  if (!Wasm::Common::JsonArrayIterate<Wasm::Common::JsonObject>(
+  if (!Wasm::Common::JsonArrayIterate(
           jwks_json, "keys", [&](const Wasm::Common::JsonObject &obj) -> bool {
             key_refs.emplace_back(
                 std::reference_wrapper<const Wasm::Common::JsonObject>(obj));

--- a/src/envoy/http/jwt_auth/jwt.cc
+++ b/src/envoy/http/jwt_auth/jwt.cc
@@ -251,16 +251,15 @@ Jwt::Jwt(const std::string &jwt) {
   }
 
   // Parse header json
-  auto parser = Wasm::Common::JsonParser();
   header_str_base64url_ = std::string(jwt_split[0].begin(), jwt_split[0].end());
   header_str_ = Base64UrlDecode(header_str_base64url_);
 
-  parser.parse(header_str_);
-  if (parser.detail() != Wasm::Common::JsonParserResultDetail::OK) {
+  auto result = Wasm::Common::JsonParse(header_str_);
+  if (result.second != Wasm::Common::JsonParserResultDetail::OK) {
     UpdateStatus(Status::JWT_HEADER_PARSE_ERROR);
     return;
   } else {
-    header_ = parser.object();
+    header_ = result.first;
   }
 
   // Header should contain "alg".
@@ -303,12 +302,12 @@ Jwt::Jwt(const std::string &jwt) {
   payload_str_base64url_ =
       std::string(jwt_split[1].begin(), jwt_split[1].end());
   payload_str_ = Base64UrlDecode(payload_str_base64url_);
-  parser.parse(payload_str_);
-  if (parser.detail() != Wasm::Common::JsonParserResultDetail::OK) {
+  result = Wasm::Common::JsonParse(payload_str_);
+  if (result.second != Wasm::Common::JsonParserResultDetail::OK) {
     UpdateStatus(Status::JWT_PAYLOAD_PARSE_ERROR);
     return;
   } else {
-    payload_ = parser.object();
+    payload_ = result.first;
   }
 
   iss_ = Wasm::Common::JsonGetField<std::string>(payload_, "iss").fetch_or("");
@@ -491,14 +490,13 @@ void Pubkeys::CreateFromPemCore(const std::string &pkey_pem) {
 void Pubkeys::CreateFromJwksCore(const std::string &pkey_jwks) {
   keys_.clear();
 
-  auto parser = Wasm::Common::JsonParser();
   Wasm::Common::JsonObject jwks_json;
-  parser.parse(pkey_jwks);
-  if (parser.detail() != Wasm::Common::JsonParserResultDetail::OK) {
+  auto result = Wasm::Common::JsonParse(pkey_jwks);
+  if (result.second != Wasm::Common::JsonParserResultDetail::OK) {
     UpdateStatus(Status::JWK_PARSE_ERROR);
     return;
   } else {
-    jwks_json = parser.object();
+    jwks_json = result.first;
   }
 
   std::vector<std::reference_wrapper<const Wasm::Common::JsonObject>> key_refs;

--- a/src/envoy/http/jwt_auth/jwt.cc
+++ b/src/envoy/http/jwt_auth/jwt.cc
@@ -26,7 +26,6 @@
 #include "common/common/assert.h"
 #include "common/common/base64.h"
 #include "common/common/utility.h"
-#include "common/json/json_loader.h"
 #include "openssl/bn.h"
 #include "openssl/ecdsa.h"
 #include "openssl/evp.h"

--- a/src/envoy/http/jwt_auth/jwt.cc
+++ b/src/envoy/http/jwt_auth/jwt.cc
@@ -255,12 +255,11 @@ Jwt::Jwt(const std::string &jwt) {
   header_str_ = Base64UrlDecode(header_str_base64url_);
 
   auto result = Wasm::Common::JsonParse(header_str_);
-  if (result.second != Wasm::Common::JsonParserResultDetail::OK) {
+  if (!result.has_value()) {
     UpdateStatus(Status::JWT_HEADER_PARSE_ERROR);
     return;
-  } else {
-    header_ = result.first;
   }
+  header_ = result.value();
 
   // Header should contain "alg".
   if (header_.find("alg") == header_.end()) {
@@ -273,7 +272,7 @@ Jwt::Jwt(const std::string &jwt) {
     UpdateStatus(Status::JWT_HEADER_BAD_ALG);
     return;
   }
-  alg_ = alg_field.fetch();
+  alg_ = alg_field.value();
 
   if (alg_ != "RS256" && alg_ != "ES256" && alg_ != "RS384" &&
       alg_ != "RS512") {
@@ -295,7 +294,7 @@ Jwt::Jwt(const std::string &jwt) {
       return;
     }
   } else {
-    kid_ = kid_field.fetch();
+    kid_ = kid_field.value();
   }
 
   // Parse payload json
@@ -303,16 +302,15 @@ Jwt::Jwt(const std::string &jwt) {
       std::string(jwt_split[1].begin(), jwt_split[1].end());
   payload_str_ = Base64UrlDecode(payload_str_base64url_);
   result = Wasm::Common::JsonParse(payload_str_);
-  if (result.second != Wasm::Common::JsonParserResultDetail::OK) {
+  if (!result.has_value()) {
     UpdateStatus(Status::JWT_PAYLOAD_PARSE_ERROR);
     return;
-  } else {
-    payload_ = result.first;
   }
+  payload_ = result.value();
 
-  iss_ = Wasm::Common::JsonGetField<std::string>(payload_, "iss").fetch_or("");
-  sub_ = Wasm::Common::JsonGetField<std::string>(payload_, "sub").fetch_or("");
-  exp_ = Wasm::Common::JsonGetField<uint64_t>(payload_, "exp").fetch_or(0);
+  iss_ = Wasm::Common::JsonGetField<std::string>(payload_, "iss").value_or("");
+  sub_ = Wasm::Common::JsonGetField<std::string>(payload_, "sub").value_or("");
+  exp_ = Wasm::Common::JsonGetField<uint64_t>(payload_, "exp").value_or(0);
 
   // "aud" can be either string array or string.
   // Try as string array, read it as empty array if doesn't exist.
@@ -331,7 +329,7 @@ Jwt::Jwt(const std::string &jwt) {
       UpdateStatus(Status::JWT_PAYLOAD_PARSE_ERROR);
       return;
     }
-    aud_.emplace_back(aud_field.fetch());
+    aud_.emplace_back(aud_field.value());
   }
 
   // Set up signature
@@ -492,12 +490,11 @@ void Pubkeys::CreateFromJwksCore(const std::string &pkey_jwks) {
 
   Wasm::Common::JsonObject jwks_json;
   auto result = Wasm::Common::JsonParse(pkey_jwks);
-  if (result.second != Wasm::Common::JsonParserResultDetail::OK) {
+  if (!result.has_value()) {
     UpdateStatus(Status::JWK_PARSE_ERROR);
     return;
-  } else {
-    jwks_json = result.first;
   }
+  jwks_json = result.value();
 
   std::vector<std::reference_wrapper<const Wasm::Common::JsonObject>> key_refs;
 
@@ -538,9 +535,9 @@ bool Pubkeys::ExtractPubkeyFromJwk(const Wasm::Common::JsonObject &jwk_json) {
 
   // Extract public key according to "kty" value.
   // https://tools.ietf.org/html/rfc7518#section-6.1
-  if (kty_field.fetch() == "EC") {
+  if (kty_field.value() == "EC") {
     return ExtractPubkeyFromJwkEC(jwk_json);
-  } else if (kty_field.fetch() == "RSA") {
+  } else if (kty_field.value() == "RSA") {
     return ExtractPubkeyFromJwkRSA(jwk_json);
   }
 
@@ -556,7 +553,7 @@ bool Pubkeys::ExtractPubkeyFromJwkRSA(
   // https://tools.ietf.org/html/rfc7517#page-8
   auto kid_field = Wasm::Common::JsonGetField<std::string>(jwk_json, "kid");
   if (kid_field.detail() == Wasm::Common::JsonParserResultDetail::OK) {
-    pubkey->kid_ = kid_field.fetch();
+    pubkey->kid_ = kid_field.value();
     pubkey->kid_specified_ = true;
   }
 
@@ -564,26 +561,26 @@ bool Pubkeys::ExtractPubkeyFromJwkRSA(
   if (alg_field.detail() == Wasm::Common::JsonParserResultDetail::OK) {
     // Allow only "RS" prefixed algorithms.
     // https://tools.ietf.org/html/rfc7518#section-3.1
-    if (!(alg_field.fetch() == "RS256" || alg_field.fetch() == "RS384" ||
-          alg_field.fetch() == "RS512")) {
+    if (!(alg_field.value() == "RS256" || alg_field.value() == "RS384" ||
+          alg_field.value() == "RS512")) {
       return false;
     }
-    pubkey->alg_ = alg_field.fetch();
+    pubkey->alg_ = alg_field.value();
     pubkey->alg_specified_ = true;
   }
 
   auto pubkey_kty_field =
       Wasm::Common::JsonGetField<std::string>(jwk_json, "kty");
   assert(pubkey_kty_field.detail() == Wasm::Common::JsonParserResultDetail::OK);
-  pubkey->kty_ = pubkey_kty_field.fetch();
+  pubkey->kty_ = pubkey_kty_field.value();
   auto n_str_field = Wasm::Common::JsonGetField<std::string>(jwk_json, "n");
   auto e_str_field = Wasm::Common::JsonGetField<std::string>(jwk_json, "e");
   if (n_str_field.detail() != Wasm::Common::JsonParserResultDetail::OK ||
       e_str_field.detail() != Wasm::Common::JsonParserResultDetail::OK) {
     return false;
   }
-  n_str = n_str_field.fetch();
-  e_str = e_str_field.fetch();
+  n_str = n_str_field.value();
+  e_str = e_str_field.value();
 
   EvpPkeyGetter e;
   pubkey->evp_pkey_ = e.EvpPkeyFromJwkRSA(n_str, e_str);
@@ -604,7 +601,7 @@ bool Pubkeys::ExtractPubkeyFromJwkEC(const Wasm::Common::JsonObject &jwk_json) {
   // https://tools.ietf.org/html/rfc7517#page-8
   auto kid_field = Wasm::Common::JsonGetField<std::string>(jwk_json, "kid");
   if (kid_field.detail() == Wasm::Common::JsonParserResultDetail::OK) {
-    pubkey->kid_ = kid_field.fetch();
+    pubkey->kid_ = kid_field.value();
     pubkey->kid_specified_ = true;
   }
 
@@ -612,25 +609,25 @@ bool Pubkeys::ExtractPubkeyFromJwkEC(const Wasm::Common::JsonObject &jwk_json) {
   if (alg_field.detail() == Wasm::Common::JsonParserResultDetail::OK) {
     // Allow only "RS" prefixed algorithms.
     // https://tools.ietf.org/html/rfc7518#section-3.1
-    if (alg_field.fetch() != "ES256") {
+    if (alg_field.value() != "ES256") {
       return false;
     }
-    pubkey->alg_ = alg_field.fetch();
+    pubkey->alg_ = alg_field.value();
     pubkey->alg_specified_ = true;
   }
 
   auto pubkey_kty_field =
       Wasm::Common::JsonGetField<std::string>(jwk_json, "kty");
   assert(pubkey_kty_field.detail() == Wasm::Common::JsonParserResultDetail::OK);
-  pubkey->kty_ = pubkey_kty_field.fetch();
+  pubkey->kty_ = pubkey_kty_field.value();
   auto x_str_field = Wasm::Common::JsonGetField<std::string>(jwk_json, "x");
   auto y_str_field = Wasm::Common::JsonGetField<std::string>(jwk_json, "y");
   if (x_str_field.detail() != Wasm::Common::JsonParserResultDetail::OK ||
       y_str_field.detail() != Wasm::Common::JsonParserResultDetail::OK) {
     return false;
   }
-  x_str = x_str_field.fetch();
-  y_str = y_str_field.fetch();
+  x_str = x_str_field.value();
+  y_str = y_str_field.value();
 
   EvpPkeyGetter e;
   pubkey->ec_key_ = e.EcKeyFromJwkEC(x_str, y_str);

--- a/src/envoy/http/jwt_auth/jwt.h
+++ b/src/envoy/http/jwt_auth/jwt.h
@@ -15,11 +15,12 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "envoy/json/json_object.h"
+#include "extensions/common/json_util.h"
 #include "openssl/ec.h"
 #include "openssl/evp.h"
 
@@ -190,7 +191,7 @@ class Jwt : public WithStatus {
   // It returns a pointer to a JSON object of the header of the given JWT.
   // When the given JWT has a format error, it returns nullptr.
   // It returns the header JSON even if the signature is invalid.
-  Json::ObjectSharedPtr Header();
+  Wasm::Common::JsonObject& Header();
 
   // They return a string (or base64url-encoded string) of the header JSON of
   // the given JWT.
@@ -207,7 +208,7 @@ class Jwt : public WithStatus {
   // It returns a pointer to a JSON object of the payload of the given JWT.
   // When the given jWT has a format error, it returns nullptr.
   // It returns the payload JSON even if the signature is invalid.
-  Json::ObjectSharedPtr Payload();
+  Wasm::Common::JsonObject& Payload();
 
   // They return a string (or base64url-encoded string) of the payload JSON of
   // the given JWT.
@@ -231,10 +232,10 @@ class Jwt : public WithStatus {
   int64_t Exp();
 
  private:
-  Json::ObjectSharedPtr header_;
+  Wasm::Common::JsonObject header_;
   std::string header_str_;
   std::string header_str_base64url_;
-  Json::ObjectSharedPtr payload_;
+  Wasm::Common::JsonObject payload_;
   std::string payload_str_;
   std::string payload_str_base64url_;
   std::string signature_;
@@ -270,9 +271,9 @@ class Pubkeys : public WithStatus {
   void CreateFromPemCore(const std::string& pkey_pem);
   void CreateFromJwksCore(const std::string& pkey_jwks);
   // Extracts the public key from a jwk key (jkey) and sets it to keys_;
-  void ExtractPubkeyFromJwk(Json::ObjectSharedPtr jwk_json);
-  void ExtractPubkeyFromJwkRSA(Json::ObjectSharedPtr jwk_json);
-  void ExtractPubkeyFromJwkEC(Json::ObjectSharedPtr jwk_json);
+  bool ExtractPubkeyFromJwk(const Wasm::Common::JsonObject& jwk_json);
+  bool ExtractPubkeyFromJwkRSA(const Wasm::Common::JsonObject& jwk_json);
+  bool ExtractPubkeyFromJwkEC(const Wasm::Common::JsonObject& jwk_json);
 
   class Pubkey {
    public:

--- a/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_authenticator_test.cc
@@ -16,7 +16,6 @@
 #include "src/envoy/http/jwt_auth/jwt_authenticator.h"
 
 #include "common/http/message_impl.h"
-#include "common/json/json_loader.h"
 #include "gtest/gtest.h"
 #include "test/mocks/upstream/mocks.h"
 #include "test/test_common/utility.h"

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -537,8 +537,6 @@ class JwtTest : public testing::Test {
       EXPECT_TRUE(EqJson(*payload, jwt.Payload()));
     }
   }
-
-  Wasm::Common::JsonParser parser_;
 };
 
 // Test cases w/ PEM-formatted public key
@@ -549,20 +547,20 @@ class JwtTestPem : public JwtTest {
 };
 
 TEST_F(JwtTestPem, OK) {
-  parser_.parse(ds.kJwtPayload);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
+  auto payload = result.first;
   DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs384) {
-  parser_.parse(ds.kJwtPayload);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
+  auto payload = result.first;
   DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs512) {
-  parser_.parse(ds.kJwtPayload);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
+  auto payload = result.first;
   DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
@@ -677,14 +675,14 @@ class JwtTestJwks : public JwtTest {
 };
 
 TEST_F(JwtTestJwks, OkNoKid) {
-  parser_.parse(ds.kJwtPayload);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
+  auto payload = result.first;
   DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
-  parser_.parse(ds.kJwtPayload);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
+  auto payload = result.first;
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"RS256\",";
   std::string pubkey_no_alg = ds.kPublicKeyRSA;
@@ -709,15 +707,15 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
 }
 
 TEST_F(JwtTestJwks, OkNoKidLogExp) {
-  parser_.parse(ds.kJwtPayloadLongExp);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp);
+  auto payload = result.first;
   DoTest(ds.kJwtNoKidLongExp, ds.kPublicKeyRSA, "jwks", true, Status::OK,
          &payload);
 }
 
 TEST_F(JwtTestJwks, OkCorrectKid) {
-  parser_.parse(ds.kJwtPayload);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
+  auto payload = result.first;
   DoTest(ds.kJwtWithCorrectKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
          &payload);
 }
@@ -762,8 +760,8 @@ TEST_F(JwtTestJwks, JwkBadPublicKey) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkEC) {
-  parser_.parse(ds.kJwtPayloadEC);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
+  auto payload = result.first;
   // ES256-signed token with kid specified.
   DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK, &payload);
   // ES256-signed token without kid specified.
@@ -772,8 +770,8 @@ TEST_F(JwtTestJwks, OkTokenJwkEC) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
-  parser_.parse(ds.kJwtPayloadEC);
-  auto payload = parser_.object();
+  auto result = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
+  auto payload = result.first;
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"ES256\",";
   std::string pubkey_no_alg = ds.kPublicKeyJwkEC;

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -537,6 +537,8 @@ class JwtTest : public testing::Test {
       EXPECT_TRUE(EqJson(*payload, jwt.Payload()));
     }
   }
+
+  Wasm::Common::JsonParser parser_;
 };
 
 // Test cases w/ PEM-formatted public key
@@ -547,20 +549,21 @@ class JwtTestPem : public JwtTest {
 };
 
 TEST_F(JwtTestPem, OK) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
-  DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload.value());
+  parser_.parse(ds.kJwtPayload);
+  auto payload = parser_.object();
+  DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs384) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
-  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK,
-         &payload.value());
+  parser_.parse(ds.kJwtPayload);
+  auto payload = parser_.object();
+  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs512) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
-  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK,
-         &payload.value());
+  parser_.parse(ds.kJwtPayload);
+  auto payload = parser_.object();
+  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, MultiAudiences) {
@@ -674,13 +677,14 @@ class JwtTestJwks : public JwtTest {
 };
 
 TEST_F(JwtTestJwks, OkNoKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
-  DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         &payload.value());
+  parser_.parse(ds.kJwtPayload);
+  auto payload = parser_.object();
+  DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
+  parser_.parse(ds.kJwtPayload);
+  auto payload = parser_.object();
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"RS256\",";
   std::string pubkey_no_alg = ds.kPublicKeyRSA;
@@ -689,8 +693,7 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
     pubkey_no_alg.erase(alg_pos, alg_claim.length());
     alg_pos = pubkey_no_alg.find(alg_claim);
   }
-  DoTest(ds.kJwtNoKid, pubkey_no_alg, "jwks", true, Status::OK,
-         &payload.value());
+  DoTest(ds.kJwtNoKid, pubkey_no_alg, "jwks", true, Status::OK, &payload);
 
   // Remove "kid" claim from public key.
   std::string kid_claim1 =
@@ -702,20 +705,21 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
   pubkey_no_kid.erase(kid_pos, kid_claim1.length());
   kid_pos = pubkey_no_kid.find(kid_claim2);
   pubkey_no_kid.erase(kid_pos, kid_claim2.length());
-  DoTest(ds.kJwtNoKid, pubkey_no_kid, "jwks", true, Status::OK,
-         &payload.value());
+  DoTest(ds.kJwtNoKid, pubkey_no_kid, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, OkNoKidLogExp) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp);
+  parser_.parse(ds.kJwtPayloadLongExp);
+  auto payload = parser_.object();
   DoTest(ds.kJwtNoKidLongExp, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         &payload.value());
+         &payload);
 }
 
 TEST_F(JwtTestJwks, OkCorrectKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
+  parser_.parse(ds.kJwtPayload);
+  auto payload = parser_.object();
   DoTest(ds.kJwtWithCorrectKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         &payload.value());
+         &payload);
 }
 
 TEST_F(JwtTestJwks, IncorrectKid) {
@@ -758,17 +762,18 @@ TEST_F(JwtTestJwks, JwkBadPublicKey) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkEC) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
+  parser_.parse(ds.kJwtPayloadEC);
+  auto payload = parser_.object();
   // ES256-signed token with kid specified.
-  DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK,
-         &payload.value());
+  DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK, &payload);
   // ES256-signed token without kid specified.
   DoTest(ds.kTokenECNoKid, ds.kPublicKeyJwkEC, "jwks", true, Status::OK,
-         &payload.value());
+         &payload);
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
+  parser_.parse(ds.kJwtPayloadEC);
+  auto payload = parser_.object();
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"ES256\",";
   std::string pubkey_no_alg = ds.kPublicKeyJwkEC;
@@ -777,8 +782,7 @@ TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
     pubkey_no_alg.erase(alg_pos, alg_claim.length());
     alg_pos = pubkey_no_alg.find(alg_claim);
   }
-  DoTest(ds.kTokenEC, pubkey_no_alg, "jwks", true, Status::OK,
-         &payload.value());
+  DoTest(ds.kTokenEC, pubkey_no_alg, "jwks", true, Status::OK, &payload);
 
   // Remove "kid" claim from public key.
   std::string kid_claim1 = ",\"kid\": \"abc\"";
@@ -788,8 +792,7 @@ TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
   pubkey_no_kid.erase(kid_pos, kid_claim1.length());
   kid_pos = pubkey_no_kid.find(kid_claim2);
   pubkey_no_kid.erase(kid_pos, kid_claim2.length());
-  DoTest(ds.kTokenEC, pubkey_no_kid, "jwks", true, Status::OK,
-         &payload.value());
+  DoTest(ds.kTokenEC, pubkey_no_kid, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, NonExistKidEC) {

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -547,20 +547,17 @@ class JwtTestPem : public JwtTest {
 };
 
 TEST_F(JwtTestPem, OK) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload).value();
   DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs384) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload).value();
   DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs512) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload).value();
   DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
@@ -675,14 +672,12 @@ class JwtTestJwks : public JwtTest {
 };
 
 TEST_F(JwtTestJwks, OkNoKid) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload).value();
   DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload).value();
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"RS256\",";
   std::string pubkey_no_alg = ds.kPublicKeyRSA;
@@ -707,15 +702,13 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
 }
 
 TEST_F(JwtTestJwks, OkNoKidLogExp) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp).value();
   DoTest(ds.kJwtNoKidLongExp, ds.kPublicKeyRSA, "jwks", true, Status::OK,
          &payload);
 }
 
 TEST_F(JwtTestJwks, OkCorrectKid) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayload);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload).value();
   DoTest(ds.kJwtWithCorrectKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
          &payload);
 }
@@ -760,8 +753,7 @@ TEST_F(JwtTestJwks, JwkBadPublicKey) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkEC) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC).value();
   // ES256-signed token with kid specified.
   DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK, &payload);
   // ES256-signed token without kid specified.
@@ -770,8 +762,7 @@ TEST_F(JwtTestJwks, OkTokenJwkEC) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
-  auto result = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
-  auto payload = result.first;
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC).value();
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"ES256\",";
   std::string pubkey_no_alg = ds.kPublicKeyJwkEC;

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -547,18 +547,20 @@ class JwtTestPem : public JwtTest {
 };
 
 TEST_F(JwtTestPem, OK) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
-  DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
+  DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload.value());
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs384) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
-  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, &payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
+  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK,
+         &payload.value());
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs512) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
-  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, &payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
+  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK,
+         &payload.value());
 }
 
 TEST_F(JwtTestPem, MultiAudiences) {
@@ -672,12 +674,13 @@ class JwtTestJwks : public JwtTest {
 };
 
 TEST_F(JwtTestJwks, OkNoKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
-  DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK, &payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
+  DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
+         &payload.value());
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"RS256\",";
   std::string pubkey_no_alg = ds.kPublicKeyRSA;
@@ -686,7 +689,8 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
     pubkey_no_alg.erase(alg_pos, alg_claim.length());
     alg_pos = pubkey_no_alg.find(alg_claim);
   }
-  DoTest(ds.kJwtNoKid, pubkey_no_alg, "jwks", true, Status::OK, &payload);
+  DoTest(ds.kJwtNoKid, pubkey_no_alg, "jwks", true, Status::OK,
+         &payload.value());
 
   // Remove "kid" claim from public key.
   std::string kid_claim1 =
@@ -698,19 +702,20 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
   pubkey_no_kid.erase(kid_pos, kid_claim1.length());
   kid_pos = pubkey_no_kid.find(kid_claim2);
   pubkey_no_kid.erase(kid_pos, kid_claim2.length());
-  DoTest(ds.kJwtNoKid, pubkey_no_kid, "jwks", true, Status::OK, &payload);
+  DoTest(ds.kJwtNoKid, pubkey_no_kid, "jwks", true, Status::OK,
+         &payload.value());
 }
 
 TEST_F(JwtTestJwks, OkNoKidLogExp) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp, true);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp);
   DoTest(ds.kJwtNoKidLongExp, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         &payload);
+         &payload.value());
 }
 
 TEST_F(JwtTestJwks, OkCorrectKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload);
   DoTest(ds.kJwtWithCorrectKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         &payload);
+         &payload.value());
 }
 
 TEST_F(JwtTestJwks, IncorrectKid) {
@@ -753,16 +758,17 @@ TEST_F(JwtTestJwks, JwkBadPublicKey) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkEC) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC, true);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
   // ES256-signed token with kid specified.
-  DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK, &payload);
+  DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK,
+         &payload.value());
   // ES256-signed token without kid specified.
   DoTest(ds.kTokenECNoKid, ds.kPublicKeyJwkEC, "jwks", true, Status::OK,
-         &payload);
+         &payload.value());
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
-  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC, true);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC);
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"ES256\",";
   std::string pubkey_no_alg = ds.kPublicKeyJwkEC;
@@ -771,7 +777,8 @@ TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
     pubkey_no_alg.erase(alg_pos, alg_claim.length());
     alg_pos = pubkey_no_alg.find(alg_claim);
   }
-  DoTest(ds.kTokenEC, pubkey_no_alg, "jwks", true, Status::OK, &payload);
+  DoTest(ds.kTokenEC, pubkey_no_alg, "jwks", true, Status::OK,
+         &payload.value());
 
   // Remove "kid" claim from public key.
   std::string kid_claim1 = ",\"kid\": \"abc\"";
@@ -781,7 +788,8 @@ TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
   pubkey_no_kid.erase(kid_pos, kid_claim1.length());
   kid_pos = pubkey_no_kid.find(kid_claim2);
   pubkey_no_kid.erase(kid_pos, kid_claim2.length());
-  DoTest(ds.kTokenEC, pubkey_no_kid, "jwks", true, Status::OK, &payload);
+  DoTest(ds.kTokenEC, pubkey_no_kid, "jwks", true, Status::OK,
+         &payload.value());
 }
 
 TEST_F(JwtTestJwks, NonExistKidEC) {

--- a/src/envoy/http/jwt_auth/jwt_test.cc
+++ b/src/envoy/http/jwt_auth/jwt_test.cc
@@ -18,7 +18,6 @@
 #include <tuple>
 
 #include "common/common/utility.h"
-#include "common/json/json_loader.h"
 #include "test/test_common/utility.h"
 
 namespace Envoy {
@@ -512,15 +511,15 @@ class DatasetJwk {
 
 namespace {
 
-bool EqJson(Json::ObjectSharedPtr p1, Json::ObjectSharedPtr p2) {
-  return p1->asJsonString() == p2->asJsonString();
+bool EqJson(Wasm::Common::JsonObject& p1, Wasm::Common::JsonObject& p2) {
+  return p1.dump() == p2.dump();
 }
 }  // namespace
 
 class JwtTest : public testing::Test {
  protected:
   void DoTest(std::string jwt_str, std::string pkey, std::string pkey_type,
-              bool verified, Status status, Json::ObjectSharedPtr payload) {
+              bool verified, Status status, Wasm::Common::JsonObject* payload) {
     Jwt jwt(jwt_str);
     Verifier v;
     std::unique_ptr<Pubkeys> key;
@@ -534,8 +533,8 @@ class JwtTest : public testing::Test {
     EXPECT_EQ(verified, v.Verify(jwt, *key));
     EXPECT_EQ(status, v.GetStatus());
     if (verified) {
-      ASSERT_TRUE(jwt.Payload());
-      EXPECT_TRUE(EqJson(payload, jwt.Payload()));
+      ASSERT_NE(0, jwt.Payload().size());
+      EXPECT_TRUE(EqJson(*payload, jwt.Payload()));
     }
   }
 };
@@ -548,18 +547,18 @@ class JwtTestPem : public JwtTest {
 };
 
 TEST_F(JwtTestPem, OK) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
-  DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
+  DoTest(ds.kJwt, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs384) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
-  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
+  DoTest(ds.kJwtRs384, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, OKWithAlgRs512) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
-  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
+  DoTest(ds.kJwtRs512, ds.kPublicKey, "pem", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestPem, MultiAudiences) {
@@ -673,12 +672,12 @@ class JwtTestJwks : public JwtTest {
 };
 
 TEST_F(JwtTestJwks, OkNoKid) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
-  DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK, payload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
+  DoTest(ds.kJwtNoKid, ds.kPublicKeyRSA, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"RS256\",";
   std::string pubkey_no_alg = ds.kPublicKeyRSA;
@@ -687,7 +686,7 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
     pubkey_no_alg.erase(alg_pos, alg_claim.length());
     alg_pos = pubkey_no_alg.find(alg_claim);
   }
-  DoTest(ds.kJwtNoKid, pubkey_no_alg, "jwks", true, Status::OK, payload);
+  DoTest(ds.kJwtNoKid, pubkey_no_alg, "jwks", true, Status::OK, &payload);
 
   // Remove "kid" claim from public key.
   std::string kid_claim1 =
@@ -699,19 +698,19 @@ TEST_F(JwtTestJwks, OkTokenJwkRSAPublicKeyOptionalAlgKid) {
   pubkey_no_kid.erase(kid_pos, kid_claim1.length());
   kid_pos = pubkey_no_kid.find(kid_claim2);
   pubkey_no_kid.erase(kid_pos, kid_claim2.length());
-  DoTest(ds.kJwtNoKid, pubkey_no_kid, "jwks", true, Status::OK, payload);
+  DoTest(ds.kJwtNoKid, pubkey_no_kid, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, OkNoKidLogExp) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayloadLongExp);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadLongExp, true);
   DoTest(ds.kJwtNoKidLongExp, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         payload);
+         &payload);
 }
 
 TEST_F(JwtTestJwks, OkCorrectKid) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayload);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayload, true);
   DoTest(ds.kJwtWithCorrectKid, ds.kPublicKeyRSA, "jwks", true, Status::OK,
-         payload);
+         &payload);
 }
 
 TEST_F(JwtTestJwks, IncorrectKid) {
@@ -754,16 +753,16 @@ TEST_F(JwtTestJwks, JwkBadPublicKey) {
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkEC) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayloadEC);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC, true);
   // ES256-signed token with kid specified.
-  DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK, payload);
+  DoTest(ds.kTokenEC, ds.kPublicKeyJwkEC, "jwks", true, Status::OK, &payload);
   // ES256-signed token without kid specified.
   DoTest(ds.kTokenECNoKid, ds.kPublicKeyJwkEC, "jwks", true, Status::OK,
-         payload);
+         &payload);
 }
 
 TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
-  auto payload = Json::Factory::loadFromString(ds.kJwtPayloadEC);
+  auto payload = Wasm::Common::JsonParse(ds.kJwtPayloadEC, true);
   // Remove "alg" claim from public key.
   std::string alg_claim = "\"alg\": \"ES256\",";
   std::string pubkey_no_alg = ds.kPublicKeyJwkEC;
@@ -772,7 +771,7 @@ TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
     pubkey_no_alg.erase(alg_pos, alg_claim.length());
     alg_pos = pubkey_no_alg.find(alg_claim);
   }
-  DoTest(ds.kTokenEC, pubkey_no_alg, "jwks", true, Status::OK, payload);
+  DoTest(ds.kTokenEC, pubkey_no_alg, "jwks", true, Status::OK, &payload);
 
   // Remove "kid" claim from public key.
   std::string kid_claim1 = ",\"kid\": \"abc\"";
@@ -782,7 +781,7 @@ TEST_F(JwtTestJwks, OkTokenJwkECPublicKeyOptionalAlgKid) {
   pubkey_no_kid.erase(kid_pos, kid_claim1.length());
   kid_pos = pubkey_no_kid.find(kid_claim2);
   pubkey_no_kid.erase(kid_pos, kid_claim2.length());
-  DoTest(ds.kTokenEC, pubkey_no_kid, "jwks", true, Status::OK, payload);
+  DoTest(ds.kTokenEC, pubkey_no_kid, "jwks", true, Status::OK, &payload);
 }
 
 TEST_F(JwtTestJwks, NonExistKidEC) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace json processing strategy from envoy native json loader for cleanup.