### PR TITLE
fix all shellcheck for files in scripts and extension directory

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -110,7 +110,7 @@ check:
 	@echo >&2 "Please use \"make lint\" instead."
 	@false
 
-lint: lint-copyright-banner format-go lint-go tidy-go
+lint: lint-copyright-banner format-go lint-go tidy-go lint-scripts
 	@scripts/check-repository.sh
 	@scripts/check-style.sh
 

--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -21,18 +21,12 @@
 
 FINDFILES=find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses \) -prune -o -type f
 XARGS = xargs -0 -r
-LINT_SCRIPTS_DIR ?= .
 
 lint-dockerfiles:
 	@${FINDFILES} -name 'Dockerfile*' -print0 | ${XARGS} hadolint -c ./common/config/.hadolint.yml
 
 lint-scripts:
 	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck
-
-lint-scripts-dir:
-	@find ${LINT_SCRIPTS_DIR} \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses \) -prune -o -type f -name '*.sh' -print0 |\
-		${XARGS} shellcheck
-
 
 # TODO(nmittler): disabled pipefail due to grep failing when no files contain "{{". Need to investigate options.
 lint-yaml:

--- a/common/Makefile.common.mk
+++ b/common/Makefile.common.mk
@@ -21,12 +21,18 @@
 
 FINDFILES=find . \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses \) -prune -o -type f
 XARGS = xargs -0 -r
+LINT_SCRIPTS_DIR ?= .
 
 lint-dockerfiles:
 	@${FINDFILES} -name 'Dockerfile*' -print0 | ${XARGS} hadolint -c ./common/config/.hadolint.yml
 
 lint-scripts:
 	@${FINDFILES} -name '*.sh' -print0 | ${XARGS} shellcheck
+
+lint-scripts-dir:
+	@find ${LINT_SCRIPTS_DIR} \( -path ./common-protos -o -path ./.git -o -path ./out -o -path ./.github -o -path ./licenses \) -prune -o -type f -name '*.sh' -print0 |\
+		${XARGS} shellcheck
+
 
 # TODO(nmittler): disabled pipefail due to grep failing when no files contain "{{". Need to investigate options.
 lint-yaml:

--- a/extensions/stats/run_test.sh
+++ b/extensions/stats/run_test.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Copyright Istio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
+WD=$(dirname "$0")
+WD=$(cd "$WD"; pwd)
 
 BAZEL_BIN="${WD}/../../bazel-bin"
 
 set -ex
 
-${BAZEL_BIN}/src/envoy/envoy -c ${WD}/testdata/client.yaml --concurrency 2 --allow-unknown-fields
-${BAZEL_BIN}/src/envoy/envoy -c ${WD}/testdata/server.yaml --concurrency 2 --allow-unknown-fields
+"${BAZEL_BIN}"/src/envoy/envoy -c "${WD}"/testdata/client.yaml --concurrency 2 --allow-unknown-fields
+"${BAZEL_BIN}"/src/envoy/envoy -c "${WD}"/testdata/server.yaml --concurrency 2 --allow-unknown-fields

--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Copyright 2017 Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1; pwd)
+ROOT=$(dirname "$WD")
 WORKSPACE="${ROOT}/WORKSPACE"
 
 # Exit immediately for non zero status
@@ -24,6 +26,7 @@ set -u
 # Print commands
 set -x
 
+# shellcheck disable=SC2034
 GOPATH=/home/prow/go
 ROOT=/go/src
 
@@ -40,7 +43,9 @@ if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_PREFIX:-}" ]]; then
 fi
 
 # e2e tests under //test/envoye2e/... use Bazel artifacts.
-export BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-fastbuild/bin"
+# shellcheck disable=SC2086
+BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-fastbuild/bin"
+export BAZEL_OUT
 
 # Disable RBE execution due to failures like https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_proxy/2633/release-test_proxy/211
 export BAZEL_BUILD_RBE_JOBS=0

--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
 
 ########################################
 # Postsubmit script triggered by Prow. #
 ########################################
-
+# shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then

--- a/prow/proxy-presubmit-asan.sh
+++ b/prow/proxy-presubmit-asan.sh
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
 
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-
+# shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 
 echo 'Bazel Tests'

--- a/prow/proxy-presubmit-release.sh
+++ b/prow/proxy-presubmit-release.sh
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
 
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-
+# shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 
 echo 'Test building release artifacts'

--- a/prow/proxy-presubmit-tsan.sh
+++ b/prow/proxy-presubmit-tsan.sh
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
 
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-
+# shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 
 echo 'Bazel Tests'

--- a/prow/proxy-presubmit-wasm.sh
+++ b/prow/proxy-presubmit-wasm.sh
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
 
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-
+# shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 
 echo 'Generate Wasm module files and run Wasm related test'

