### PR TITLE
feat(testing): Update Stackdriver fake to support traces and edges retrieval.

### DIFF
--- a/test/envoye2e/stackdriver_plugin/cmd/Makefile
+++ b/test/envoye2e/stackdriver_plugin/cmd/Makefile
@@ -18,12 +18,12 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 SD_PATH := $(dir $(MKFILE_PATH))
 IMG := gcr.io/istio-testing/fake-stackdriver
-TAG := 3.0
+TAG := 4.0
 
 all: build_and_push clean
 
 build_and_push:
-	cd $(SD_PATH) && go build main.go
+	cd $(SD_PATH) && GOOS=linux GOARCH=amd64 go build main.go
 	docker build $(SD_PATH) -t $(IMG):$(TAG)
 	docker push $(IMG):$(TAG)
 	rm $(SD_PATH)/main


### PR DESCRIPTION
This PR:
- updates the regexs to match GCP project id (include '-')
- adds a go routine to prevent blocking on channel writes
- initializes trace map
- increments the tag for new builds of the image

These changes were motivated by new integration testing in istio/istio.

