### PR TITLE
Add connection_id in stackdriver access log

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -337,6 +337,7 @@ void populateExtendedRequestInfo(RequestInfo* request_info) {
   getValue({"source", "address"}, &request_info->source_address);
   getValue({"destination", "address"}, &request_info->destination_address);
   getValue({"source", "port"}, &request_info->source_port);
+  getValue({"connection_id"}, &request_info->connection_id);
 }
 
 void populateTCPRequestInfo(bool outbound, RequestInfo* request_info,

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -142,6 +142,9 @@ struct RequestInfo {
   std::string source_principal;
   std::string destination_principal;
 
+  // Connection id of the TCP connection.
+  uint64_t connection_id;
+
   // The following fields will only be populated by calling
   // populateExtendedHTTPRequestInfo.
   std::string source_address;

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -184,6 +184,7 @@ void Logger::fillAndFlushLogEntry(
           request_info.service_auth_policy));
   (*label_map)["protocol"] = request_info.request_protocol;
   (*label_map)["log_sampled"] = request_info.log_sampled ? "true" : "false";
+  (*label_map)["connection_id"] = std::to_string(request_info.connection_id);
 
   // Insert trace headers, if exist.
   if (request_info.b3_trace_sampled) {

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -123,6 +123,7 @@ const ::Wasm::Common::FlatNode& peerNodeInfo(
   request_info.referer = "www.google.com";
   request_info.source_address = "1.1.1.1";
   request_info.destination_address = "2.2.2.2";
+  request_info.connection_id = 0;
   return request_info;
 }
 
@@ -170,7 +171,8 @@ std::string write_log_request_json = R"({
            "source_workload":"test_peer_workload",
            "response_flag":"-",
            "protocol":"HTTP",
-           "log_sampled":"false"
+           "log_sampled":"false",
+           "connection_id":"0"
         },
         "trace":"projects/test_project/traces/123abc",
         "spanId":"abc123",

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -96,6 +96,7 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 					delete(entry.Labels, "destination_port")
 					delete(entry.Labels, "total_sent_bytes")
 					delete(entry.Labels, "total_received_bytes")
+					delete(entry.Labels, "connection_id")
 				}
 				sd.Lock()
 				sd.ls[proto.MarshalTextString(req)] = struct{}{}


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

**What this PR does / why we need it**:
Add connection_id in stackdriver access log
Added for both http and tcp, so that for http we can get underlying connection's id too for debugging..

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
