### PR TITLE
Fix Blackthrough Passthrough clusters destination service name refactoring

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -115,7 +115,9 @@ void getDestinationService(const std::string& dest_namespace,
     return;
   }
 
-  if (cluster_name == kInboundPassthroughClusterIpv4 ||
+  if (cluster_name == kBlackHoleCluster ||
+      cluster_name == kPassThroughCluster ||
+      cluster_name == kInboundPassthroughClusterIpv4 ||
       cluster_name == kInboundPassthroughClusterIpv6) {
     *dest_svc_name = cluster_name;
     return;


### PR DESCRIPTION
Fix Blackthrough Passthrough clusters destination service name refactoring

Signed-off-by: gargnupur <gargnupur@google.com>

**What this PR does / why we need it**:
https://github.com/istio/proxy/commit/60f5e7928c412acd96bc1dcf00050ed67759143e deleted looking at cluster name for passthrough and blackhole.. it's looking only at route data for it..

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
