### PR TITLE
[release-1.7] Ignore the out/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/envoye2e/http_metadata_exchange/testoutput
 /extensions/common/node_info_bfbs_generated.h
 /extensions/common/proxy_expr.h
 /extensions/common/nlohmann_json.hpp
+out/

--- a/out/.env
+++ b/out/.env
@@ -1,8 +1,0 @@
-TARGET_OUT_LINUX=/tmp/ci-xYxnXsOghI/proxy/out/linux_amd64
-TARGET_OUT=/tmp/ci-xYxnXsOghI/proxy/out/linux_amd64
-TIMEZONE=/etc/localtime
-LOCAL_OS=Linux
-TARGET_OS=linux
-LOCAL_ARCH=x86_64
-TARGET_ARCH=amd64
-BUILD_WITH_CONTAINER=0


### PR DESCRIPTION
Manual cherrypick of https://github.com/istio/proxy/pull/2944

It was populated by mistake by automator.
Putting it on .gitignore will make automator ignore it.