--- a/prow/proxy-presubmit.sh
+++ b/prow/proxy-presubmit.sh
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-WD=$(dirname $0)
-WD=$(cd $WD; pwd)
-ROOT=$(dirname $WD)
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
 
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-
+# shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 
 echo 'Code Check'

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -19,7 +19,7 @@
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 CLANG_VERSION_REQUIRED="9.0.0"
-CLANG_FORMAT=$(which clang-format)
+CLANG_FORMAT=$(command -v clang-format)
 CLANG_VERSION="$(${CLANG_FORMAT} -version 2>/dev/null | cut -d ' ' -f 3 | cut -d '-' -f 1)"
 if [[ ! -x "${CLANG_FORMAT}" || "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then
   # Install required clang version to a folder and cache it.
@@ -28,7 +28,7 @@ if [[ ! -x "${CLANG_FORMAT}" || "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}
 
   if [ "$(uname)" == "Darwin" ]; then
     CLANG_BIN="x86_64-darwin-apple.tar.xz"
-  elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  elif [[ "$(uname -s)" =~ Linux* ]]; then
     CLANG_BIN="x86_64-linux-gnu-ubuntu-14.04.tar.xz"
   else
     echo "Unsupported environment." ; exit 1 ;
@@ -37,21 +37,21 @@ if [[ ! -x "${CLANG_FORMAT}" || "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}
   echo "Downloading clang-format: https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}"
   echo "Installing required clang-format ${CLANG_VERSION_REQUIRED} to ${CLANG_DIRECTORY}"
 
-  mkdir -p ${CLANG_DIRECTORY}
+  mkdir -p "${CLANG_DIRECTORY}"
   curl --silent --show-error --retry 10 \
     "https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-${CLANG_BIN}" \
     | tar Jx -C "${CLANG_DIRECTORY}" --strip=1 \
   || { echo "Could not install required clang-format. Skip formatting." ; exit 1 ; }
 fi
 
-BUILDIFIER=$(which buildifier)
+BUILDIFIER=$(command -v buildifier)
 if [[ ! -x "${BUILDIFIER}" ]]; then
   BUILDIFIER="${HOME}/bin/buildifier"
   if [[ ! -x "${BUILDIFIER}" ]]; then
 
     if [ "$(uname)" == "Darwin" ]; then
       BUILDIFIER_BIN="buildifier.osx"
-    elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    elif [[ "$(uname -s)" =~ Linux* ]]; then
       BUILDIFIER_BIN="buildifier"
     else
       echo "Unsupported environment." ; exit 1 ;
@@ -64,35 +64,41 @@ if [[ ! -x "${BUILDIFIER}" ]]; then
       "https://github.com/bazelbuild/buildtools/releases/download/0.29.0/${BUILDIFIER_BIN}" \
       -o "${BUILDIFIER}" \
     || { echo "Could not install required buildifier. Skip formatting." ; exit 1 ; }
-    chmod +x ${BUILDIFIER}
+    chmod +x "${BUILDIFIER}"
   fi
 fi
 
 echo "Checking file format ..."
 
-pushd ${ROOT} > /dev/null
+pushd "${ROOT}" > /dev/null || exit 1
 
-SOURCE_FILES=($(git ls-tree -r HEAD --name-only | grep -E '\.(h|c|cc|proto)$'))
+SOURCE_FILES=()
+while IFS='' read -r line; do SOURCE_FILES+=("$line"); done < <(git ls-tree -r HEAD --name-only | grep -E '\.(h|c|cc|proto)$')
+
 "${CLANG_FORMAT}" -i "${SOURCE_FILES[@]}" \
   || { echo "Could not run clang-format." ; exit 1 ; }
 
-CHANGED_SOURCE_FILES=($(git diff HEAD --name-only | grep -E '\.(h|c|cc|proto)$'))
+CHANGED_SOURCE_FILES=()
+while IFS='' read -r line; do CHANGED_SOURCE_FILES+=("$line"); done < <(git diff HEAD --name-only | grep -E '\.(h|c|cc|proto)$')
 
-BAZEL_FILES=($(git ls-tree -r HEAD --name-only | grep -E '(\.bzl|BUILD|WORKSPACE)$'))
+BAZEL_FILES=()
+while IFS='' read -r line; do BAZEL_FILES+=("$line"); done < <(git ls-tree -r HEAD --name-only | grep -E '(\.bzl|BUILD|WORKSPACE)$')
+
 "${BUILDIFIER}" "${BAZEL_FILES[@]}" \
   || { echo "Could not run buildifier." ; exit 1 ; }
 
-CHANGED_BAZEL_FILES=($(git diff HEAD --name-only | grep -E '(\.bzl|BUILD|WORKSPACE)$'))
+CHANGED_BAZEL_FILES=()
+while IFS='' read -r line; do CHANGED_BAZEL_FILES+=("$line"); done < <(git diff HEAD --name-only | grep -E '(\.bzl|BUILD|WORKSPACE)$')
 
 if [[ "${#CHANGED_SOURCE_FILES}" -ne 0 ]]; then
-  echo -e "Source file(s) not formatted:\n${CHANGED_SOURCE_FILES[@]}"
+  echo -e "Source file(s) not formatted:\n${CHANGED_SOURCE_FILES[*]}"
 fi
 if [[ "${#CHANGED_BAZEL_FILES}" -ne 0 ]]; then
-  echo -e "Bazel file(s) not formatted:\n${CHANGED_BAZEL_FILES[@]}"
+  echo -e "Bazel file(s) not formatted:\n${CHANGED_BAZEL_FILES[*]}"
 fi
 if [[ "${#CHANGED_SOURCE_FILES}" -ne 0 || "${#CHANGED_BAZEL_FILES}" -ne 0 ]]; then
   exit 1
 fi
 echo "All files are properly formatted."
 
-popd
+popd || exit 1

--- a/scripts/push-debian.sh
+++ b/scripts/push-debian.sh
@@ -67,10 +67,12 @@ fi
 # Symlinks don't work, use full path as a temporary workaround.
 # See: https://github.com/istio/istio/issues/15714 for details.
 # k8-opt is the output directory for x86_64 optimized builds (-c opt, so --config=release-symbol and --config=release).
-BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
+# shellcheck disable=SC2086
+BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
 BAZEL_BINARY="${BAZEL_OUT}/tools/deb/istio-proxy"
 
-bazel build "${BAZEL_BUILD_ARGS}" --config=release ${BAZEL_TARGET}
+# shellcheck disable=SC2086
+bazel build ${BAZEL_BUILD_ARGS} --config=release ${BAZEL_TARGET}
 
 if [[ -n "${GCS_PATH}" ]]; then
   gsutil -m cp -r "${BAZEL_BINARY}.deb" "${GCS_PATH}"/

--- a/scripts/push-debian.sh
+++ b/scripts/push-debian.sh
@@ -67,13 +67,13 @@ fi
 # Symlinks don't work, use full path as a temporary workaround.
 # See: https://github.com/istio/istio/issues/15714 for details.
 # k8-opt is the output directory for x86_64 optimized builds (-c opt, so --config=release-symbol and --config=release).
-BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
+BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
 BAZEL_BINARY="${BAZEL_OUT}/tools/deb/istio-proxy"
 
-bazel build ${BAZEL_BUILD_ARGS} --config=release ${BAZEL_TARGET}
+bazel build "${BAZEL_BUILD_ARGS}" --config=release ${BAZEL_TARGET}
 
 if [[ -n "${GCS_PATH}" ]]; then
-  gsutil -m cp -r "${BAZEL_BINARY}.deb" ${GCS_PATH}/
+  gsutil -m cp -r "${BAZEL_BINARY}.deb" "${GCS_PATH}"/
 fi
 
 if [[ -n "${OUTPUT_DIR}" ]]; then

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -104,13 +104,15 @@ do
       CONFIG_PARAMS="--config=release"
       BINARY_BASE_NAME="envoy-alpha"
       PACKAGE_BASE_NAME="istio-proxy"
-      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
+      # shellcheck disable=SC2086
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "release-symbol")
       CONFIG_PARAMS="--config=release-symbol"
       BINARY_BASE_NAME="envoy-symbol"
       PACKAGE_BASE_NAME=""
-      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
+      # shellcheck disable=SC2086
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "asan")
       # NOTE: libc++ is dynamically linked in this build.
@@ -118,13 +120,15 @@ do
       CONFIG_PARAMS="${BAZEL_CONFIG_ASAN} --config=release-symbol"
       BINARY_BASE_NAME="envoy-asan"
       PACKAGE_BASE_NAME=""
-      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
+      # shellcheck disable=SC2086
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "debug")
       CONFIG_PARAMS="--config=debug"
       BINARY_BASE_NAME="envoy-debug"
       PACKAGE_BASE_NAME="istio-proxy-debug"
-      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-dbg/bin"
+      # shellcheck disable=SC2086
+      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-dbg/bin"
       ;;
   esac
 
@@ -133,7 +137,8 @@ do
   echo "Building ${config} proxy"
   BINARY_NAME="${HOME}/${BINARY_BASE_NAME}-${SHA}.tar.gz"
   SHA256_NAME="${HOME}/${BINARY_BASE_NAME}-${SHA}.sha256"
-  bazel build "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} //src/envoy:envoy_tar
+  # shellcheck disable=SC2086
+  bazel build ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} //src/envoy:envoy_tar
   BAZEL_TARGET="${BAZEL_OUT}/src/envoy/envoy_tar.tar.gz"
   cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
   sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
@@ -145,13 +150,15 @@ do
   fi
 
   echo "Building ${config} docker image"
-  bazel build "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} \
+  # shellcheck disable=SC2086
+  bazel build ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} \
     //tools/docker:envoy_distroless \
     //tools/docker:envoy_ubuntu
 
   if [ "${PUSH_DOCKER_IMAGE}" -eq 1 ]; then
     echo "Pushing ${config} docker image"
-    bazel run "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} \
+    # shellcheck disable=SC2086
+    bazel run ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} \
       //tools/docker:push_envoy_distroless \
       //tools/docker:push_envoy_ubuntu
   fi
