### PR TITLE
Add prow script for centos postsubmit build

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -66,7 +66,8 @@ BAZEL_ENVOY_PATH ?= $(BAZEL_OUTPUT_PATH)/k8-fastbuild/bin/src/envoy/envoy
 
 CENTOS_BUILD_ARGS ?= --cxxopt -D_GLIBCXX_USE_CXX11_ABI=1 --cxxopt -DENVOY_IGNORE_GLIBCXX_USE_CXX11_ABI_ERROR=1
 # WASM is not build on CentOS, skip it
-CENTOS_BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS} -tools/deb/... -tools/docker/... -extensions:stats.wasm -extensions:metadata_exchange.wasm -extensions:attributegen.wasm
+# TODO can we do some sort of regex?
+CENTOS_BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS} -tools/deb/... -tools/docker/... -extensions:stats.wasm -extensions:metadata_exchange.wasm -extensions:attributegen.wasm -extensions/common:json_util_wasm -extensions:basic_auth.wasm
 
 build:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) $(BAZEL_TARGETS)

--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -14,5 +14,5 @@
 
 # this repo is not on the container plan by default
 BUILD_WITH_CONTAINER ?= 0
-IMAGE_NAME = build-tools-proxy
+IMAGE_NAME ?= build-tools-proxy
 CGO_ENABLED = 0

--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -56,7 +56,7 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
   # Use RBE when logged in.
-  BAZEL_BUILD_RBE_INSTANCE="${BAZEL_BUILD_RBE_INSTANCE:-projects/istio-testing/instances/default_instance}"
+  BAZEL_BUILD_RBE_INSTANCE="${BAZEL_BUILD_RBE_INSTANCE-projects/istio-testing/instances/default_instance}"
   BAZEL_BUILD_RBE_CACHE="${BAZEL_BUILD_RBE_CACHE:-grpcs://remotebuildexecution.googleapis.com}"
   BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-200}"
   if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then

--- a/prow/proxy-postsubmit-centos.sh
+++ b/prow/proxy-postsubmit-centos.sh
@@ -28,8 +28,6 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth configure-docker
 fi
 
-GIT_SHA="$(git rev-parse --verify HEAD)"
-
 GCS_BUILD_BUCKET="${GCS_BUILD_BUCKET:-istio-build}"
 
 echo 'Create and push artifacts'

--- a/prow/proxy-postsubmit-centos.sh
+++ b/prow/proxy-postsubmit-centos.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright 2017 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+WD=$(dirname "$0")
+WD=$(cd "$WD" || exit 1 ; pwd)
+
+########################################
+# Postsubmit script triggered by Prow. #
+########################################
+# shellcheck disable=SC1090
+source "${WD}/proxy-common.inc"
+
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  echo "Detected GOOGLE_APPLICATION_CREDENTIALS, configuring Docker..." >&2
+  gcloud auth configure-docker
+fi
+
+GIT_SHA="$(git rev-parse --verify HEAD)"
+
+GCS_BUILD_BUCKET="${GCS_BUILD_BUCKET:-istio-build}"
+
+echo 'Create and push artifacts'
+make push_release_centos RELEASE_GCS_PATH="gs://${GCS_BUILD_BUCKET}/proxy"

--- a/prow/proxy-presubmit-centos-release.sh
+++ b/prow/proxy-presubmit-centos-release.sh
@@ -20,6 +20,9 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
+# Do not use RBE for this, RBE will run ubuntu instance
+export BAZEL_BUILD_RBE_INSTANCE=""
+
 # shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 


### PR DESCRIPTION
This adds a postsubmit script for centos build. Will be enabled in https://github.com/istio/test-infra/pull/2896.

Additionally, there are some minor fixes to the centos logic which broke since the original merge (its not yet blocking)