### PR TITLE
Add protocol label to access log only if this is tcp

### DIFF
--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -161,7 +161,6 @@ void Logger::addLogEntry(const ::Wasm::Common::RequestInfo& request_info,
   (*label_map)["service_authentication_policy"] =
       std::string(::Wasm::Common::AuthenticationPolicyString(
           request_info.service_auth_policy));
-  (*label_map)["protocol"] = request_info.request_protocol;
 
   if (is_tcp) {
     addTCPLabelsToLogEntry(request_info, new_entry);
@@ -230,6 +229,7 @@ void Logger::addTCPLabelsToLogEntry(
   (*label_map)["connection_state"] =
       std::string(::Wasm::Common::TCPConnectionStateString(
           request_info.tcp_connection_state));
+  (*label_map)["protocol"] = request_info.request_protocol;
 }
 
 void Logger::fillHTTPRequestInLogEntry(


### PR DESCRIPTION
**What this PR does / why we need it**:
HTTP protocol is already specified in HTTPRequest message.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