@@ -160,7 +167,8 @@ do
     echo "Building ${config} debian package"
     BINARY_NAME="${HOME}/${PACKAGE_BASE_NAME}-${SHA}.deb"
     SHA256_NAME="${HOME}/${PACKAGE_BASE_NAME}-${SHA}.sha256"
-    bazel build "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} //tools/deb:istio-proxy
+    # shellcheck disable=SC2086
+    bazel build ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} //tools/deb:istio-proxy
     BAZEL_TARGET="${BAZEL_OUT}/tools/deb/istio-proxy.deb"
     cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
     sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -104,13 +104,13 @@ do
       CONFIG_PARAMS="--config=release"
       BINARY_BASE_NAME="envoy-alpha"
       PACKAGE_BASE_NAME="istio-proxy"
-      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
+      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
       ;;
     "release-symbol")
       CONFIG_PARAMS="--config=release-symbol"
       BINARY_BASE_NAME="envoy-symbol"
       PACKAGE_BASE_NAME=""
-      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
+      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
       ;;
     "asan")
       # NOTE: libc++ is dynamically linked in this build.
@@ -118,13 +118,13 @@ do
       CONFIG_PARAMS="${BAZEL_CONFIG_ASAN} --config=release-symbol"
       BINARY_BASE_NAME="envoy-asan"
       PACKAGE_BASE_NAME=""
