### PR TITLE
[release-1.6] make wasm build able to reference a local envoy folder

### DIFF
--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -64,10 +64,17 @@ if [[ "$(docker images -q ${WASM_SDK_IMAGE}:${WASM_SDK_TAG} 2> /dev/null)" == ""
   TMP_DIR=$(mktemp -d -t ${ENVOY_REPO}-XXXXXXXXXX)
   trap "rm -rf ${TMP_DIR}" EXIT
 
+  if [[ -z ${ENVOY_DIR} ]]; then
+    cd ${TMP_DIR}
+    git clone https://github.com/${ENVOY_ORG}/${ENVOY_REPO}
+    cd ${ENVOY_REPO}
+  else
+    # ENVOY_DIR is absolute path of local envoy dir used for Wasm build.
+    cp -r ${ENVOY_DIR} ${TMP_DIR}
+    cd ${TMP_DIR}/$(basename "${ENVOY_DIR}")
+  fi
+
   # Check out to envoy SHA
-  cd ${TMP_DIR}
-  git clone https://github.com/${ENVOY_ORG}/${ENVOY_REPO}
-  cd ${ENVOY_REPO}
   git checkout ${ENVOY_SHA}
 
   # Rebuild and push

--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -64,7 +64,7 @@ if [[ "$(docker images -q ${WASM_SDK_IMAGE}:${WASM_SDK_TAG} 2> /dev/null)" == ""
   TMP_DIR=$(mktemp -d -t ${ENVOY_REPO}-XXXXXXXXXX)
   trap "rm -rf ${TMP_DIR}" EXIT
 
-  if [[ -z ${ENVOY_DIR} ]]; then
+  if [[ -z "${ENVOY_DIR}" ]]; then
     cd ${TMP_DIR}
     git clone https://github.com/${ENVOY_ORG}/${ENVOY_REPO}
     cd ${ENVOY_REPO}


### PR DESCRIPTION
This only needed in 1.6 since Wasm build in master uses bazel now.