### PR TITLE
Change not to impose a case sensitivity requirement on the word "Bearer"

### DIFF
--- a/src/envoy/http/jwt_auth/token_extractor.cc
+++ b/src/envoy/http/jwt_auth/token_extractor.cc
@@ -28,7 +28,7 @@ namespace JwtAuth {
 namespace {
 
 // The autorization bearer prefix.
-const std::string kBearerPrefix = "Bearer ";
+const std::string kBearerPrefix = "bearer ";
 
 // The query parameter name to get JWT token.
 const std::string kParamAccessToken = "access_token";
@@ -71,7 +71,7 @@ void JwtTokenExtractor::Extract(
     if (entry) {
       // Extract token from header.
       auto value = entry->value().getStringView();
-      if (absl::StartsWith(value, kBearerPrefix)) {
+      if (absl::StartsWith(LowerCaseString(value), kBearerPrefix)) {
         value.remove_prefix(kBearerPrefix.length());
         tokens->emplace_back(new Token(std::string(value),
                                        authorization_issuers_, true, nullptr));

--- a/src/envoy/http/jwt_auth/token_extractor_test.cc
+++ b/src/envoy/http/jwt_auth/token_extractor_test.cc
@@ -139,6 +139,25 @@ TEST_F(JwtTokenExtractorTest, TestDefaultParamLocation) {
   EXPECT_FALSE(tokens[0]->IsIssuerAllowed("unknown_issuer"));
 }
 
+TEST_F(JwtTokenExtractorTest, TestLowerBearerHeaderToken) {
+  auto headers =
+      TestRequestHeaderMapImpl{{"Authorization", "bearer jwt_token"}};
+  std::vector<std::unique_ptr<JwtTokenExtractor::Token>> tokens;
+  extractor_->Extract(headers, &tokens);
+  EXPECT_EQ(tokens.size(), 1);
+  EXPECT_EQ(tokens[0]->token(), "jwt_token");
+
+  EXPECT_TRUE(tokens[0]->IsIssuerAllowed("issuer1"));
+  EXPECT_FALSE(tokens[0]->IsIssuerAllowed("issuer2"));
+  EXPECT_FALSE(tokens[0]->IsIssuerAllowed("issuer3"));
+  EXPECT_FALSE(tokens[0]->IsIssuerAllowed("issuer4"));
+  EXPECT_FALSE(tokens[0]->IsIssuerAllowed("unknown_issuer"));
+
+  // Test token remove
+  tokens[0]->Remove(&headers);
+  EXPECT_FALSE(headers.Authorization());
+}
+
 TEST_F(JwtTokenExtractorTest, TestCustomHeaderToken) {
   std::vector<std::string> headerVals = {"jwt_token", "istio jwt_token"};
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Change not to impose  a case sensitivity requirement on the word "Bearer" in the Authorization header.

**Which issue this PR fixes** : fixes https://github.com/istio/istio/issues/22608

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