-      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
+      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-opt/bin"
       ;;
     "debug")
       CONFIG_PARAMS="--config=debug"
       BINARY_BASE_NAME="envoy-debug"
       PACKAGE_BASE_NAME="istio-proxy-debug"
-      BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-dbg/bin"
+      BAZEL_OUT="$(bazel info "${BAZEL_BUILD_ARGS}" output_path)/k8-dbg/bin"
       ;;
   esac
 
@@ -133,7 +133,7 @@ do
   echo "Building ${config} proxy"
   BINARY_NAME="${HOME}/${BINARY_BASE_NAME}-${SHA}.tar.gz"
   SHA256_NAME="${HOME}/${BINARY_BASE_NAME}-${SHA}.sha256"
-  bazel build ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} //src/envoy:envoy_tar
+  bazel build "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} //src/envoy:envoy_tar
   BAZEL_TARGET="${BAZEL_OUT}/src/envoy/envoy_tar.tar.gz"
   cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
   sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
@@ -145,13 +145,13 @@ do
   fi
 
   echo "Building ${config} docker image"
-  bazel build ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} \
+  bazel build "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} \
     //tools/docker:envoy_distroless \
     //tools/docker:envoy_ubuntu
 
   if [ "${PUSH_DOCKER_IMAGE}" -eq 1 ]; then
     echo "Pushing ${config} docker image"
-    bazel run ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} \
+    bazel run "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} \
       //tools/docker:push_envoy_distroless \
       //tools/docker:push_envoy_ubuntu
   fi
@@ -160,7 +160,7 @@ do
     echo "Building ${config} debian package"
     BINARY_NAME="${HOME}/${PACKAGE_BASE_NAME}-${SHA}.deb"
     SHA256_NAME="${HOME}/${PACKAGE_BASE_NAME}-${SHA}.sha256"
-    bazel build ${BAZEL_BUILD_ARGS} ${CONFIG_PARAMS} //tools/deb:istio-proxy
+    bazel build "${BAZEL_BUILD_ARGS}" ${CONFIG_PARAMS} //tools/deb:istio-proxy
     BAZEL_TARGET="${BAZEL_OUT}/tools/deb/istio-proxy.deb"
     cp -f "${BAZEL_TARGET}" "${BINARY_NAME}"
     sha256sum "${BINARY_NAME}" > "${SHA256_NAME}"
@@ -176,7 +176,7 @@ done
 # Build and publish Wasm plugins
 extensions=(stats metadata_exchange attributegen)
 TMP_WASM=$(mktemp -d -t wasm-plugins-XXXXXXXXXX)
-trap "rm -rf ${TMP_WASM}" EXIT
+trap 'rm -rf ${TMP_WASM}' EXIT
 make build_wasm
 if [ -n "${DST}" ]; then
   for extension in "${extensions[@]}"; do
@@ -185,7 +185,7 @@ if [ -n "${DST}" ]; then
     WASM_PATH="${TMP_WASM}/${WASM_NAME}"
     SHA256_PATH="${WASM_PATH}.sha256"
     BAZEL_TARGET="$(bazel info output_path)/k8-opt/bin/extensions/${extension}.wasm"
