### PR TITLE
[release-1.5] Fix generate_wasm.sh script

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,21 +38,21 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # istio/envoy commit date: Jun 02 2020
-ENVOY_ORG = "istio"
+ENVOY_PROJECT = "istio"
 
 ENVOY_REPO = "envoy"
 
-ENVOY_SHA = "b0041bd9e8ea4b04943e7873a64300105553e848"
+ENVOY_SHA = "56b2f1495e121ab86e6de1497b3287023378bfc1"
 
-ENVOY_SHA256 = "aaa0e28199089d96333332501187a763f3b9860e8cbcf6e9df0083cd2b82052a"
+ENVOY_SHA256 = "5f9c0f0fe8b27f8e1dc5e4a49e1ac369e055b6412cc68de7d4820bf220e5ae4b"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.
 http_archive(
-    name = ENVOY_REPO,
+    name = "envoy",
     sha256 = ENVOY_SHA256,
     strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,
-    url = "https://github.com/" + ENVOY_ORG + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
+    url = "https://github.com/" + ENVOY_PROJECT + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
 )
 
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,9 +42,9 @@ ENVOY_PROJECT = "istio"
 
 ENVOY_REPO = "envoy"
 
-ENVOY_SHA = "56b2f1495e121ab86e6de1497b3287023378bfc1"
+ENVOY_SHA = "b0041bd9e8ea4b04943e7873a64300105553e848"
 
-ENVOY_SHA256 = "5f9c0f0fe8b27f8e1dc5e4a49e1ac369e055b6412cc68de7d4820bf220e5ae4b"
+ENVOY_SHA256 = "aaa0e28199089d96333332501187a763f3b9860e8cbcf6e9df0083cd2b82052a"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.

--- a/scripts/generate-wasm.sh
+++ b/scripts/generate-wasm.sh
@@ -42,49 +42,44 @@ while getopts bpcd: arg ; do
   esac
 done
 
-# Get SHA of envoy-wasm repo
+# Get SHA of istio/envoy repo
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 WORKSPACE=${ROOT}/WORKSPACE
 ENVOY_SHA="$(grep -Pom1 "^ENVOY_SHA = \"\K[a-zA-Z0-9]{40}" "${WORKSPACE}")"
-ENVOY_ORG="$(grep -Pom1 "^ENVOY_ORG = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
-ENVOY_REPO="$(grep -Pom1 "^ENVOY_REPO = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
-WASM_SDK_IMAGE=${WASM_SDK_IMAGE:=gcr.io/istio-testing/wasmsdk}
-export WASM_SDK_TAG=${ENVOY_SHA}
+ENVOY_PROJECT="$(grep -Pom1 "^ENVOY_PROJECT = \"\K[a-zA-Z0-9]*" "${WORKSPACE}")"
+ENVOY_REPO="$(grep -Pom1 "^ENVOY_REPO = \"\K[a-zA-Z0-9]*" "${WORKSPACE}")"
+IMAGE=gcr.io/istio-testing/wasmsdk
+TAG=${ENVOY_SHA}
 
 # Try pull wasm builder image.
-docker pull ${WASM_SDK_IMAGE}:${WASM_SDK_TAG} || echo "${WASM_SDK_IMAGE}:${WASM_SDK_TAG} does not exist"
+docker pull ${IMAGE}:${TAG} || echo "${IMAGE}:${TAG} does not exist"
 
 # If image does not exist, try build it
-if [[ "$(docker images -q ${WASM_SDK_IMAGE}:${WASM_SDK_TAG} 2> /dev/null)" == "" ]]; then
+if [[ "$(docker images -q ${IMAGE}:${TAG} 2> /dev/null)" == "" ]]; then
   if [[ ${BUILD_CONTAINER} == 0 ]]; then
     echo "no builder image to compile wasm. Add `-b` option to create the builder image"
     exit 1
   fi
-  # Clone envoy-wasm repo and checkout to that SHA
-  TMP_DIR=$(mktemp -d -t ${ENVOY_REPO}-XXXXXXXXXX)
+  # Clone istio/envoy repo and checkout to that SHA
+  TMP_DIR=$(mktemp -d -t istio-envoy-XXXXXXXXXX)
   trap "rm -rf ${TMP_DIR}" EXIT
 
-  if [[ -z "${ENVOY_DIR}" ]]; then
-    cd ${TMP_DIR}
-    git clone https://github.com/${ENVOY_ORG}/${ENVOY_REPO}
-    cd ${ENVOY_REPO}
-  else
-    # ENVOY_DIR is absolute path of local envoy dir used for Wasm build.
-    cp -r ${ENVOY_DIR} ${TMP_DIR}
-    cd ${TMP_DIR}/$(basename "${ENVOY_DIR}")
-  fi
-
   # Check out to envoy SHA
+  cd ${TMP_DIR}
+  git clone https://github.com/${ENVOY_PROJECT}/${ENVOY_REPO}
+  cd ${ENVOY_REPO}
   git checkout ${ENVOY_SHA}
 
   # Rebuild and push
-  cd api/wasm/cpp && docker build -t ${WASM_SDK_IMAGE}:${WASM_SDK_TAG} -f Dockerfile-sdk .
+  cd api/wasm/cpp && docker build -t ${IMAGE}:${TAG} -f Dockerfile-sdk .
   if [[ ${PUSH_DOCKER_IMAGE} == 1 ]]; then
-    docker push ${WASM_SDK_IMAGE}:${WASM_SDK_TAG} || echo "fail to push to ${WASM_SDK_IMAGE} hub"
+    docker push ${IMAGE}:${TAG} || "fail to push to gcr.io/istio-testing hub"
   fi
 fi
 
 # Regenerate all wasm plugins and compare diffs
+# Tag image to v3, which is what used by all build wasm script.
+docker tag ${IMAGE}:${TAG} ${IMAGE}:v3
 cd ${ROOT}
 find . -name "*.wasm" -type f -delete
 make build_wasm
@@ -97,7 +92,6 @@ if [ -n "${DST_BUCKET}" ]; then
   TMP_WASM=$(mktemp -d -t wasm-plugins-XXXXXXXXXX)
   trap "rm -rf ${TMP_WASM}" EXIT
   for i in `find . -name "*.wasm" -type f`; do
-    ls -lh ${i}
     # Get name of the plugin
     PLUGIN_NAME=$(basename $(dirname ${i}))
     # Rename the plugin file and generate sha256 for it


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolve issue found at https://github.com/istio/istio/pull/25221#issuecomment-654486177

Get the version of the `scripts/generate_wasm.sh` script and `WORKSPACE` from the `1.5.6` tag. Update the SHAs found in the `WORKSPACE` file to fix

The previously merged PR (https://github.com/istio/proxy/pull/2892) tried to merge in `1.5.7-patch` branch and its fixed into `release-1.5`. There were issues with merging that PR and I took the version of `generate_wasm.sh` from `release-1.6` branch and updated everything accordingly. This may have broken artifacts created by by the script.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
