### PR TITLE
tests: fix parallel testing

### DIFF
--- a/test/envoye2e/driver/scenario.go
+++ b/test/envoye2e/driver/scenario.go
@@ -118,6 +118,13 @@ func (p *Params) Fill(s string) (string, error) {
 				pad := strings.Repeat(" ", n)
 				return pad + strings.Replace(s, "\n", "\n"+pad, -1)
 			},
+			"fill": func(s string) string {
+				out, err := p.Fill(s)
+				if err != nil {
+					panic(err)
+				}
+				return out
+			},
 		}).
 		Parse(s))
 	var b bytes.Buffer

--- a/test/envoye2e/env/utils.go
+++ b/test/envoye2e/env/utils.go
@@ -22,17 +22,15 @@ import (
 	"testing"
 )
 
-func GetDefaultEnvoyBin() string {
+func GetBazelBin() string {
 	// Note: `bazel info bazel-bin` returns incorrect path to a binary (always fastbuild, not opt or dbg)
 	// Instead we rely on symbolic link src/envoy/envoy in the workspace
 	workspace, _ := exec.Command("bazel", "info", "workspace").Output()
-	return filepath.Join(strings.TrimSuffix(string(workspace), "\n"), "bazel-bin/src/envoy/")
+	return filepath.Join(strings.TrimSuffix(string(workspace), "\n"), "bazel-bin/")
 }
 
-func GetBazelOptOut() string {
-	// `make build_wasm` puts generated wasm modules into k8-opt.
-	bazelOutput, _ := exec.Command("bazel", "info", "output_path").Output()
-	return filepath.Join(strings.TrimSuffix(string(bazelOutput), "\n"), "k8-opt/bin/")
+func GetDefaultEnvoyBin() string {
+	return filepath.Join(GetBazelBin(), "src/envoy/")
 }
 
 func SkipTSanASan(t *testing.T) {

--- a/test/envoye2e/http_metadata_exchange/exchange_test.go
+++ b/test/envoye2e/http_metadata_exchange/exchange_test.go
@@ -40,11 +40,11 @@ func EncodeMetadata(t *testing.T, p *driver.Params) string {
 }
 
 func TestHTTPExchange(t *testing.T) {
-	params := driver.NewTestParams(t, map[string]string{
-		"EnableMetadataExchange": "true",
-	}, envoye2e.ProxyE2ETests)
+	params := driver.NewTestParams(t, map[string]string{}, envoye2e.ProxyE2ETests)
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
+	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/mx_inbound.yaml.tmpl")
+	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/mx_outbound.yaml.tmpl")
 	if err := (&driver.Scenario{
 		[]driver.Step{
 			&driver.XDS{},

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -261,6 +261,7 @@ func TestStackdriverReload(t *testing.T) {
 }
 
 func TestStackdriverVMReload(t *testing.T) {
+	t.Skip("See issue https://github.com/istio/istio/issues/26548")
 	t.Parallel()
 	env.SkipTSanASan(t)
 	params := driver.NewTestParams(t, map[string]string{

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -24,12 +24,19 @@ import (
 	"istio.io/proxy/test/envoye2e/env"
 )
 
+func enableStackDriver(t *testing.T, vars map[string]string) {
+	t.Helper()
+	vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_inbound.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
+	vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_outbound.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+}
+
 func TestStackdriverPayload(t *testing.T) {
 	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
 		"ServiceAuthenticationPolicy": "NONE",
 		"SDLogStatusCode":             "200",
-		"EnableMetadataExchange":      "true",
 		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 		"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
 		"StatsConfig":                 driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
@@ -39,10 +46,9 @@ func TestStackdriverPayload(t *testing.T) {
 	stsPort := params.Ports.Max + 2
 	params.Vars["SDPort"] = strconv.Itoa(int(sdPort))
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
-	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
-	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	params.Vars["ClientMetadata"] = driver.LoadTestData("testdata/client_node_metadata.json.tmpl")
+	params.Vars["ServerMetadata"] = driver.LoadTestData("testdata/server_node_metadata.json.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}
 
@@ -85,20 +91,18 @@ func TestStackdriverPayload(t *testing.T) {
 func TestStackdriverPayloadGateway(t *testing.T) {
 	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
-		"RequestPath":            "echo",
-		"SDLogStatusCode":        "200",
-		"EnableMetadataExchange": "true",
-		"StackdriverRootCAFile":  driver.TestPath("testdata/certs/stackdriver.pem"),
-		"StackdriverTokenFile":   driver.TestPath("testdata/certs/access-token"),
-		"StatsConfig":            driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
+		"RequestPath":           "echo",
+		"SDLogStatusCode":       "200",
+		"StackdriverRootCAFile": driver.TestPath("testdata/certs/stackdriver.pem"),
+		"StackdriverTokenFile":  driver.TestPath("testdata/certs/access-token"),
+		"StatsConfig":           driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 	}, envoye2e.ProxyE2ETests)
 	sdPort := params.Ports.Max + 1
 	stsPort := params.Ports.Max + 2
 	params.Vars["SDPort"] = strconv.Itoa(int(sdPort))
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}
 
@@ -146,7 +150,6 @@ func TestStackdriverPayloadWithTLS(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{
 		"ServiceAuthenticationPolicy": "MUTUAL_TLS",
 		"SDLogStatusCode":             "200",
-		"EnableMetadataExchange":      "true",
 		"SourcePrincipal":             "spiffe://cluster.local/ns/default/sa/client",
 		"DestinationPrincipal":        "spiffe://cluster.local/ns/default/sa/server",
 		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
@@ -161,8 +164,7 @@ func TestStackdriverPayloadWithTLS(t *testing.T) {
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
 	params.Vars["ClientTLSContext"] = params.LoadTestData("testdata/transport_socket/client.yaml.tmpl")
 	params.Vars["ServerTLSContext"] = params.LoadTestData("testdata/transport_socket/server.yaml.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}
 
@@ -209,7 +211,6 @@ func TestStackdriverReload(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{
 		"ServiceAuthenticationPolicy": "NONE",
 		"SDLogStatusCode":             "200",
-		"EnableMetadataExchange":      "true",
 		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 		"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
 	}, envoye2e.ProxyE2ETests)
@@ -219,8 +220,7 @@ func TestStackdriverReload(t *testing.T) {
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}
 	if err := (&driver.Scenario{
@@ -266,7 +266,6 @@ func TestStackdriverVMReload(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{
 		"ServiceAuthenticationPolicy": "NONE",
 		"SDLogStatusCode":             "200",
-		"EnableMetadataExchange":      "true",
 		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 		"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
 		"ReloadVM":                    "true",
@@ -277,8 +276,7 @@ func TestStackdriverVMReload(t *testing.T) {
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}
 
@@ -331,7 +329,6 @@ func TestStackdriverGCEInstances(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{
 		"ServiceAuthenticationPolicy": "NONE",
 		"SDLogStatusCode":             "200",
-		"EnableMetadataExchange":      "true",
 		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 		"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
 	}, envoye2e.ProxyE2ETests)
@@ -341,8 +338,7 @@ func TestStackdriverGCEInstances(t *testing.T) {
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/gce_client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/gce_server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}
 	if err := (&driver.Scenario{
@@ -376,10 +372,9 @@ func TestStackdriverGCEInstances(t *testing.T) {
 func TestStackdriverParallel(t *testing.T) {
 	t.Parallel()
 	params := driver.NewTestParams(t, map[string]string{
-		"SDLogStatusCode":        "200",
-		"EnableMetadataExchange": "true",
-		"StackdriverRootCAFile":  driver.TestPath("testdata/certs/stackdriver.pem"),
-		"StackdriverTokenFile":   driver.TestPath("testdata/certs/access-token"),
+		"SDLogStatusCode":       "200",
+		"StackdriverRootCAFile": driver.TestPath("testdata/certs/stackdriver.pem"),
+		"StackdriverTokenFile":  driver.TestPath("testdata/certs/access-token"),
 	}, envoye2e.ProxyE2ETests)
 	sdPort := params.Ports.Max + 1
 	stsPort := params.Ports.Max + 2
@@ -387,8 +382,7 @@ func TestStackdriverParallel(t *testing.T) {
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort, Delay: 100 * time.Millisecond}
 
@@ -466,22 +460,21 @@ func TestStackdriverAccessLog(t *testing.T) {
 		respCode               string
 		logEntryCount          int
 		justSendErrorClientLog string
-		enableMetadataExchange string
+		enableMetadataExchange bool
 		sourceUnknown          string
 		destinationUnknown     string
 	}{
-		{"StackdriverAndAccessLogPlugin", "15s", 0, "200", 1, "", "true", "", ""},
-		{"RequestGetsLoggedAgain", "1s", 1 * time.Second, "201", 2, "", "true", "", ""},
-		{"AllErrorRequestsGetsLogged", "1s", 0, "403", 10, "", "true", "", ""},
-		{"AllClientErrorRequestsGetsLoggedOnNoMxAndError", "1s", 0, "403", 10, "true", "false", "true", "true"},
-		{"NoClientRequestsGetsLoggedOnErrorConfigAndAllSuccessRequests", "15s", 0, "200", 1, "true", "false", "true", "true"},
+		{"StackdriverAndAccessLogPlugin", "15s", 0, "200", 1, "", true, "", ""},
+		{"RequestGetsLoggedAgain", "1s", 1 * time.Second, "201", 2, "", true, "", ""},
+		{"AllErrorRequestsGetsLogged", "1s", 0, "403", 10, "", true, "", ""},
+		{"AllClientErrorRequestsGetsLoggedOnNoMxAndError", "1s", 0, "403", 10, "true", false, "true", "true"},
+		{"NoClientRequestsGetsLoggedOnErrorConfigAndAllSuccessRequests", "15s", 0, "200", 1, "true", false, "true", "true"},
 	}
 
 	for _, tt := range TestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			params := driver.NewTestParams(t, map[string]string{
 				"LogWindowDuration":           tt.logWindowDuration,
-				"EnableMetadataExchange":      tt.enableMetadataExchange,
 				"ServiceAuthenticationPolicy": "NONE",
 				"DirectResponseCode":          tt.respCode,
 				"SDLogStatusCode":             tt.respCode,
@@ -498,9 +491,15 @@ func TestStackdriverAccessLog(t *testing.T) {
 			params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 			params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 			params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-			params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/access_log_policy.yaml.tmpl") + "\n" +
-				params.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
-			params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+			params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/access_log_policy.yaml.tmpl") + "\n" +
+				driver.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
+			params.Vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
+			if tt.enableMetadataExchange {
+				params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_inbound.yaml.tmpl") + "\n" +
+					params.Vars["ServerHTTPFilters"]
+				params.Vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_outbound.yaml.tmpl") + "\n" +
+					params.Vars["ClientHTTPFilters"]
+			}
 
 			sd := &Stackdriver{Port: sdPort}
 			respCode, _ := strconv.Atoi(tt.respCode)
@@ -562,7 +561,6 @@ func TestStackdriverTCPMetadataExchange(t *testing.T) {
 			params := driver.NewTestParams(t, map[string]string{
 				"ServiceAuthenticationPolicy": "MUTUAL_TLS",
 				"SDLogStatusCode":             "200",
-				"EnableMetadataExchange":      "true",
 				"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 				"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
 				"SourcePrincipal":             "spiffe://cluster.local/ns/default/sa/client",

--- a/test/envoye2e/stats_plugin/README.md
+++ b/test/envoye2e/stats_plugin/README.md
@@ -98,7 +98,6 @@ params := driver.NewTestParams(t, map[string]string{
 				"StatsFilterCode": 			  "inline_string: \"envoy.wasm.stats\"",
 				"AttributeGenFilterConfig":   runtime.AttributeGenFilterCode,
 				"AttributeGenWasmRuntime":    runtime.WasmRuntime,
-				"EnableMetadataExchange":     "true",
 				"WasmRuntime":				  "envoy.wasm.runtime.null",
 				"StatsConfig":                driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 				"StatsFilterClientConfig":    driver.LoadTestJSON("testdata/stats/client_config.yaml"),

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -64,13 +64,13 @@ var Runtimes = []struct {
 		WasmRuntime:                "envoy.wasm.runtime.null",
 	},
 	{
-		MetadataExchangeFilterCode: "filename: " + filepath.Join(env.GetBazelOptOut(), "extensions/metadata_exchange.wasm"),
-		StatsFilterCode:            "filename: " + filepath.Join(env.GetBazelOptOut(), "extensions/stats.wasm"),
+		MetadataExchangeFilterCode: "filename: " + filepath.Join(env.GetBazelBin(), "extensions/metadata_exchange.wasm"),
+		StatsFilterCode:            "filename: " + filepath.Join(env.GetBazelBin(), "extensions/stats.wasm"),
 		WasmRuntime:                "envoy.wasm.runtime.v8",
 	},
 	{
-		MetadataExchangeFilterCode: "filename: " + filepath.Join(env.GetBazelOptOut(), "extensions/metadata_exchange.compiled.wasm"),
-		StatsFilterCode:            "filename: " + filepath.Join(env.GetBazelOptOut(), "extensions/stats.compiled.wasm"),
+		MetadataExchangeFilterCode: "filename: " + filepath.Join(env.GetBazelBin(), "extensions/metadata_exchange.compiled.wasm"),
+		StatsFilterCode:            "filename: " + filepath.Join(env.GetBazelBin(), "extensions/stats.compiled.wasm"),
 		WasmRuntime:                "envoy.wasm.runtime.v8",
 	},
 }
@@ -97,7 +97,7 @@ var TestCases = []struct {
 	},
 	{
 		Name:         "Customized",
-		ClientConfig: "testdata/stats/client_config_customized.yaml",
+		ClientConfig: "testdata/stats/client_config_customized.yaml.tmpl",
 		ClientStats: map[string]driver.StatMatcher{
 			"istio_custom":         &driver.ExactStat{"testdata/metric/client_custom_metric.yaml.tmpl"},
 			"istio_requests_total": &driver.ExactStat{"testdata/metric/client_request_total_customized.yaml.tmpl"},
@@ -137,9 +137,17 @@ var AttributeGenRuntimes = []struct {
 		WasmRuntime:            "envoy.wasm.runtime.null",
 	},
 	{
-		AttributeGenFilterCode: "filename: " + filepath.Join(env.GetBazelOptOut(), "extensions/attributegen.wasm"),
+		AttributeGenFilterCode: "filename: " + filepath.Join(env.GetBazelBin(), "extensions/attributegen.wasm"),
 		WasmRuntime:            "envoy.wasm.runtime.v8",
 	},
+}
+
+func enableStats(t *testing.T, vars map[string]string) {
+	t.Helper()
+	vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_inbound.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
+	vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_outbound.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stats_outbound.yaml.tmpl")
 }
 
 func TestStatsPayload(t *testing.T) {
@@ -150,7 +158,6 @@ func TestStatsPayload(t *testing.T) {
 				skipWasm(t, runtime.WasmRuntime)
 				params := driver.NewTestParams(t, map[string]string{
 					"RequestCount":               "10",
-					"EnableMetadataExchange":     "true",
 					"MetadataExchangeFilterCode": runtime.MetadataExchangeFilterCode,
 					"StatsFilterCode":            runtime.StatsFilterCode,
 					"WasmRuntime":                runtime.WasmRuntime,
@@ -161,8 +168,7 @@ func TestStatsPayload(t *testing.T) {
 				}, envoye2e.ProxyE2ETests)
 				params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 				params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-				params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
-				params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stats_outbound.yaml.tmpl")
+				enableStats(t, params.Vars)
 				if err := (&driver.Scenario{
 					[]driver.Step{
 						&driver.XDS{},
@@ -204,7 +210,6 @@ func TestStatsParallel(t *testing.T) {
 				"MetadataExchangeFilterCode": "inline_string: \"envoy.wasm.metadata_exchange\"",
 				"StatsFilterCode":            "inline_string: \"envoy.wasm.stats\"",
 				"WasmRuntime":                "envoy.wasm.runtime.null",
-				"EnableMetadataExchange":     "true",
 				"StatsConfig":                driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 				"StatsFilterClientConfig":    driver.LoadTestJSON(testCase.ClientConfig),
 				"StatsFilterServerConfig":    driver.LoadTestJSON("testdata/stats/server_config.yaml"),
@@ -215,14 +220,16 @@ func TestStatsParallel(t *testing.T) {
 			serverRequestTotal := &dto.MetricFamily{}
 			params.LoadTestProto("testdata/metric/client_request_total.yaml.tmpl", clientRequestTotal)
 			params.LoadTestProto("testdata/metric/server_request_total.yaml.tmpl", serverRequestTotal)
-			params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
-			params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stats_outbound.yaml.tmpl")
+			enableStats(t, params.Vars)
+
+			clientListenerTemplate := driver.LoadTestData("testdata/listener/client.yaml.tmpl")
+			serverListenerTemplate := driver.LoadTestData("testdata/listener/server.yaml.tmpl")
 
 			if err := (&driver.Scenario{
 				[]driver.Step{
 					&driver.XDS{},
-					&driver.Update{Node: "client", Version: "0", Listeners: []string{params.LoadTestData("testdata/listener/client.yaml.tmpl")}},
-					&driver.Update{Node: "server", Version: "0", Listeners: []string{params.LoadTestData("testdata/listener/server.yaml.tmpl")}},
+					&driver.Update{Node: "client", Version: "0", Listeners: []string{clientListenerTemplate}},
+					&driver.Update{Node: "server", Version: "0", Listeners: []string{serverListenerTemplate}},
 					&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
 					&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
 					&driver.Sleep{1 * time.Second},
@@ -245,12 +252,12 @@ func TestStatsParallel(t *testing.T) {
 									&driver.Update{
 										Node:      "client",
 										Version:   "{{.N}}",
-										Listeners: []string{params.LoadTestData("testdata/listener/client.yaml.tmpl")},
+										Listeners: []string{clientListenerTemplate},
 									},
 									&driver.Update{
 										Node:      "server",
 										Version:   "{{.N}}",
-										Listeners: []string{params.LoadTestData("testdata/listener/server.yaml.tmpl")},
+										Listeners: []string{serverListenerTemplate},
 									},
 									// may need short delay so we don't eat all the CPU
 									&driver.Sleep{100 * time.Millisecond},
@@ -277,15 +284,13 @@ func TestStatsGrpc(t *testing.T) {
 		"DisableDirectResponse":      "true",
 		"UsingGrpcBackend":           "true",
 		"GrpcResponseStatus":         "7",
-		"EnableMetadataExchange":     "true",
 		"StatsConfig":                driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 		"StatsFilterClientConfig":    driver.LoadTestJSON("testdata/stats/client_config.yaml"),
 		"StatsFilterServerConfig":    driver.LoadTestJSON("testdata/stats/server_config.yaml"),
 	}, envoye2e.ProxyE2ETests)
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
-	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stats_outbound.yaml.tmpl")
+	enableStats(t, params.Vars)
 	if err := (&driver.Scenario{
 		Steps: []driver.Step{
 			&driver.XDS{},
@@ -325,7 +330,6 @@ func TestAttributeGen(t *testing.T) {
 				"StatsFilterCode":            "inline_string: \"envoy.wasm.stats\"",
 				"AttributeGenFilterConfig":   runtime.AttributeGenFilterCode,
 				"AttributeGenWasmRuntime":    runtime.WasmRuntime,
-				"EnableMetadataExchange":     "true",
 				"WasmRuntime":                "envoy.wasm.runtime.null",
 				"StatsConfig":                driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
 				"StatsFilterClientConfig":    driver.LoadTestJSON("testdata/stats/client_config.yaml"),
@@ -334,9 +338,9 @@ func TestAttributeGen(t *testing.T) {
 			}, envoye2e.ProxyE2ETests)
 			params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 			params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-			params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/attributegen.yaml.tmpl") + "\n" +
-				params.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
-			params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/stats_outbound.yaml.tmpl")
+			enableStats(t, params.Vars)
+			params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/attributegen.yaml.tmpl") + "\n" +
+				params.Vars["ServerHTTPFilters"]
 			if err := (&driver.Scenario{
 				[]driver.Step{
 					&driver.XDS{},

--- a/testdata/bootstrap/client.yaml.tmpl
+++ b/testdata/bootstrap/client.yaml.tmpl
@@ -1,7 +1,7 @@
 node:
   id: client
   cluster: test-cluster
-  metadata: { {{ .Vars.ClientMetadata }} }
+  metadata: { {{ .Vars.ClientMetadata | fill }} }
 admin:
   access_log_path: /dev/null
   address:

--- a/testdata/bootstrap/server.yaml.tmpl
+++ b/testdata/bootstrap/server.yaml.tmpl
@@ -1,7 +1,7 @@
 node:
   id: server
   cluster: test-cluster
-  metadata: { {{ .Vars.ServerMetadata }} }
+  metadata: { {{ .Vars.ServerMetadata | fill }} }
 admin:
   access_log_path: /dev/null
   address:

--- a/testdata/filters/mx_inbound.yaml.tmpl
+++ b/testdata/filters/mx_inbound.yaml.tmpl
@@ -1,0 +1,23 @@
+- name: mx_inbound{{.N}}
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.http.wasm.v3.Wasm
+    value:
+      config:
+        vm_config:
+          {{- if .Vars.WasmRuntime }}
+          runtime: {{ .Vars.WasmRuntime }}
+          {{- else }}
+          runtime: envoy.wasm.runtime.null
+          {{- end }}
+          code:
+            {{- if .Vars.MetadataExchangeFilterCode }}
+            local: { {{ .Vars.MetadataExchangeFilterCode }} }
+            {{- else }}
+            local: { inline_string: "envoy.wasm.metadata_exchange" }
+            {{- end }}
+          allow_precompiled: true
+        configuration:
+          "@type": "type.googleapis.com/google.protobuf.StringValue"
+          value: |
+            { "max_peer_cache_size": 20 }

--- a/testdata/filters/mx_outbound.yaml.tmpl
+++ b/testdata/filters/mx_outbound.yaml.tmpl
@@ -1,0 +1,23 @@
+- name: mx_outbound{{.N}}
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.http.wasm.v3.Wasm
+    value:
+      config:
+        vm_config:
+          {{- if .Vars.WasmRuntime }}
+          runtime: {{ .Vars.WasmRuntime }}
+          {{- else }}
+          runtime: envoy.wasm.runtime.null
+          {{- end }}
+          code:
+            {{- if .Vars.MetadataExchangeFilterCode }}
+            local: { {{ .Vars.MetadataExchangeFilterCode }} }
+            {{- else }}
+            local: { inline_string: "envoy.wasm.metadata_exchange" }
+            {{- end }}
+          allow_precompiled: true
+        configuration:
+          "@type": "type.googleapis.com/google.protobuf.StringValue"
+          value: |
+            { "max_peer_cache_size": 20 }

--- a/testdata/filters/stackdriver_inbound.yaml.tmpl
+++ b/testdata/filters/stackdriver_inbound.yaml.tmpl
@@ -1,4 +1,4 @@
-- name: envoy.filters.http.wasm
+- name: stackdriver_inbound
   typed_config:
     "@type": type.googleapis.com/udpa.type.v1.TypedStruct
     type_url: envoy.extensions.filters.http.wasm.v3.Wasm

--- a/testdata/filters/stackdriver_outbound.yaml.tmpl
+++ b/testdata/filters/stackdriver_outbound.yaml.tmpl
@@ -1,4 +1,4 @@
-- name: envoy.filters.http.wasm
+- name: stackdriver_outbound
   typed_config:
     "@type": type.googleapis.com/udpa.type.v1.TypedStruct
     type_url: envoy.extensions.filters.http.wasm.v3.Wasm

--- a/testdata/filters/stats_inbound.yaml.tmpl
+++ b/testdata/filters/stats_inbound.yaml.tmpl
@@ -1,10 +1,10 @@
-- name: envoy.filters.http.wasm
+- name: stats_inbound{{ .N }}
   typed_config:
     "@type": type.googleapis.com/udpa.type.v1.TypedStruct
     type_url: envoy.extensions.filters.http.wasm.v3.Wasm
     value:
       config:
-        root_id: "stats_inbound"
+        root_id: stats_inbound
         vm_config:
           vm_id: stats_inbound{{ .N }}
           runtime: {{ .Vars.WasmRuntime }}
@@ -14,4 +14,4 @@
         configuration:
           "@type": "type.googleapis.com/google.protobuf.StringValue"
           value: |
-            {{ .Vars.StatsFilterServerConfig }}
+            {{ .Vars.StatsFilterServerConfig | fill }}

--- a/testdata/filters/stats_outbound.yaml.tmpl
+++ b/testdata/filters/stats_outbound.yaml.tmpl
@@ -1,10 +1,10 @@
-- name: envoy.filters.http.wasm
+- name: stats_outbound{{ .N }}
   typed_config:
     "@type": type.googleapis.com/udpa.type.v1.TypedStruct
     type_url: envoy.extensions.filters.http.wasm.v3.Wasm
     value:
       config:
-        root_id: "stats_outbound"
+        root_id: stats_outbound
         vm_config:
           vm_id: stats_outbound{{ .N }}
           runtime: {{ .Vars.WasmRuntime }}
@@ -14,5 +14,5 @@
         configuration:
           "@type": "type.googleapis.com/google.protobuf.StringValue"
           value: |
-            {{ .Vars.StatsFilterClientConfig }}
+            {{ .Vars.StatsFilterClientConfig | fill }}
 

--- a/testdata/listener/client.yaml.tmpl
+++ b/testdata/listener/client.yaml.tmpl
@@ -15,34 +15,7 @@ filter_chains:
       codec_type: AUTO
       stat_prefix: client
       http_filters:
-{{- if eq .Vars.EnableMetadataExchange "true" }}
-      - name: envoy.filters.http.wasm
-        typed_config:
-          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              vm_config:
-                {{- if .Vars.WasmRuntime }}
-                runtime: {{ .Vars.WasmRuntime }}
-                {{- else }}
-                runtime: envoy.wasm.runtime.null
-                {{- end }}
-                code:
-                  {{- if .Vars.MetadataExchangeFilterCode }}
-                  local: { {{ .Vars.MetadataExchangeFilterCode }} }
-                  {{- else }}
-                  local: { inline_string: "envoy.wasm.metadata_exchange" }
-                  {{- end }}
-                allow_precompiled: true
-              configuration:
-                "@type": "type.googleapis.com/google.protobuf.StringValue"
-                value: |
-                  { "max_peer_cache_size": 20 }
-{{- end }}
-{{- if ne .Vars.ClientHTTPFilters "" }}
-{{ .Vars.ClientHTTPFilters | indent 6 }}
-{{- end }}
+{{ .Vars.ClientHTTPFilters | fill | indent 6 }}
       - name: envoy.router
       route_config:
         name: client

--- a/testdata/listener/server.yaml.tmpl
+++ b/testdata/listener/server.yaml.tmpl
@@ -15,34 +15,7 @@ filter_chains:
       codec_type: AUTO
       stat_prefix: server
       http_filters:
-{{- if eq .Vars.EnableMetadataExchange "true" }}
-      - name: envoy.filters.http.wasm
-        typed_config:
-          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              vm_config:
-                {{- if .Vars.WasmRuntime }}
-                runtime: {{ .Vars.WasmRuntime }}
-                {{- else }}
-                runtime: envoy.wasm.runtime.null
-                {{- end }}
-                code:
-                  {{- if .Vars.MetadataExchangeFilterCode }}
-                  local: { {{ .Vars.MetadataExchangeFilterCode }} }
-                  {{- else }}
-                  local: { inline_string: "envoy.wasm.metadata_exchange" }
-                  {{- end }}
-                allow_precompiled: true
-              configuration:
-                "@type": "type.googleapis.com/google.protobuf.StringValue"
-                value: |
-                  { "max_peer_cache_size": 20 }
-{{- end }}
-{{- if ne .Vars.ServerHTTPFilters "" }}
-{{ .Vars.ServerHTTPFilters | indent 6 }}
-{{- end }}
+{{ .Vars.ServerHTTPFilters | fill | indent 6 }}
       - name: envoy.router
       route_config:
         name: server

--- a/testdata/listener/tcp_client.yaml.tmpl
+++ b/testdata/listener/tcp_client.yaml.tmpl
@@ -9,9 +9,7 @@ listener_filters:
 - name: "envoy.filters.listener.http_inspector"
 filter_chains:
 - filters:
-{{- if .Vars.ClientNetworkFilters }}
-{{ .Vars.ClientNetworkFilters | indent 2 }}
-{{- end }}
+{{ .Vars.ClientNetworkFilters | fill | indent 2 }}
   - name: tcp_proxy
     typed_config:
       "@type": type.googleapis.com/udpa.type.v1.TypedStruct

--- a/testdata/listener/tcp_server.yaml.tmpl
+++ b/testdata/listener/tcp_server.yaml.tmpl
@@ -9,9 +9,7 @@ listener_filters:
 - name: "envoy.filters.listener.http_inspector"
 filter_chains:
 - filters:
-{{- if .Vars.ServerNetworkFilters }}
-{{ .Vars.ServerNetworkFilters | indent 2 }}
-{{- end }}
+{{ .Vars.ServerNetworkFilters | fill | indent 2 }}
   - name: tcp_proxy
     typed_config:
       "@type": type.googleapis.com/udpa.type.v1.TypedStruct

--- a/testdata/stats/client_config_customized.yaml.tmpl
+++ b/testdata/stats/client_config_customized.yaml.tmpl
@@ -25,7 +25,7 @@ metrics:
       request_protocol: request.protocol
       destination_version: "'_' + (has(node.metadata.LABELS.version) ? node.metadata.LABELS.version : 'unknown')"
       destination_service_namespace: "'_' + upstream_peer.labels['app'].value"
-      destination_app: "cannot _ parse"
+      destination_app: "cannot _ parse | {{ .N }}"
       destination_workload: "cannot_evaluate"
     tags_to_remove:
     - grpc_response_status


### PR DESCRIPTION
Templates were filled once instead of repeatedly for every iteration. So it kept the config identical and not exercising VM reloading. Fix by delaying templating.

Also, move out metadata exchange config. This will be used to load it dynamically just like others.