-    cp ${BAZEL_TARGET} ${WASM_PATH}
+    cp "${BAZEL_TARGET}" "${WASM_PATH}"
     sha256sum "${WASM_PATH}" > "${SHA256_PATH}"
     
     # push wasm files and sha to the given bucket

--- a/tools/deb/postinst.sh
+++ b/tools/deb/postinst.sh
@@ -17,9 +17,6 @@
 ################################################################################
 set -e
 
-action="$1"
-oldversion="$2"
-
 umask 022
 
 if ! getent passwd istio-proxy >/dev/null; then

--- a/tools/deb/test/machine_setup.sh
+++ b/tools/deb/test/machine_setup.sh
@@ -36,8 +36,8 @@ cp cluster.env /var/lib/istio/envoy
 echo "ISTIO_INBOUND_PORTS=80" > /var/lib/istio/envoy/sidecar.env
 
 # Update DHCP - if needed
-grep "^prepend domain-name-servers 127.0.0.1;" /etc/dhcp/dhclient.conf > /dev/null
-if [[ $? != 0 ]]; then
+if ! grep "^prepend domain-name-servers 127.0.0.1;" /etc/dhcp/dhclient.conf > /dev/null
+then
   echo 'prepend domain-name-servers 127.0.0.1;' >> /etc/dhcp/dhclient.conf
   # TODO: find a better way to re-trigger dhclient
   dhclient -v -1
@@ -46,8 +46,8 @@ fi
 # Install istio binaries
 dpkg -i istio-*.deb;
 
