### PR TITLE
Fix binary name for centos

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -182,13 +182,13 @@ test_release:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh
 
 test_release_centos:
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BASE_BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c
 
 push_release: build
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)" -p
 
 push_release_centos:
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c -d "$(RELEASE_GCS_PATH)"
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BASE_BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c -d "$(RELEASE_GCS_PATH)"
 
 # Used by build container to export the build output from the docker volume cache
 exportcache:

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -41,7 +41,7 @@ DST=""
 CHECK=1
 
 # Defines the base binary name for artifacts. For example, this will be "envoy-debug".
-BINARY_NAME="${BINARY_NAME:-"envoy"}"
+BASE_BINARY_NAME="${BASE_BINARY_NAME:-"envoy"}"
 
 # If enabled, we will just build the Envoy binary rather then docker images, deb, wasm, etc
 BUILD_ENVOY_BINARY_ONLY="${BUILD_ENVOY_BINARY_ONLY:-0}"
@@ -116,14 +116,14 @@ do
   case $config in
     "release" )
       CONFIG_PARAMS="--config=release"
-      BINARY_BASE_NAME="envoy-alpha"
+      BINARY_BASE_NAME="${BASE_BINARY_NAME}-alpha"
       PACKAGE_BASE_NAME="istio-proxy"
       # shellcheck disable=SC2086
       BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "release-symbol")
       CONFIG_PARAMS="--config=release-symbol"
-      BINARY_BASE_NAME="envoy-symbol"
+      BINARY_BASE_NAME="${BASE_BINARY_NAME}-symbol"
       PACKAGE_BASE_NAME=""
       # shellcheck disable=SC2086
       BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
@@ -132,14 +132,14 @@ do
       # NOTE: libc++ is dynamically linked in this build.
       PUSH_DOCKER_IMAGE=0
       CONFIG_PARAMS="${BAZEL_CONFIG_ASAN} --config=release-symbol"
-      BINARY_BASE_NAME="envoy-asan"
+      BINARY_BASE_NAME="${BASE_BINARY_NAME}-asan"
       PACKAGE_BASE_NAME=""
       # shellcheck disable=SC2086
       BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-opt/bin"
       ;;
     "debug")
       CONFIG_PARAMS="--config=debug"
-      BINARY_BASE_NAME="envoy-debug"
+      BINARY_BASE_NAME="${BASE_BINARY_NAME}-debug"
       PACKAGE_BASE_NAME="istio-proxy-debug"
       # shellcheck disable=SC2086
       BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-dbg/bin"


### PR DESCRIPTION
The build is green but its overwriting the ubunutu image since we didn't
properly pull the BINARY_NAME option that was added through to all
locations (and had a naming conflict). I think this should be the last
change needed but unfortunately its a bit hard to test postsubmit jobs

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
