### PR TITLE
Remove unneeded check in release build

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -188,7 +188,7 @@ push_release: build
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)" -p
 
 push_release_centos:
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)"
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c -d "$(RELEASE_GCS_PATH)"
 
 # Used by build container to export the build output from the docker volume cache
 exportcache:

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -182,13 +182,13 @@ test_release:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh
 
 test_release_centos:
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -i
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh
 
 push_release: build
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)" -p
 
 push_release_centos:
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -i -d "$(RELEASE_GCS_PATH)"
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)"
 
 # Used by build container to export the build output from the docker volume cache
 exportcache:

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -182,7 +182,7 @@ test_release:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh
 
 test_release_centos:
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c
 
 push_release: build
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)" -p

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -81,13 +81,16 @@ if [ "${DST}" == "none" ]; then
 fi
 
 # Make sure the release binaries are built on x86_64 Ubuntu 16.04 (Xenial)
-if [ "${CHECK}" -eq 1 ]; then
+if [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 0 ]; then
   if [[ "${BAZEL_BUILD_ARGS}" != *"--config=remote-"* ]]; then
     UBUNTU_RELEASE=${UBUNTU_RELEASE:-$(lsb_release -c -s)}
     [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'Must run on Ubuntu 16.04 (Xenial).'; exit 1; }
   fi
   [[ "$(uname -m)" == 'x86_64' ]] || { echo 'Must run on x86_64.'; exit 1; }
-elif [ -n "${DST}" ] && [ "${BUILD_FOR_CENTOS}" -ne 0 ]; then
+elif [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 1 ]; then
+# Make sure the release binaries are built on CentOS 7
+  [[ $(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1) == "7" ]] || { echo "Must run on CentOS 7, got $(cat /centos-release)"; exit 1; }
+elif [ -n "${DST}" ]; then
   echo "The -i option is not allowed together with -d option."
   exit 1
 fi

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -49,12 +49,16 @@ BUILD_ENVOY_BINARY_ONLY="${BUILD_ENVOY_BINARY_ONLY:-0}"
 # Push envoy docker image.
 PUSH_DOCKER_IMAGE=0
 
+# Support CentOS builds
+BUILD_FOR_CENTOS=0
+
 function usage() {
   echo "$0
     -d  The bucket name to store proxy binary (optional).
         If not provided, both envoy binary push and docker image push are skipped.
     -i  Skip Ubuntu Xenial check. DO NOT USE THIS FOR RELEASED BINARIES.
-        Cannot be used together with -d option.
+        Cannot be used together with -d option unless -c is set.
+    -c  Build for CentOS releases. This will disable the Ubuntu Xenial check.
     -p  Push envoy docker image.
         Registry is hard coded to gcr.io and repository is controlled via DOCKER_REPOSITORY env var."
   exit 1
@@ -65,6 +69,7 @@ while getopts d:ipc arg ; do
     d) DST="${OPTARG}";;
     i) CHECK=0;;
     p) PUSH_DOCKER_IMAGE=1;;
+    c) BUILD_FOR_CENTOS=1;;
     *) usage;;
   esac
 done
@@ -82,6 +87,9 @@ if [ "${CHECK}" -eq 1 ]; then
     [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'Must run on Ubuntu 16.04 (Xenial).'; exit 1; }
   fi
   [[ "$(uname -m)" == 'x86_64' ]] || { echo 'Must run on x86_64.'; exit 1; }
+elif [ -n "${DST}" ] && [ "${BUILD_FOR_CENTOS}" -ne 0 ]; then
+  echo "The -i option is not allowed together with -d option."
+  exit 1
 fi
 
 # The proxy binary name.

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -89,7 +89,7 @@ if [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 0 ]; then
   [[ "$(uname -m)" == 'x86_64' ]] || { echo 'Must run on x86_64.'; exit 1; }
 elif [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 1 ]; then
 # Make sure the release binaries are built on CentOS 7
-  [[ $(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1) == "7" ]] || { echo "Must run on CentOS 7, got $(cat /centos-release)"; exit 1; }
+  [[ $(</etc/centos-release tr -dc '0-9.'|cut -d \. -f1) == "7" ]] || { echo "Must run on CentOS 7, got $(cat /centos-release)"; exit 1; }
 elif [ -n "${DST}" ]; then
   echo "The -i option is not allowed together with -d option."
   exit 1

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -57,7 +57,7 @@ function usage() {
     -d  The bucket name to store proxy binary (optional).
         If not provided, both envoy binary push and docker image push are skipped.
     -i  Skip Ubuntu Xenial check. DO NOT USE THIS FOR RELEASED BINARIES.
-        Cannot be used together with -d option unless -c is set.
+        Cannot be used together with -d option.
     -c  Build for CentOS releases. This will disable the Ubuntu Xenial check.
     -p  Push envoy docker image.
         Registry is hard coded to gcr.io and repository is controlled via DOCKER_REPOSITORY env var."
@@ -88,7 +88,7 @@ if [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 0 ]; then
   fi
   [[ "$(uname -m)" == 'x86_64' ]] || { echo 'Must run on x86_64.'; exit 1; }
 elif [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 1 ]; then
-# Make sure the release binaries are built on CentOS 7
+  # Make sure the release binaries are built on CentOS 7
   [[ $(</etc/centos-release tr -dc '0-9.'|cut -d \. -f1) == "7" ]] || { echo "Must run on CentOS 7, got $(cat /centos-release)"; exit 1; }
 elif [ -n "${DST}" ]; then
   echo "The -i option is not allowed together with -d option."

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -82,9 +82,6 @@ if [ "${CHECK}" -eq 1 ]; then
     [[ "${UBUNTU_RELEASE}" == 'xenial' ]] || { echo 'Must run on Ubuntu 16.04 (Xenial).'; exit 1; }
   fi
   [[ "$(uname -m)" == 'x86_64' ]] || { echo 'Must run on x86_64.'; exit 1; }
-elif [ -n "${DST}" ]; then
-  echo "The -i option is not allowed together with -d option."
-  exit 1
 fi
 
 # The proxy binary name.


### PR DESCRIPTION
This blocks centos, which is intentionally passing -i and -d. I think
its reasonable to remove the check entirely rather than changing the
logic around, since passing `-i` is already explicitly opting out of the
check

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
