### PR TITLE
Minor additions to Access Logs

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -370,7 +370,7 @@ void populateExtendedRequestInfo(RequestInfo* request_info) {
   getValue({"connection_id"}, &request_info->connection_id);
   getValue({"upstream", "address"}, &request_info->upstream_host);
   getValue({"connection", "requested_server_name"},
-           &request_info->request_serever_name);
+           &request_info->requested_server_name);
   auto envoy_original_path = getHeaderMapValue(
       WasmHeaderMapType::RequestHeaders, kEnvoyOriginalPathKey);
   request_info->x_envoy_original_path =
@@ -379,6 +379,8 @@ void populateExtendedRequestInfo(RequestInfo* request_info) {
       WasmHeaderMapType::RequestHeaders, kEnvoyOriginalDstHostKey);
   request_info->x_envoy_original_dst_host =
       envoy_original_dst_host ? envoy_original_dst_host->toString() : "";
+  getValue({"upstream", "transport_failure_reason"},
+           &request_info->upstream_transport_failure_reason);
 }
 
 void populateTCPRequestInfo(bool outbound, RequestInfo* request_info,

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -130,6 +130,8 @@ struct RequestInfo {
   // The path portion of the URL without the query string.
   std::string request_url_path;
 
+  std::string upstream_transport_failure_reason;
+
   // Service authentication policy (NONE, MUTUAL_TLS)
   ServiceAuthenticationPolicy service_auth_policy =
       ServiceAuthenticationPolicy::Unspecified;
@@ -151,7 +153,7 @@ struct RequestInfo {
   std::string route_name;
   std::string upstream_host;
   std::string upstream_cluster;
-  std::string request_serever_name;
+  std::string requested_server_name;
   std::string x_envoy_original_path;
   std::string x_envoy_original_dst_host;
 

--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -113,6 +113,8 @@ constexpr char kLoggingExportIntervalKey[] =
     "STACKDRIVER_LOGGING_EXPORT_INTERVAL_SECS";
 constexpr char kTcpLogEntryTimeoutKey[] =
     "STACKDRIVER_TCP_LOG_ENTRY_TIMEOUT_SECS";
+constexpr char kProxyTickerIntervalKey[] =
+    "STACKDRIVER_PROXY_TICKER_INTERVAL_SECS";
 constexpr char kTokenFile[] = "STACKDRIVER_TOKEN_FILE";
 constexpr char kCACertFile[] = "STACKDRIVER_ROOT_CA_FILE";
 

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -27,7 +27,7 @@ package stackdriver.config.v1alpha1;
 import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
-// next id: 12
+// next id: 14
 message PluginConfig {
   // Types of Access logs to export. Does not affect audit logging.
   enum AccessLogging {
@@ -44,6 +44,17 @@ message PluginConfig {
   // Optional. Controls whether to export server access log.
   // This is deprecated in favor of AccessLogging enum.
   bool disable_server_access_logging = 1 [deprecated = true];
+
+  // Optional. Allows configuration of the size of the LogWrite request. The
+  // size is in bytes, so that it allows for better performance. Default is 4MB.
+  // The size of one log entry within LogWrite request is approx 1Kb.
+  int32 max_log_batch_size_in_bytes = 12;
+
+  // Optional. Allows configuration of the time between calls out to the
+  // stackdriver logging service to report buffered LogWrite request.
+  // Customers can choose to report more aggressively by keeping shorter report
+  // interval if needed. Default is 10s.
+  google.protobuf.Duration log_report_duration = 13;
 
   // Optional. Controls whether to export audit log.
   bool enable_audit_log = 11;

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -298,13 +298,29 @@ void Logger::fillAndFlushLogEntry(
     (*label_map)["protocol"] = request_info.request_protocol;
     (*label_map)["log_sampled"] = request_info.log_sampled ? "true" : "false";
     (*label_map)["connection_id"] = std::to_string(request_info.connection_id);
-    (*label_map)["route_name"] = request_info.route_name;
-    (*label_map)["upstream_host"] = request_info.upstream_host;
+    if (!request_info.route_name.empty()) {
+      (*label_map)["route_name"] = request_info.route_name;
+    }
+    if (!request_info.upstream_host.empty()) {
+      (*label_map)["upstream_host"] = request_info.upstream_host;
+    }
     (*label_map)["upstream_cluster"] = request_info.upstream_cluster;
-    (*label_map)["requested_server_name"] = request_info.request_serever_name;
-    (*label_map)["x-envoy-original-path"] = request_info.x_envoy_original_path;
-    (*label_map)["x-envoy-original-dst-host"] =
-        request_info.x_envoy_original_dst_host;
+    if (!request_info.requested_server_name.empty()) {
+      (*label_map)["requested_server_name"] =
+          request_info.requested_server_name;
+    }
+    if (!request_info.x_envoy_original_path.empty()) {
+      (*label_map)["x-envoy-original-path"] =
+          request_info.x_envoy_original_path;
+    }
+    if (!request_info.x_envoy_original_dst_host.empty()) {
+      (*label_map)["x-envoy-original-dst-host"] =
+          request_info.x_envoy_original_dst_host;
+    }
+    if (!request_info.upstream_transport_failure_reason.empty()) {
+      (*label_map)["upstream_transport_failure_reason"] =
+          request_info.upstream_transport_failure_reason;
+    }
   }
 
   // Insert trace headers, if exist.

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -129,7 +129,7 @@ const ::Wasm::Common::FlatNode& peerNodeInfo(
   request_info.upstream_cluster =
       "inbound|9080|http|server.default.svc.cluster.local";
   request_info.upstream_host = "1.1.1.1:1000";
-  request_info.request_serever_name = "server.com";
+  request_info.requested_server_name = "server.com";
   request_info.x_envoy_original_dst_host = "tmp.com";
   request_info.x_envoy_original_path = "/tmp";
   return request_info;

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -45,6 +45,7 @@ constexpr long int kDefaultEdgeNewReportDurationNanoseconds =
 constexpr long int kDefaultEdgeEpochReportDurationNanoseconds =
     600000000000;                                                        // 10m
 constexpr long int kDefaultTcpLogEntryTimeoutNanoseconds = 60000000000;  // 1m
+constexpr long int kDefaultLogExportNanoseconds = 10000000000;           // 10s
 
 #ifdef NULL_PLUGIN
 PROXY_WASM_NULL_PLUGIN_REGISTRY;
@@ -159,6 +160,10 @@ class StackdriverRootContext : public RootContext {
       kDefaultEdgeEpochReportDurationNanoseconds;
 
   long int tcp_log_entry_timeout_ = kDefaultTcpLogEntryTimeoutNanoseconds;
+
+  long int last_log_report_call_nanos_ = 0;
+
+  long int log_report_duration_nanos_ = kDefaultLogExportNanoseconds;
 
   bool use_host_header_fallback_;
   bool initialized_ = false;

--- a/testdata/stackdriver/client_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/client_access_log_entry.yaml.tmpl
@@ -36,8 +36,4 @@ labels:
   log_sampled: "false"
   {{- end }}
   upstream_cluster: "outbound|9080|http|server.default.svc.cluster.local"
-  route_name: ""
-  requested_server_name: ""
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO

--- a/testdata/stackdriver/client_gateway_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/client_gateway_access_log_entry.yaml.tmpl
@@ -21,8 +21,4 @@ labels:
   destination_canonical_service: ratings
   log_sampled: "false"
   upstream_cluster: "outbound|9080|http|server.default.svc.cluster.local"
-  route_name: ""
-  requested_server_name: ""
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO

--- a/testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl
@@ -24,10 +24,6 @@ labels:
   connection_state: "CLOSE"
   log_sampled: "false"
   upstream_cluster: "outbound|9080|tcp|server.default.svc.cluster.local"
-  route_name: ""
-  requested_server_name: ""
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO
 {{- if .Vars.DestinationUnknown }}
 text_payload: "productpage-v1 --> server.default.svc.cluster.local"

--- a/testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl
+++ b/testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl
@@ -24,10 +24,6 @@ labels:
   connection_state: "OPEN"
   log_sampled: "false"
   upstream_cluster: "outbound|9080|tcp|server.default.svc.cluster.local"
-  route_name: ""
-  requested_server_name: ""
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO
 {{- if .Vars.DestinationUnknown }}
 text_payload: "productpage-v1 --> server.default.svc.cluster.local"

--- a/testdata/stackdriver/gateway_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/gateway_access_log_entry.yaml.tmpl
@@ -21,8 +21,4 @@ labels:
   source_canonical_revision: version-1
   log_sampled: "false"
   upstream_cluster: "inbound|9080|http|server.default.svc.cluster.local"
-  route_name: ""
-  requested_server_name: ""
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO

--- a/testdata/stackdriver/server_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_access_log_entry.yaml.tmpl
@@ -35,8 +35,4 @@ labels:
   log_sampled: "false"
   {{- end }}
   upstream_cluster: "inbound|9080|http|server.default.svc.cluster.local"
-  route_name: ""
-  requested_server_name: ""
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO

--- a/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
@@ -33,10 +33,7 @@ labels:
   connection_state: "CLOSE"
   log_sampled: "false"
   upstream_cluster: "inbound|9080|tcp|server.default.svc.cluster.local"
-  route_name: ""
   requested_server_name: "server.com"
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO
 {{- if .Vars.SourceUnknownOnClose }}
 text_payload: " --> ratings"

--- a/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
@@ -33,10 +33,7 @@ labels:
   connection_state: "OPEN"
   log_sampled: "false"
   upstream_cluster: "inbound|9080|tcp|server.default.svc.cluster.local"
-  route_name: ""
   requested_server_name: "server.com"
-  x-envoy-original-dst-host: ""
-  x-envoy-original-path: ""
 severity: INFO
 {{- if .Vars.SourceUnknownOnOpen }}
 text_payload: " --> ratings"


### PR DESCRIPTION
Minor additions to Access Logs
1) Made batch size and interval for reporting configurable
2) Don't add labels if they are empty-> this is done for labels that are known to empty sometimes
3) Add upstream_transport_failure_reason label to logs

Signed-off-by: gargnupur <gargnupur@google.com>

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
