### PR TITLE
mde: set additional remote port

### DIFF
--- a/src/envoy/tcp/metadata_exchange/BUILD
+++ b/src/envoy/tcp/metadata_exchange/BUILD
@@ -54,6 +54,7 @@ envoy_cc_library(
         "@envoy//source/common/network:utility_lib",
         "@envoy//source/common/protobuf",
         "@envoy//source/common/protobuf:utility_lib",
+        "@envoy//source/common/stream_info:uint32_accessor_lib",
         "@envoy//source/extensions/common/wasm:wasm_interoperation_lib",
         "@envoy//source/extensions/filters/network:well_known_names",
     ],


### PR DESCRIPTION
Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Add a functionality to propagate downstream socket port to upstream.

This will be used by BTS for http traffic. BTS ingress listener is always listening on port 15008. 
The egress listener need the original workload port(e.g 80) to select the route.

This is mainly to address the use case that
Client send request to svc:80 with :authority svc:80 but VS rewrite :authority to svc:8080 but not L4 address is remained at svc:80.

Before BTS, the ingress listener could recover the port 80. Now this information but be encoded through egress sidecar and ingresssidecar.

This PR add the prototype to deliver the dest port through metadata_exchange plugin, however, it is not done yet 
since it's 15008 port is delivered instead of the 80

The follow up PR will be focusing on egress sidecar to figure out the port 80 despite the endpoint port is 15008 (though endpoint metadata)

part of https://github.com/istio/istio/issues/24540