-mkdir /var/www/html/$NAME
-echo "VM $NAME" > /var/www/html/$NAME/index.html
+mkdir /var/www/html/"$NAME"
+echo "VM $NAME" > /var/www/html/"$NAME"/index.html
 
 cat <<EOF > /etc/nginx/conf.d/zipkin.conf
 server {

--- a/tools/deb/test/machine_setup.sh
+++ b/tools/deb/test/machine_setup.sh
@@ -36,8 +36,7 @@ cp cluster.env /var/lib/istio/envoy
 echo "ISTIO_INBOUND_PORTS=80" > /var/lib/istio/envoy/sidecar.env
 
 # Update DHCP - if needed
-if ! grep "^prepend domain-name-servers 127.0.0.1;" /etc/dhcp/dhclient.conf > /dev/null
-then
+if ! grep "^prepend domain-name-servers 127.0.0.1;" /etc/dhcp/dhclient.conf > /dev/null ; then
   echo 'prepend domain-name-servers 127.0.0.1;' >> /etc/dhcp/dhclient.conf
   # TODO: find a better way to re-trigger dhclient
   dhclient -v -1

--- a/tools/deb/test/run_gce_test.sh
+++ b/tools/deb/test/run_gce_test.sh
@@ -96,7 +96,6 @@ function istioVMInit() {
   # Wait for machine to start up ssh
   for i in {1..10}
   do
-    istioRun "$NAME" 'echo hi'
     if ! istioRun "$NAME" 'echo hi' ; then
         echo Waiting for startup $?
         sleep 5

--- a/tools/deb/test/run_gce_test.sh
+++ b/tools/deb/test/run_gce_test.sh
@@ -44,7 +44,7 @@ function istioRun() {
   local NAME=$1
   local CMD=$2
 
-  gcloud compute ssh --project $PROJECT --zone $ISTIO_ZONE $NAME --command "$CMD"
+  gcloud compute ssh --project "$PROJECT" --zone "$ISTIO_ZONE" "$NAME" --command "$CMD"
 }
 
 # Copy files to the VM
@@ -55,7 +55,8 @@ function istioCopy() {
   shift
   local FILES=$*
 
-  gcloud compute scp --project $PROJECT --zone $ISTIO_ZONE $FILES ${NAME}:
+  # shellcheck disable=SC2086
+  gcloud compute scp --project "$PROJECT" --zone "$ISTIO_ZONE" $FILES "${NAME}:"
 }
 
 
@@ -66,26 +67,26 @@ function istioVMInit() {
   local IMAGE=${2:-debian-9-stretch-v20170816}
   local IMAGE_PROJECT=${3:-debian-cloud}
 
-  gcloud compute --project $PROJECT instances  describe $NAME  --zone ${ISTIO_ZONE} >/dev/null
-  if [[ $? == 0 ]] ; then
+  if gcloud compute --project "$PROJECT" instances  describe "$NAME"  --zone "${ISTIO_ZONE}" >/dev/null ; then
 
-    gcloud compute --project $PROJECT \
-     instances reset $NAME \
-     --zone $ISTIO_ZONE \
+    gcloud compute --project "$PROJECT" \
+     instances reset "$NAME" \
+     --zone "$ISTIO_ZONE" \
 
   else
 
-    gcloud compute --project $PROJECT \
-     instances create $NAME \
-     --zone $ISTIO_ZONE \
+    # shellcheck disable=SC2140
+    gcloud compute --project "$PROJECT" \
+     instances create "$NAME" \
+     --zone "$ISTIO_ZONE" \
      --machine-type "n1-standard-1" \
      --subnet default \
      --can-ip-forward \
-     --service-account $ACCOUNT \
+     --service-account "$ACCOUNT" \
      --scopes "https://www.googleapis.com/auth/cloud-platform" \
      --tags "http-server","https-server" \
-     --image $IMAGE \
-     --image-project $IMAGE_PROJECT \
+     --image "$IMAGE" \
+     --image-project "$IMAGE_PROJECT" \
      --boot-disk-size "10" \
      --boot-disk-type "pd-standard" \
      --boot-disk-device-name "debtest"
@@ -95,8 +96,8 @@ function istioVMInit() {
   # Wait for machine to start up ssh
   for i in {1..10}
   do
-    istioRun $NAME 'echo hi'
-    if [[ $? -ne 0 ]] ; then
+    istioRun "$NAME" 'echo hi'
+    if ! istioRun "$NAME" 'echo hi' ; then
         echo Waiting for startup $?
         sleep 5
     else
@@ -113,18 +114,18 @@ function istioVMInit() {
 
 function istioVMDelete() {
   local NAME=${1:-$TESTVM}
-  gcloud compute -q --project $PROJECT --zone $ISTIO_ZONE instances delete $NAME --zone $ISTIO_ZONE
+  gcloud compute -q --project "$PROJECT" --zone "$ISTIO_ZONE" instances delete "$NAME" --zone "$ISTIO_ZONE"
 }
 
 # Helper to get the external IP of a raw VM
 function istioVMExternalIP() {
-  local NAME=${1:-$TESTVM}
-  gcloud compute --project $PROJECT instances describe $NAME --zone $ISTIO_ZONE --format='value(networkInterfaces[0].accessConfigs[0].natIP)'
+  local NAME=${TESTVM}
+  gcloud compute --project "$PROJECT" instances describe "$NAME" --zone "$ISTIO_ZONE" --format='value(networkInterfaces[0].accessConfigs[0].natIP)'
 }
 
 function istioVMInternalIP() {
   local NAME=${1:-$TESTVM}
-  gcloud compute --project $PROJECT instances describe $NAME  --zone $ISTIO_ZONE --format='value(networkInterfaces[0].networkIP)'
+  gcloud compute --project "$PROJECT" instances describe "$NAME"  --zone "$ISTIO_ZONE" --format='value(networkInterfaces[0].networkIP)'
 }
 
 # Initialize the K8S cluster, generating config files for the raw VMs.
@@ -184,12 +185,13 @@ spec:
     istio: mixer
 EOF
 
+  # shellcheck disable=SC2034
   for i in {1..10}
   do
     PILOT_IP=$(kubectl get service istio-pilot-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     ISTIO_DNS=$(kubectl get -n kube-system service dns-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     MIXER_IP=$(kubectl get service mixer-ilb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    if [ ${PILOT_IP} == "" -o  ${PILOT_IP} == "" -o ${MIXER_IP} == "" ] ; then
+    if [ "${PILOT_IP}" == "" ] || [ "${PILOT_IP}" == "" ] || [ "${MIXER_IP}" == "" ] ; then
         echo Waiting for ILBs
         sleep 10
     else
@@ -197,18 +199,20 @@ EOF
     fi
   done
 
-  if [ ${PILOT_IP} == "" -o  ${PILOT_IP} == "" -o ${MIXER_IP} == "" ] ; then
+  if [ "${PILOT_IP}" == "" ] || [ "${PILOT_IP}" == "" ] || [ "${MIXER_IP}" == "" ] ; then
     echo "Failed to create ILBs"
     exit 1
   fi
 
   #/etc/dnsmasq.d/kubedns
   echo "server=/default.svc.cluster.local/$ISTIO_DNS" > kubedns
-  echo "address=/istio-mixer/$MIXER_IP" >> kubedns
-  echo "address=/mixer-server/$MIXER_IP" >> kubedns
-  echo "address=/istio-pilot/$PILOT_IP" >> kubedns
+  { 
+    echo "address=/istio-mixer/$MIXER_IP"
+    echo "address=/mixer-server/$MIXER_IP"
+    echo "address=/istio-pilot/$PILOT_IP"
+  } >> kubedns
 
-  CIDR=$(gcloud container clusters describe ${K8SCLUSTER} --zone=${ISTIO_ZONE} --format "value(servicesIpv4Cidr)")
+  CIDR=$(gcloud container clusters describe "${K8SCLUSTER}" --zone="${ISTIO_ZONE}" --format "value(servicesIpv4Cidr)")
   echo "ISTIO_SERVICE_CIDR=$CIDR" > cluster.env
 
 }
@@ -285,13 +289,13 @@ function istioProvisionTestWorker() {
 
  istioPrepareCluster
 
- istioRun $NAME "sudo rm -f istio-*.deb machine_setup.sh"
+ istioRun "$NAME" "sudo rm -f istio-*.deb machine_setup.sh"
 
  # Copy deb, helper and config files
- istioCopy $NAME kubedns cluster.env tools/deb/test/machine_setup.sh $PROXY_DIR/bazel-bin/tools/deb/*.deb
+ istioCopy "$NAME" kubedns cluster.env tools/deb/test/machine_setup.sh "$PROXY_DIR"/bazel-bin/tools/deb/*.deb
 
 
- istioRun $NAME "sudo bash -c ./machine_setup.sh $NAME"
+ istioRun "$NAME" "sudo bash -c ./machine_setup.sh $NAME"
 
 }
 
@@ -301,29 +305,31 @@ function ingressIP() {
 
 function setUp() {
 
- LOCAL_IP=$(istioVMInternalIP $TESTVM)
+ LOCAL_IP=$(istioVMInternalIP "$TESTVM")
 
  # Configure a service for the local nginx server, and add an ingress route
- istioConfigHttpService rawvm 80 $LOCAL_IP
+ istioConfigHttpService rawvm 80 "$LOCAL_IP"
  istioRoute "/${TESTVM}/" rawvm 80
 }
 
 # Verify that cluster (istio-ingress) can reach the VM.
 function testClusterToRawVM() {
-  local INGRESS=$(ingressIP)
+  local INGRESS
+  INGRESS=$(ingressIP)
 
   # -f == fail, return != 0 if status code is not 200
-  curl -f http://$INGRESS/${TESTVM}/
+  curl -f http://"$INGRESS"/"${TESTVM}"/
 
   echo $?
 }
 
 # Verify that the VM can reach the cluster. Use the local http server running on the VM.
 function testRawVMToCluster() {
-  local RAWVM=$(istioVMExternalIP)
+  local RAWVM
+  RAWVM=$(istioVMExternalIP)
 
   # -f == fail, return != 0 if status code is not 200
-  curl -f http://${RAWVM}:9411/zipkin/
+  curl -f http://"${RAWVM}":9411/zipkin/
 
   echo $?
 }
@@ -335,17 +341,17 @@ function test() {
 
 function trearDown() {
   # TODO: it is also possible to reset the VM, may be faster
-  istioVMDelete ${TESTVM}
+  istioVMDelete "${TESTVM}"
 }
 
 if [[ ${1:-} == "init" ]] ; then
-  istioProvisionTestWorker ${TESTVM}
+  istioProvisionTestWorker "${TESTVM}"
 elif [[ ${1:-} == "test" ]] ; then
   setUp
   test
 else
-  istioVMInit ${TESTVM}
-  istioProvisionTestWorker ${TESTVM}
+  istioVMInit "${TESTVM}"
+  istioProvisionTestWorker "${TESTVM}"
   setUp
   test
 fi

--- a/tools/deb/test/run_pilot_test.sh
+++ b/tools/deb/test/run_pilot_test.sh
@@ -48,10 +48,10 @@ function build_all() {
     (cd "$GOPATH"/src/istio.io || exit 1; git clone https://github.com/istio/mixer)
   fi
 
-  pushd "$GOPATH"/src/istio.io/pilot
+  pushd "$GOPATH"/src/istio.io/pilot || exit 1
   bazel build ...
   ./bin/init.sh
-  popd
+  popd || exit 1
 
   (cd "$GOPATH"/src/istio.io/mixer || exit 1; bazel build ...)
   bazel build tools/deb/...

--- a/tools/deb/test/run_pilot_test.sh
+++ b/tools/deb/test/run_pilot_test.sh
@@ -27,61 +27,61 @@ PILOT=${PILOT:-${GOPATH}/src/istio.io/pilot}
 # Build debian and binaries for all components we'll test on the VM
 # Will checkout mixer, pilot and proxy in the expected locations/
 function build_all() {
-  mkdir -p $WS/go/src/istio.io
+  mkdir -p "$WS"/go/src/istio.io
 
 
   if [[ -d $GOPATH/src/istio.io/pilot ]]; then
-    (cd $GOPATH/src/istio.io/pilot; git pull upstream master)
+    (cd "$GOPATH"/src/istio.io/pilot || exit 1; git pull upstream master)
   else
-    (cd $GOPATH/src/istio.io; git clone https://github.com/istio/pilot)
+    (cd "$GOPATH"/src/istio.io || exit 1; git clone https://github.com/istio/pilot)
   fi
 
   if [[ -d $GOPATH/src/istio.io/istio ]]; then
-    (cd $GOPATH/src/istio.io/istio; git pull upstream master)
+    (cd "$GOPATH"/src/istio.io/istio || exit 1; git pull upstream master)
   else
-    (cd $GOPATH/src/istio.io; git clone https://github.com/istio/istio)
+    (cd "$GOPATH"/src/istio.io || exit 1; git clone https://github.com/istio/istio)
   fi
 
   if [[ -d $GOPATH/src/istio.io/mixer ]]; then
-    (cd $GOPATH/src/istio.io/mixer; git pull upstream master)
+    (cd "$GOPATH"/src/istio.io/mixer || exit 1; git pull upstream master)
   else
-    (cd $GOPATH/src/istio.io; git clone https://github.com/istio/mixer)
+    (cd "$GOPATH"/src/istio.io || exit 1; git clone https://github.com/istio/mixer)
   fi
 
-  pushd $GOPATH/src/istio.io/pilot
+  pushd "$GOPATH"/src/istio.io/pilot
   bazel build ...
   ./bin/init.sh
   popd
 
-  (cd $GOPATH/src/istio.io/mixer; bazel build ...)
+  (cd "$GOPATH"/src/istio.io/mixer || exit 1; bazel build ...)
   bazel build tools/deb/...
 
 }
 
 function kill_all() {
   if [[ -f $LOG_DIR/pilot.pid ]] ; then
-    kill -9 $(cat $LOG_DIR/pilot.pid)
-    kill -9 $(cat $LOG_DIR/mixer.pid)
-    kill -9 $(cat $LOG_DIR/envoy.pid)
-    kill -9 $(cat $LOG_DIR/test_server.pid)
+    kill -9 "$(cat "$LOG_DIR"/pilot.pid)"
+    kill -9 "$(cat "$LOG_DIR"/mixer.pid)"
+    kill -9 "$(cat "$LOG_DIR"/envoy.pid)"
+    kill -9 "$(cat "$LOG_DIR"/test_server.pid)"
   fi
 }
 
 # Start pilot, envoy and mixer for local integration testing.
 function start_all() {
-  mkdir -p $LOG_DIR
-  POD_NAME=pilot POD_NAMESPACE=default  ${PILOT}/bazel-bin/cmd/pilot-discovery/pilot-discovery discovery -n default --kubeconfig ~/.kube/config &
-  echo $! > $LOG_DIR/pilot.pid
+  mkdir -p "$LOG_DIR"
+  POD_NAME=pilot POD_NAMESPACE=default  "${PILOT}"/bazel-bin/cmd/pilot-discovery/pilot-discovery discovery -n default --kubeconfig ~/.kube/config &
+  echo $! > "$LOG_DIR"/pilot.pid
 
-  ${GOPATH}/src/istio.io/mixer/bazel-bin/cmd/server/mixs server --configStoreURL=fs:${GOPATH}/src/istio.io/mixer/testdata/configroot -v=2 --logtostderr &
-  echo $! > $LOG_DIR/mixer.pid
+  "${GOPATH}"/src/istio.io/mixer/bazel-bin/cmd/server/mixs server --configStoreURL=fs:"${GOPATH}"/src/istio.io/mixer/testdata/configroot -v=2 --logtostderr &
+  echo $! > "$LOG_DIR"/mixer.pid
 
-  ${GOPATH}/src/istio.io/pilot/bazel-bin/test/server/server --port 9999 > $LOG_DIR/test_server.log 2>&1 &
-  echo $! > $LOG_DIR/test_server.pid
+  "${GOPATH}"/src/istio.io/pilot/bazel-bin/test/server/server --port 9999 > "$LOG_DIR"/test_server.log 2>&1 &
+  echo $! > "$LOG_DIR"/test_server.pid
 
   # 'lds' disabled, so we can use manual config.
   bazel-bin/src/envoy/envoy -c tools/deb/test/envoy_local.json --restart-epoch 0 --drain-time-s 2 --parent-shutdown-time-s 3 --service-cluster istio-proxy --service-node sidecar~172.17.0.2~mysvc.~svc.cluster.local &
-  echo $! > $LOG_DIR/envoy.pid
+  echo $! > "$LOG_DIR"/envoy.pid
 }
 
 # Add a service and endpoint to K8S.


### PR DESCRIPTION
**What this PR does / why we need it**:
fix shellcheck  in scritps and extension, Improving the robustness of scripts 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

the shellcheck  code i fixed as follow:
[SC2230](https://github.com/koalaman/shellcheck/wiki/SC2230): which is non-standard. Use builtin 'command -v' instead.
[SC2003](https://github.com/koalaman/shellcheck/wiki/SC2003): expr is antiquated. Consider rewriting this using $((..)), ${} or [[ ]].
[SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164): Use 'pushd ... || exit' or 'pushd ... || return' in case pushd fails.
[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086):  Double quote to prevent globbing and word splitting.
[SC2207](https://github.com/koalaman/shellcheck/wiki/SC2207):  Prefer mapfile or read -a to split command output (or quote to avoid splitting).
[SC2145](https://github.com/koalaman/shellcheck/wiki/SC2145): Argument mixes string and array.     Use * or separate argument.
[SC2064](https://github.com/koalaman/shellcheck/wiki/SC2064): Use single quotes, otherwise this expands now rather than when signalled.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
