### PR TITLE
fix: implement metadata fallback on the special value

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -280,36 +280,21 @@ flatbuffers::DetachedBuffer extractLocalNodeFlatBuffer() {
   return fbb.Release();
 }
 
-PeerNodeInfo::PeerNodeInfo(const std::string_view peer_metadata_id_key,
-                           const std::string_view peer_metadata_key) {
-  fallback_peer_node_ = extractEmptyNodeFlatBuffer();
-  found_ = getValue({peer_metadata_id_key}, &peer_id_);
-  if (found_) {
-    getValue({peer_metadata_key}, &peer_node_);
-    return;
-  }
-  if (peer_metadata_id_key == kDownstreamMetadataIdKey) {
-    // Downstream peer's metadata will never be in localhost endpoint. Skip
-    // looking for it.
-    return;
-  }
-
-  // Construct a fallback peer node metadata based on endpoint labels if it is
-  // not in filter state.
+bool extractPeerMetadataFromUpstreamHostMetadata(
+    flatbuffers::FlatBufferBuilder& fbb) {
   std::string endpoint_labels;
   if (!getValue(
           {"upstream_host_metadata", "filter_metadata", "istio", "workload"},
           &endpoint_labels)) {
-    return;
+    return false;
   }
   std::vector<std::string_view> parts = absl::StrSplit(endpoint_labels, ';');
   // workload label should semicolon separated four parts string:
   // workload_name;namespace;canonical_service;canonical_revision.
   if (parts.size() < 4) {
-    return;
+    return false;
   }
 
-  flatbuffers::FlatBufferBuilder fbb;
   flatbuffers::Offset<flatbuffers::String> workload_name, namespace_;
   std::vector<flatbuffers::Offset<KeyVal>> labels;
   workload_name = fbb.CreateString(parts[0]);
@@ -332,7 +317,37 @@ PeerNodeInfo::PeerNodeInfo(const std::string_view peer_metadata_id_key,
   node.add_labels(labels_offset);
   auto data = node.Finish();
   fbb.Finish(data);
-  fallback_peer_node_ = fbb.Release();
+  return true;
+}
+
+PeerNodeInfo::PeerNodeInfo(const std::string_view peer_metadata_id_key,
+                           const std::string_view peer_metadata_key) {
+  found_ = getValue({peer_metadata_id_key}, &peer_id_);
+  if (peer_id_ == kMetadataNotFoundValue) {
+    // Sentinel value is preserved as ID to implement maybeWaiting.
+    found_ = false;
+    fallback_peer_node_ = extractEmptyNodeFlatBuffer();
+    return;
+  }
+  if (found_) {
+    getValue({peer_metadata_key}, &peer_node_);
+    return;
+  }
+  if (peer_metadata_id_key == kDownstreamMetadataIdKey) {
+    // Downstream peer's metadata will never be in localhost endpoint. Skip
+    // looking for it.
+    fallback_peer_node_ = extractEmptyNodeFlatBuffer();
+    return;
+  }
+
+  // Construct a fallback peer node metadata based on endpoint labels if it is
+  // not in filter state.
+  flatbuffers::FlatBufferBuilder fbb;
+  if (extractPeerMetadataFromUpstreamHostMetadata(fbb)) {
+    fallback_peer_node_ = fbb.Release();
+  } else {
+    fallback_peer_node_ = extractEmptyNodeFlatBuffer();
+  }
 }
 
 const ::Wasm::Common::FlatNode& PeerNodeInfo::get() const {

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -217,7 +217,7 @@ flatbuffers::DetachedBuffer extractEmptyNodeFlatBuffer();
 flatbuffers::DetachedBuffer extractLocalNodeFlatBuffer();
 
 // Extract upstream peer metadata from upstream host metadata.
-// Returns true if the metadat is found in the upstream host metadata.
+// Returns true if the metadata is found in the upstream host metadata.
 bool extractPeerMetadataFromUpstreamHostMetadata(
     flatbuffers::FlatBufferBuilder& fbb);
 

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -32,6 +32,9 @@ constexpr std::string_view kUpstreamMetadataKey = "upstream_peer";
 constexpr std::string_view kDownstreamMetadataIdKey = "downstream_peer_id";
 constexpr std::string_view kDownstreamMetadataKey = "downstream_peer";
 
+// Sentinel value assigned to peer metadata ID key, indicating that the peer
+// metadata is absent. This is different from a missing peer metadata ID key
+// which could indicate that the metadata is not received yet.
 const std::string kMetadataNotFoundValue =
     "envoy.wasm.metadata_exchange.peer_unknown";
 
@@ -213,19 +216,33 @@ flatbuffers::DetachedBuffer extractEmptyNodeFlatBuffer();
 // address access.
 flatbuffers::DetachedBuffer extractLocalNodeFlatBuffer();
 
+// Extract upstream peer metadata from upstream host metadata.
+// Returns true if the metadat is found in the upstream host metadata.
+bool extractPeerMetadataFromUpstreamHostMetadata(
+    flatbuffers::FlatBufferBuilder& fbb);
+
 // Returns flatbuffer schema for node info.
 std::string_view nodeInfoSchema();
 
 class PeerNodeInfo {
  public:
-  PeerNodeInfo(const std::string_view peer_metadata_id_key,
-               const std::string_view peer_metadata_key);
+  explicit PeerNodeInfo(const std::string_view peer_metadata_id_key,
+                        const std::string_view peer_metadata_key);
+  PeerNodeInfo() = delete;
   const ::Wasm::Common::FlatNode& get() const;
-  const std::string& getId() const { return peer_id_; }
+  const std::string& id() const { return peer_id_; }
+
+  // Found indicates whether both ID and metadata is available.
   bool found() const { return found_; }
 
+  // Maybe waiting indicates that the metadata is not found but may arrive
+  // later.
+  bool maybeWaiting() const {
+    return !found_ && peer_id_ != ::Wasm::Common::kMetadataNotFoundValue;
+  }
+
  private:
-  bool found_ = false;
+  bool found_;
   std::string peer_id_;
   std::string peer_node_;
   flatbuffers::DetachedBuffer fallback_peer_node_;

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -449,7 +449,7 @@ void StackdriverRootContext::record() {
           "; skipping edge."));
       return;
     }
-    edge_reporter_->addEdge(request_info, peer_node_info.getId(),
+    edge_reporter_->addEdge(request_info, peer_node_info.id(),
                             peer_node_info.get());
   }
 }
@@ -477,9 +477,7 @@ bool StackdriverRootContext::recordTCP(uint32_t id) {
   getValue({"response", "flags"}, &response_flags);
   auto cur = static_cast<long int>(
       proxy_wasm::null_plugin::getCurrentTimeNanoseconds());
-  bool waiting_for_metadata =
-      !peer_node_info.found() &&
-      peer_node_info.getId() != ::Wasm::Common::kMetadataNotFoundValue;
+  bool waiting_for_metadata = peer_node_info.maybeWaiting();
   bool no_error = response_flags == 0;
   bool log_open_on_timeout =
       !record_info.tcp_open_entry_logged &&

--- a/extensions/stats/config.proto
+++ b/extensions/stats/config.proto
@@ -68,6 +68,7 @@ message PluginConfig {
   // next id: 7
   // The following settings should be rarely used.
   // Enable debug for this filter.
+  // DEPRECATED.
   bool debug = 1;
 
   // maximum size of the peer metadata cache.

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -455,7 +455,6 @@ bool PluginRootContext::configure(size_t configuration_size) {
     peer_metadata_key_ = ::Wasm::Common::kDownstreamMetadataKey;
   }
 
-  debug_ = JsonGetField<bool>(j, "debug").value_or(false);
   use_host_header_fallback_ =
       !JsonGetField<bool>(j, "disable_host_header_fallback").value_or(false);
 
@@ -561,7 +560,7 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
     // been no error in connection.
     uint64_t response_flags = 0;
     getValue({"response", "flags"}, &response_flags);
-    if (!peer_node_info.found() && response_flags == 0) {
+    if (peer_node_info.maybeWaiting() && response_flags == 0) {
       return false;
     }
     if (!request_info.is_populated) {

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -274,7 +274,6 @@ class PluginRootContext : public RootContext {
   std::string_view peer_metadata_id_key_;
   std::string_view peer_metadata_key_;
   bool outbound_;
-  bool debug_;
   bool use_host_header_fallback_;
 
   int64_t cache_hits_accumulator_ = 0;
@@ -309,7 +308,7 @@ class PluginRootContextInbound : public PluginRootContext {
 class PluginContext : public Context {
  public:
   explicit PluginContext(uint32_t id, RootContext* root)
-      : Context(id, root), is_tcp_(false), context_id_(id) {
+      : Context(id, root), is_tcp_(false) {
     request_info_ = std::make_shared<::Wasm::Common::RequestInfo>();
   }
 
@@ -329,7 +328,7 @@ class PluginContext : public Context {
     }
     is_tcp_ = true;
     request_info_->tcp_connections_opened++;
-    rootContext()->addToTCPRequestQueue(context_id_, request_info_);
+    rootContext()->addToTCPRequestQueue(id(), request_info_);
     return FilterStatus::Continue;
   }
 
@@ -356,12 +355,11 @@ class PluginContext : public Context {
   };
 
   void cleanupTCPOnClose() {
-    rootContext()->deleteFromTCPRequestQueue(context_id_);
+    rootContext()->deleteFromTCPRequestQueue(id());
     request_info_->tcp_connections_closed++;
   }
 
   bool is_tcp_;
-  uint32_t context_id_;
   std::shared_ptr<::Wasm::Common::RequestInfo> request_info_;
 };
 


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

- Fix handling of TCP metadata exchange in fallback extraction. Fallback if the metadata ID is the special "not found" value. Fixes a crash with a memory access into an empty string flatbuffer.
- Minor simplifications in stats plugin.