### PR TITLE
Bind lifetime of http metadata to DownstreamRequest

### DIFF
--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -105,7 +105,8 @@ bool PluginRootContext::onConfigure(size_t size) {
   const std::string function = "declare_property";
   envoy::source::extensions::common::wasm::DeclarePropertyArguments args;
   args.set_type(envoy::source::extensions::common::wasm::WasmType::FlatBuffers);
-  args.set_span(envoy::source::extensions::common::wasm::LifeSpan::FilterChain);
+  args.set_span(
+      envoy::source::extensions::common::wasm::LifeSpan::DownstreamRequest);
   args.set_schema(::Wasm::Common::nodeInfoSchema().data(),
                   ::Wasm::Common::nodeInfoSchema().size());
   std::string in;
@@ -113,8 +114,7 @@ bool PluginRootContext::onConfigure(size_t size) {
   args.SerializeToString(&in);
   proxy_call_foreign_function(function.data(), function.size(), in.data(),
                               in.size(), nullptr, nullptr);
-  args.set_span(
-      envoy::source::extensions::common::wasm::LifeSpan::DownstreamConnection);
+
   args.set_name(std::string(::Wasm::Common::kDownstreamMetadataKey));
   args.SerializeToString(&in);
   proxy_call_foreign_function(function.data(), function.size(), in.data(),

--- a/extensions/metadata_exchange/plugin.cc
+++ b/extensions/metadata_exchange/plugin.cc
@@ -105,8 +105,7 @@ bool PluginRootContext::onConfigure(size_t size) {
   const std::string function = "declare_property";
   envoy::source::extensions::common::wasm::DeclarePropertyArguments args;
   args.set_type(envoy::source::extensions::common::wasm::WasmType::FlatBuffers);
-  args.set_span(
-      envoy::source::extensions::common::wasm::LifeSpan::DownstreamConnection);
+  args.set_span(envoy::source::extensions::common::wasm::LifeSpan::FilterChain);
   args.set_schema(::Wasm::Common::nodeInfoSchema().data(),
                   ::Wasm::Common::nodeInfoSchema().size());
   std::string in;
@@ -114,6 +113,8 @@ bool PluginRootContext::onConfigure(size_t size) {
   args.SerializeToString(&in);
   proxy_call_foreign_function(function.data(), function.size(), in.data(),
                               in.size(), nullptr, nullptr);
+  args.set_span(
+      envoy::source::extensions::common::wasm::LifeSpan::DownstreamConnection);
   args.set_name(std::string(::Wasm::Common::kDownstreamMetadataKey));
   args.SerializeToString(&in);
   proxy_call_foreign_function(function.data(), function.size(), in.data(),

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -550,11 +550,11 @@ void PluginRootContext::onTick() {
 bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
                                bool is_tcp) {
   std::string peer_id;
-  getValue({peer_metadata_id_key_}, &peer_id);
+  bool peer_found = getValue({peer_metadata_id_key_}, &peer_id);
 
   std::string peer;
   const ::Wasm::Common::FlatNode* peer_node =
-      getValue({peer_metadata_key_}, &peer)
+      peer_found && getValue({peer_metadata_key_}, &peer)
           ? flatbuffers::GetRoot<::Wasm::Common::FlatNode>(peer.data())
           : nullptr;
 
@@ -576,9 +576,7 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
     // been no error in connection.
     uint64_t response_flags = 0;
     getValue({"response", "flags"}, &response_flags);
-    if (peer_node == nullptr &&
-        peer_id != ::Wasm::Common::kMetadataNotFoundValue &&
-        response_flags == 0) {
+    if (!peer_found && response_flags == 0) {
       return false;
     }
     if (!request_info.is_populated) {


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/25274

1. Change lifetime of metadata to DownstreamRequest.
2. Do not read metadata if peer_id not found.