### PR TITLE
Set TextPayload for TCP Access Log 

### DIFF
--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -105,10 +105,10 @@ struct RequestInfo {
   int64_t response_size = 0;
 
   // Destination port that the request targets.
-  uint32_t destination_port = 0;
+  uint64_t destination_port = 0;
 
   // Source port of the client.
-  uint32_t source_port = 0;
+  uint64_t source_port = 0;
 
   // Protocol used the request (HTTP/1.1, gRPC, etc).
   std::string request_protocol;

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -105,7 +105,7 @@ struct RequestInfo {
   int64_t response_size = 0;
 
   // Destination port that the request targets.
-  uint64_t destination_port = 0;
+  uint32_t destination_port = 0;
 
   // Source port of the client.
   uint64_t source_port = 0;

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -30,6 +30,21 @@
 namespace Extensions {
 namespace Stackdriver {
 namespace Log {
+namespace {
+void setSourceCanonicalService(
+    const ::Wasm::Common::FlatNode& peer_node_info,
+    google::protobuf::Map<std::string, std::string>* label_map) {
+  const auto peer_labels = peer_node_info.labels();
+  if (peer_labels) {
+    auto ics_iter = peer_labels->LookupByKey(
+        Wasm::Common::kCanonicalServiceLabelName.data());
+    if (ics_iter) {
+      (*label_map)["source_canonical_service"] =
+          flatbuffers::GetString(ics_iter->value());
+    }
+  }
+}
+}  // namespace
 
 using google::protobuf::util::TimeUtil;
 
@@ -119,7 +134,7 @@ void Logger::addTcpLogEntry(const ::Wasm::Common::RequestInfo& request_info,
   *new_entry->mutable_timestamp() =
       google::protobuf::util::TimeUtil::NanosecondsToTimestamp(log_time);
 
-  addTCPLabelsToLogEntry(request_info, new_entry);
+  addTCPLabelsToLogEntry(request_info, peer_node_info, new_entry);
   fillAndFlushLogEntry(request_info, peer_node_info, new_entry);
 }
 
@@ -160,11 +175,13 @@ void Logger::fillAndFlushLogEntry(
     if (app_iter) {
       (*label_map)["source_app"] = flatbuffers::GetString(app_iter->value());
     }
-    auto ics_iter = peer_labels->LookupByKey(
-        Wasm::Common::kCanonicalServiceLabelName.data());
-    if (ics_iter) {
-      (*label_map)["source_canonical_service"] =
-          flatbuffers::GetString(ics_iter->value());
+    if (label_map->find("source_canonical_service") == label_map->end()) {
+      auto ics_iter = peer_labels->LookupByKey(
+          Wasm::Common::kCanonicalServiceLabelName.data());
+      if (ics_iter) {
+        (*label_map)["source_canonical_service"] =
+            flatbuffers::GetString(ics_iter->value());
+      }
     }
     auto rev_iter = peer_labels->LookupByKey(
         Wasm::Common::kCanonicalServiceRevisionLabelName.data());
@@ -243,8 +260,16 @@ bool Logger::exportLogEntry(bool is_on_done) {
 
 void Logger::addTCPLabelsToLogEntry(
     const ::Wasm::Common::RequestInfo& request_info,
+    const ::Wasm::Common::FlatNode& peer_node_info,
     google::logging::v2::LogEntry* log_entry) {
   auto label_map = log_entry->mutable_labels();
+  setSourceCanonicalService(peer_node_info, label_map);
+  log_entry->set_text_payload(absl::StrCat(
+      label_map->find("source_canonical_service") != label_map->end()
+          ? (*label_map)["source_canonical_service"]
+          : flatbuffers::GetString(peer_node_info.workload_name()),
+      "-->",
+      log_entries_request_->labels().at("destination_canonical_service")));
   (*label_map)["source_ip"] = request_info.source_address;
   (*label_map)["destination_ip"] = request_info.destination_address;
   (*label_map)["source_port"] = std::to_string(request_info.source_port);

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -259,15 +259,17 @@ void Logger::addTCPLabelsToLogEntry(
     google::logging::v2::LogEntry* log_entry) {
   auto label_map = log_entry->mutable_labels();
   setSourceCanonicalService(peer_node_info, label_map);
-  log_entry->set_text_payload(absl::StrCat(
-      label_map->find("source_canonical_service") != label_map->end()
-          ? (*label_map)["source_canonical_service"]
-          : flatbuffers::GetString(peer_node_info.workload_name()),
-      " --> ",
-      log_entries_request_->labels().find("destination_canonical_service") !=
-              log_entries_request_->labels().end()
-          ? log_entries_request_->labels().at("destination_canonical_service")
-          : request_info.destination_service_name));
+  auto source_cs_iter = label_map->find("source_canonical_service");
+  auto destination_cs_iter =
+      log_entries_request_->labels().find("destination_canonical_service");
+  log_entry->set_text_payload(
+      absl::StrCat(source_cs_iter != label_map->end()
+                       ? source_cs_iter->second
+                       : flatbuffers::GetString(peer_node_info.workload_name()),
+                   " --> ",
+                   destination_cs_iter != log_entries_request_->labels().end()
+                       ? destination_cs_iter->second
+                       : request_info.destination_service_name));
   (*label_map)["source_ip"] = request_info.source_address;
   (*label_map)["destination_ip"] = request_info.destination_address;
   (*label_map)["source_port"] = std::to_string(request_info.source_port);

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -176,12 +176,7 @@ void Logger::fillAndFlushLogEntry(
       (*label_map)["source_app"] = flatbuffers::GetString(app_iter->value());
     }
     if (label_map->find("source_canonical_service") == label_map->end()) {
-      auto ics_iter = peer_labels->LookupByKey(
-          Wasm::Common::kCanonicalServiceLabelName.data());
-      if (ics_iter) {
-        (*label_map)["source_canonical_service"] =
-            flatbuffers::GetString(ics_iter->value());
-      }
+      setSourceCanonicalService(peer_node_info, label_map);
     }
     auto rev_iter = peer_labels->LookupByKey(
         Wasm::Common::kCanonicalServiceRevisionLabelName.data());
@@ -268,8 +263,11 @@ void Logger::addTCPLabelsToLogEntry(
       label_map->find("source_canonical_service") != label_map->end()
           ? (*label_map)["source_canonical_service"]
           : flatbuffers::GetString(peer_node_info.workload_name()),
-      "-->",
-      log_entries_request_->labels().at("destination_canonical_service")));
+      " --> ",
+      log_entries_request_->labels().find("destination_canonical_service") !=
+              log_entries_request_->labels().end()
+          ? log_entries_request_->labels().at("destination_canonical_service")
+          : request_info.destination_service_name));
   (*label_map)["source_ip"] = request_info.source_address;
   (*label_map)["destination_ip"] = request_info.destination_address;
   (*label_map)["source_port"] = std::to_string(request_info.source_port);

--- a/extensions/stackdriver/log/logger.h
+++ b/extensions/stackdriver/log/logger.h
@@ -63,6 +63,7 @@ class Logger {
 
   // Add TCP Specific labels to LogEntry.
   void addTCPLabelsToLogEntry(const ::Wasm::Common::RequestInfo& request_info,
+                              const ::Wasm::Common::FlatNode& peer_node_info,
                               google::logging::v2::LogEntry* log_entry);
 
   // Fill Http_Request entry in LogEntry.

--- a/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
@@ -37,3 +37,8 @@ labels:
   x-envoy-original-dst-host: ""
   x-envoy-original-path: ""
 severity: INFO
+{{- if .Vars.SourceUnknownOnClose }}
+text_payload: "-->ratings"
+{{- else }}
+text_payload: "productpage-v1-->ratings"
+{{- end }}

--- a/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
@@ -38,7 +38,7 @@ labels:
   x-envoy-original-path: ""
 severity: INFO
 {{- if .Vars.SourceUnknownOnClose }}
-text_payload: "-->ratings"
+text_payload: " --> ratings"
 {{- else }}
-text_payload: "productpage-v1-->ratings"
+text_payload: "productpage-v1 --> ratings"
 {{- end }}

--- a/testdata/stackdriver/server_tcp_access_log_entry_on_no_mx.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry_on_no_mx.yaml.tmpl
@@ -21,3 +21,4 @@ labels:
   x-envoy-original-dst-host: ""
   x-envoy-original-path: ""
 severity: INFO
+text_payload: "productpage-v1-->ratings"

--- a/testdata/stackdriver/server_tcp_access_log_entry_on_no_mx.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry_on_no_mx.yaml.tmpl
@@ -21,4 +21,4 @@ labels:
   x-envoy-original-dst-host: ""
   x-envoy-original-path: ""
 severity: INFO
-text_payload: "productpage-v1-->ratings"
+text_payload: "productpage-v1 --> ratings"

--- a/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
@@ -38,7 +38,7 @@ labels:
   x-envoy-original-path: ""
 severity: INFO
 {{- if .Vars.SourceUnknownOnOpen }}
-text_payload: "-->ratings"
+text_payload: " --> ratings"
 {{- else }}
-text_payload: "productpage-v1-->ratings"
+text_payload: "productpage-v1 --> ratings"
 {{- end }}

--- a/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
@@ -37,3 +37,8 @@ labels:
   x-envoy-original-dst-host: ""
   x-envoy-original-path: ""
 severity: INFO
+{{- if .Vars.SourceUnknownOnOpen }}
+text_payload: "-->ratings"
+{{- else }}
+text_payload: "productpage-v1-->ratings"
+{{- end }}


### PR DESCRIPTION
Set TextPayload for TCP Access Log  and fix source_port showing up as 0 in TCP logs

Signed-off-by: gargnupur <gargnupur@google.com>

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
