### PR TITLE
fix(fake): preserve trace attributes in stackdriver fake

### DIFF
--- a/test/envoye2e/stackdriver_plugin/cmd/Makefile
+++ b/test/envoye2e/stackdriver_plugin/cmd/Makefile
@@ -18,7 +18,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 SD_PATH := $(dir $(MKFILE_PATH))
 IMG := gcr.io/istio-testing/fake-stackdriver
-TAG := 4.0
+TAG := 5.0
 
 all: build_and_push clean
 

--- a/test/envoye2e/stackdriver_plugin/fake_stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/fake_stackdriver.go
@@ -341,7 +341,7 @@ func (s *TracesServer) BatchWriteSpans(ctx context.Context, req *cloudtracev2.Ba
 		}
 
 		for key, val := range span.Attributes.AttributeMap {
-			newTraceSpan.Labels[key] = val.String()
+			newTraceSpan.Labels[key] = val.GetStringValue().Value
 		}
 
 		if existingTrace, ok := s.traceMap[traceID]; ok {

--- a/test/envoye2e/stackdriver_plugin/fake_stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/fake_stackdriver.go
@@ -340,6 +340,10 @@ func (s *TracesServer) BatchWriteSpans(ctx context.Context, req *cloudtracev2.Ba
 			newTraceSpan.Labels["root"] = span.DisplayName.GetValue()
 		}
 
+		for key, val := range span.Attributes.AttributeMap {
+			newTraceSpan.Labels[key] = val.String()
+		}
+
 		if existingTrace, ok := s.traceMap[traceID]; ok {
 			existingTrace.Spans = append(existingTrace.Spans, newTraceSpan)
 		} else {


### PR DESCRIPTION
This enables testing that checks on the `custom_tags` functionality for Stackdriver. In particular, it will be used to verify the ability to annotate Cloud Trace spans with canonical service information.