### PR TITLE
This PR outputs binaries with BUILD_W_C=1

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -165,6 +165,13 @@ test_release:
 push_release: build
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)" -p
 
+# Used by build container to export the build output from the docker volume cache
+exportcache:
+	mkdir -p /work/out/linux_amd64
+	cp -a /work/bazel-bin/src/envoy/envoy /work/out/linux_amd64
+	cp -a /work/bazel-bin/extensions/*wasm /work/out/linux_amd64
+
+
 .PHONY: build clean test check artifacts extensions-proto
 
 include common/Makefile.common.mk


### PR DESCRIPTION
When BUILD_WITH_CONTAINER=1 is set, this PR outputs all relevant binaries
for envoy. This target can be used to export the build cache, or
alternatively it may be viable to use the build cache directly in the
Istio build, linking these two repositories via a volume mount.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
