### PR TITLE
generalize interval reporting to HTTP

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -59,31 +59,28 @@ namespace {
 // * Otherwise, try fetching cluster metadata for destination service name and
 //   host. If cluster metadata is not available, set destination service name
 //   the same as destination service host.
-void getDestinationService(bool use_host_header, std::string* dest_svc_host,
-                           std::string* dest_svc_name,
-                           const std::string& cluster_name,
-                           const std::string& route_name) {
-  *dest_svc_host = use_host_header
-                       ? getHeaderMapValue(WasmHeaderMapType::RequestHeaders,
-                                           kAuthorityHeaderKey)
-                             ->toString()
-                       : "unknown";
+void populateDestinationService(bool use_host_header,
+                                RequestInfo* request_info) {
+  request_info->destination_service_host =
+      use_host_header ? request_info->url_host : "unknown";
 
   // override the cluster name if this is being sent to the
   // blackhole or passthrough cluster
+  const std::string& route_name = request_info->route_name;
   if (route_name == kBlackHoleRouteName) {
-    *dest_svc_name = kBlackHoleCluster;
+    request_info->destination_service_name = kBlackHoleCluster;
     return;
   } else if (route_name == kPassThroughRouteName) {
-    *dest_svc_name = kPassThroughCluster;
+    request_info->destination_service_name = kPassThroughCluster;
     return;
   }
 
+  const std::string& cluster_name = request_info->upstream_cluster;
   if (cluster_name == kBlackHoleCluster ||
       cluster_name == kPassThroughCluster ||
       cluster_name == kInboundPassthroughClusterIpv4 ||
       cluster_name == kInboundPassthroughClusterIpv6) {
-    *dest_svc_name = cluster_name;
+    request_info->destination_service_name = cluster_name;
     return;
   }
 
@@ -105,63 +102,57 @@ void getDestinationService(bool use_host_header, std::string* dest_svc_host,
   // identify the intended host.
   if (getValue({"cluster_metadata", "filter_metadata", "istio", "services", "0",
                 "name"},
-               dest_svc_name)) {
+               &request_info->destination_service_name)) {
     getValue({"cluster_metadata", "filter_metadata", "istio", "services", "0",
               "host"},
-             dest_svc_host);
+             &request_info->destination_service_host);
   } else {
     // if cluster metadata cannot be found, fallback to destination service
     // host. If host header fallback is enabled, this will be host header. If
     // host header fallback is disabled, this will be unknown. This could happen
     // if a request does not route to any cluster.
-    *dest_svc_name = *dest_svc_host;
+    request_info->destination_service_name =
+        request_info->destination_service_host;
   }
-}
-
-void populateRequestInfo(bool outbound, bool use_host_header_fallback,
-                         RequestInfo* request_info) {
-  request_info->is_populated = true;
-  getValue({"cluster_name"}, &request_info->upstream_cluster);
-  getValue({"route_name"}, &request_info->route_name);
-  // Fill in request info.
-  // Get destination service name and host based on cluster name and host
-  // header.
-  getDestinationService(
-      use_host_header_fallback, &request_info->destination_service_host,
-      &request_info->destination_service_name, request_info->upstream_cluster,
-      request_info->route_name);
-
-  getValue({"request", "url_path"}, &request_info->request_url_path);
-
-  uint64_t destination_port = 0;
-  if (outbound) {
-    getValue({"upstream", "port"}, &destination_port);
-    getValue({"upstream", "uri_san_peer_certificate"},
-             &request_info->destination_principal);
-    getValue({"upstream", "uri_san_local_certificate"},
-             &request_info->source_principal);
-  } else {
-    getValue({"destination", "port"}, &destination_port);
-
-    bool mtls = false;
-    if (getValue({"connection", "mtls"}, &mtls)) {
-      request_info->service_auth_policy =
-          mtls ? ::Wasm::Common::ServiceAuthenticationPolicy::MutualTLS
-               : ::Wasm::Common::ServiceAuthenticationPolicy::None;
-    }
-    getValue({"connection", "uri_san_local_certificate"},
-             &request_info->destination_principal);
-    getValue({"connection", "uri_san_peer_certificate"},
-             &request_info->source_principal);
-  }
-  request_info->destination_port = destination_port;
-
-  uint64_t response_flags = 0;
-  getValue({"response", "flags"}, &response_flags);
-  request_info->response_flag = parseResponseFlag(response_flags);
 }
 
 }  // namespace
+
+void populateRequestInfo(bool outbound, bool use_host_header_fallback,
+                         RequestInfo* request_info) {
+  if (!request_info->is_populated) {
+    request_info->is_populated = true;
+
+    getValue({"cluster_name"}, &request_info->upstream_cluster);
+    getValue({"route_name"}, &request_info->route_name);
+    // Fill in request info.
+    // Get destination service name and host based on cluster name and host
+    // header.
+    populateDestinationService(use_host_header_fallback, request_info);
+    uint64_t destination_port = 0;
+    if (outbound) {
+      getValue({"upstream", "port"}, &destination_port);
+      getValue({"upstream", "uri_san_peer_certificate"},
+               &request_info->destination_principal);
+      getValue({"upstream", "uri_san_local_certificate"},
+               &request_info->source_principal);
+    } else {
+      getValue({"destination", "port"}, &destination_port);
+
+      bool mtls = false;
+      if (getValue({"connection", "mtls"}, &mtls)) {
+        request_info->service_auth_policy =
+            mtls ? ::Wasm::Common::ServiceAuthenticationPolicy::MutualTLS
+                 : ::Wasm::Common::ServiceAuthenticationPolicy::None;
+      }
+      getValue({"connection", "uri_san_local_certificate"},
+               &request_info->destination_principal);
+      getValue({"connection", "uri_san_peer_certificate"},
+               &request_info->source_principal);
+    }
+    request_info->destination_port = destination_port;
+  }
+}
 
 std::string_view AuthenticationPolicyString(
     ServiceAuthenticationPolicy policy) {
@@ -184,6 +175,20 @@ std::string_view TCPConnectionStateString(TCPConnectionState state) {
       return kConnected;
     case TCPConnectionState::Close:
       return kClose;
+    default:
+      break;
+  }
+  return {};
+}
+
+std::string_view ProtocolString(Protocol protocol) {
+  switch (protocol) {
+    case Protocol::TCP:
+      return kProtocolTCP;
+    case Protocol::HTTP:
+      return kProtocolHTTP;
+    case Protocol::GRPC:
+      return kProtocolGRPC;
     default:
       break;
   }
@@ -362,6 +367,8 @@ const ::Wasm::Common::FlatNode& PeerNodeInfo::get() const {
 // Normally it is ok to use host header within the mesh, but not at ingress.
 void populateHTTPRequestInfo(bool outbound, bool use_host_header_fallback,
                              RequestInfo* request_info) {
+  populateRequestProtocol(request_info);
+  getValue({"request", "url_path"}, &request_info->request_url_path);
   populateRequestInfo(outbound, use_host_header_fallback, request_info);
 
   int64_t response_code = 0;
@@ -369,20 +376,16 @@ void populateHTTPRequestInfo(bool outbound, bool use_host_header_fallback,
     request_info->response_code = response_code;
   }
 
-  int64_t grpc_status_code = 2;
-  getValue({"response", "grpc_status"}, &grpc_status_code);
-  request_info->grpc_status = grpc_status_code;
+  uint64_t response_flags = 0;
+  if (getValue({"response", "flags"}, &response_flags)) {
+    request_info->response_flag = parseResponseFlag(response_flags);
+  }
 
-  if (kGrpcContentTypes.count(
-          getHeaderMapValue(WasmHeaderMapType::RequestHeaders,
-                            kContentTypeHeaderKey)
-              ->toString()) != 0) {
-    request_info->request_protocol = kProtocolGRPC;
+  if (request_info->request_protocol == Protocol::GRPC) {
+    int64_t grpc_status_code = 2;
+    getValue({"response", "grpc_status"}, &grpc_status_code);
+    request_info->grpc_status = grpc_status_code;
     populateGRPCInfo(request_info);
-  } else {
-    // TODO Add http/1.1, http/1.0, http/2 in a separate attribute.
-    // http|grpc classification is compatible with Mixerclient
-    request_info->request_protocol = kProtocolHTTP;
   }
 
   std::string operation_id;
@@ -449,7 +452,25 @@ void populateTCPRequestInfo(bool outbound, RequestInfo* request_info) {
   // host_header_fallback is for HTTP/gRPC only.
   populateRequestInfo(outbound, false, request_info);
 
-  request_info->request_protocol = kProtocolTCP;
+  uint64_t response_flags = 0;
+  if (getValue({"response", "flags"}, &response_flags)) {
+    request_info->response_flag = parseResponseFlag(response_flags);
+  }
+
+  request_info->request_protocol = Protocol::TCP;
+}
+
+void populateRequestProtocol(RequestInfo* request_info) {
+  if (kGrpcContentTypes.count(
+          getHeaderMapValue(WasmHeaderMapType::RequestHeaders,
+                            kContentTypeHeaderKey)
+              ->toString()) != 0) {
+    request_info->request_protocol = Protocol::GRPC;
+  } else {
+    // TODO Add http/1.1, http/1.0, http/2 in a separate attribute.
+    // http|grpc classification is compatible with Mixerclient
+    request_info->request_protocol = Protocol::HTTP;
+  }
 }
 
 bool populateGRPCInfo(RequestInfo* request_info) {

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -49,9 +49,9 @@ constexpr std::string_view kEnvoyOriginalDstHostKey =
     "x-envoy-original-dst-host";
 constexpr std::string_view kEnvoyOriginalPathKey = "x-envoy-original-path";
 
-const std::string kProtocolHTTP = "http";
-const std::string kProtocolGRPC = "grpc";
-const std::string kProtocolTCP = "tcp";
+constexpr std::string_view kProtocolHTTP = "http";
+constexpr std::string_view kProtocolGRPC = "grpc";
+constexpr std::string_view kProtocolTCP = "tcp";
 
 constexpr std::string_view kCanonicalServiceLabelName =
     "service.istio.io/canonical-name";
@@ -62,17 +62,24 @@ constexpr std::string_view kLatest = "latest";
 const std::set<std::string> kGrpcContentTypes{
     "application/grpc", "application/grpc+proto", "application/grpc+json"};
 
-enum class ServiceAuthenticationPolicy : int64_t {
+enum class ServiceAuthenticationPolicy : int8_t {
   Unspecified = 0,
   None = 1,
   MutualTLS = 2,
 };
 
-enum class TCPConnectionState : int64_t {
+enum class TCPConnectionState : int8_t {
   Unspecified = 0,
   Open = 1,
   Connected = 2,
   Close = 3,
+};
+
+enum class Protocol : uint32_t {
+  Unspecified = 0x0,
+  TCP = 0x1,
+  HTTP = 0x2,
+  GRPC = 0x4,
 };
 
 constexpr std::string_view kMutualTLS = "MUTUAL_TLS";
@@ -83,6 +90,7 @@ constexpr std::string_view kClose = "CLOSE";
 
 std::string_view AuthenticationPolicyString(ServiceAuthenticationPolicy policy);
 std::string_view TCPConnectionStateString(TCPConnectionState state);
+std::string_view ProtocolString(Protocol protocol);
 
 // None response flag.
 const std::string NONE = "-";
@@ -109,7 +117,7 @@ struct RequestInfo {
   uint64_t source_port = 0;
 
   // Protocol used the request (HTTP/1.1, gRPC, etc).
-  std::string request_protocol;
+  Protocol request_protocol = Protocol::Unspecified;
 
   // Response code of the request.
   uint32_t response_code = 0;
@@ -174,12 +182,12 @@ struct RequestInfo {
   std::string url_scheme;
 
   // TCP variables.
-  int64_t tcp_connections_opened = 0;
-  int64_t tcp_connections_closed = 0;
-  int64_t tcp_sent_bytes = 0;
-  int64_t tcp_received_bytes = 0;
-  int64_t tcp_total_sent_bytes = 0;
-  int64_t tcp_total_received_bytes = 0;
+  uint8_t tcp_connections_opened = 0;
+  uint8_t tcp_connections_closed = 0;
+  uint64_t tcp_sent_bytes = 0;
+  uint64_t tcp_received_bytes = 0;
+  uint64_t tcp_total_sent_bytes = 0;
+  uint64_t tcp_total_received_bytes = 0;
   TCPConnectionState tcp_connection_state = TCPConnectionState::Unspecified;
 
   bool is_populated = false;
@@ -188,6 +196,8 @@ struct RequestInfo {
   // gRPC variables.
   uint64_t request_message_count = 0;
   uint64_t response_message_count = 0;
+  uint64_t last_request_message_count = 0;
+  uint64_t last_response_message_count = 0;
 };
 
 // RequestContext contains all the information available in the request.
@@ -248,6 +258,12 @@ class PeerNodeInfo {
   flatbuffers::DetachedBuffer fallback_peer_node_;
 };
 
+// Populate shared information between all protocols.
+// Requires that the connections are established both downstrean and upstream.
+// Caches computation using is_populated field.
+void populateRequestInfo(bool outbound, bool use_host_header_fallback,
+                         RequestInfo* request_info);
+
 // populateHTTPRequestInfo populates the RequestInfo struct. It needs access to
 // the request context.
 void populateHTTPRequestInfo(bool outbound, bool use_host_header,
@@ -264,6 +280,9 @@ void populateExtendedRequestInfo(RequestInfo* request_info);
 // populateTCPRequestInfo populates the RequestInfo struct. It needs access to
 // the request context.
 void populateTCPRequestInfo(bool outbound, RequestInfo* request_info);
+
+// Detect HTTP and gRPC request protocols.
+void populateRequestProtocol(RequestInfo* request_info);
 
 // populateGRPCInfo fills gRPC-related information, such as message counts.
 // Returns true if all information is filled.

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -68,7 +68,7 @@ enum class ServiceAuthenticationPolicy : uint8_t {
   MutualTLS = 2,
 };
 
-enum class TCPConnectionState : int8_t {
+enum class TCPConnectionState : uint8_t {
   Unspecified = 0,
   Open = 1,
   Connected = 2,

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -62,7 +62,7 @@ constexpr std::string_view kLatest = "latest";
 const std::set<std::string> kGrpcContentTypes{
     "application/grpc", "application/grpc+proto", "application/grpc+json"};
 
-enum class ServiceAuthenticationPolicy : int8_t {
+enum class ServiceAuthenticationPolicy : uint8_t {
   Unspecified = 0,
   None = 1,
   MutualTLS = 2,

--- a/extensions/metadata_exchange/plugin.h
+++ b/extensions/metadata_exchange/plugin.h
@@ -49,12 +49,8 @@ class PluginRootContext : public RootContext {
  public:
   PluginRootContext(uint32_t id, std::string_view root_id)
       : RootContext(id, root_id) {}
-  ~PluginRootContext() = default;
-
   bool onConfigure(size_t) override;
   bool configure(size_t);
-  bool onStart(size_t) override { return true; };
-  void onTick() override{};
 
   std::string_view metadataValue() { return metadata_value_; };
   std::string_view nodeId() { return node_id_; };
@@ -78,7 +74,6 @@ class PluginContext : public Context {
     direction_ = ::Wasm::Common::getTrafficDirection();
   }
 
-  void onCreate() override{};
   FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
   FilterHeadersStatus onResponseHeaders(uint32_t, bool) override;
 

--- a/extensions/stackdriver/edges/edge_reporter.cc
+++ b/extensions/stackdriver/edges/edge_reporter.cc
@@ -155,11 +155,10 @@ void EdgeReporter::addEdge(const ::Wasm::Common::RequestInfo& request_info,
   edge->mutable_destination()->CopyFrom(node_instance_);
 
   auto protocol = request_info.request_protocol;
-  if (protocol == "http" || protocol == "HTTP") {
+  // TODO: add support for HTTPS
+  if (protocol == ::Wasm::Common::Protocol::HTTP) {
     edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_HTTP);
-  } else if (protocol == "https" || protocol == "HTTPS") {
-    edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_HTTPS);
-  } else if (protocol == "grpc" || protocol == "GRPC") {
+  } else if (protocol == ::Wasm::Common::Protocol::GRPC) {
     edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_GRPC);
   } else {
     edge->set_protocol(TrafficAssertion_Protocol_PROTOCOL_TCP);

--- a/extensions/stackdriver/edges/edge_reporter_test.cc
+++ b/extensions/stackdriver/edges/edge_reporter_test.cc
@@ -146,7 +146,7 @@ flatbuffers::DetachedBuffer nodeInfo(const std::string& data) {
   ::Wasm::Common::RequestInfo request_info;
   request_info.destination_service_host = "httpbin.org";
   request_info.destination_service_name = "httpbin";
-  request_info.request_protocol = "HTTP";
+  request_info.request_protocol = ::Wasm::Common::Protocol::HTTP;
   return request_info;
 }
 

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -295,7 +295,8 @@ void Logger::fillAndFlushLogEntry(
     (*label_map)["service_authentication_policy"] =
         std::string(::Wasm::Common::AuthenticationPolicyString(
             request_info.service_auth_policy));
-    (*label_map)["protocol"] = request_info.request_protocol;
+    (*label_map)["protocol"] =
+        ::Wasm::Common::ProtocolString(request_info.request_protocol);
     (*label_map)["log_sampled"] = request_info.log_sampled ? "true" : "false";
     (*label_map)["connection_id"] = std::to_string(request_info.connection_id);
     if (!request_info.route_name.empty()) {
@@ -441,7 +442,8 @@ void Logger::fillHTTPRequestInLogEntry(
   http_request->set_user_agent(request_info.user_agent);
   http_request->set_remote_ip(request_info.source_address);
   http_request->set_server_ip(request_info.destination_address);
-  http_request->set_protocol(request_info.request_protocol);
+  http_request->set_protocol(
+      ::Wasm::Common::ProtocolString(request_info.request_protocol).data());
   *http_request->mutable_latency() =
       google::protobuf::util::TimeUtil::NanosecondsToDuration(
           request_info.duration);

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -107,7 +107,7 @@ const ::Wasm::Common::FlatNode& peerNodeInfo(
   request_info.destination_service_host = "httpbin.org";
   request_info.destination_service_name = "httpbin";
   request_info.response_flag = "-";
-  request_info.request_protocol = "HTTP";
+  request_info.request_protocol = ::Wasm::Common::Protocol::HTTP;
   request_info.destination_principal = "destination_principal";
   request_info.source_principal = "source_principal";
   request_info.service_auth_policy =
@@ -161,7 +161,7 @@ std::string write_audit_request_json = R"({
            "referer":"www.google.com",
            "serverIp":"2.2.2.2",
            "latency":"10s",
-           "protocol":"HTTP"
+           "protocol":"http"
         },
         "timestamp":"1970-01-01T00:00:00Z",
         "severity":"INFO",
@@ -210,7 +210,7 @@ std::string write_log_request_json = R"({
            "referer":"www.google.com",
            "serverIp":"2.2.2.2",
            "latency":"10s",
-           "protocol":"HTTP"
+           "protocol":"http"
         },
         "timestamp":"1970-01-01T00:00:00Z",
         "severity":"INFO",
@@ -225,7 +225,7 @@ std::string write_log_request_json = R"({
            "service_authentication_policy":"MUTUAL_TLS",
            "source_workload":"test_peer_workload",
            "response_flag":"-",
-           "protocol":"HTTP",
+           "protocol":"http",
            "log_sampled":"false",
            "connection_id":"0",
            "upstream_cluster": "server-inbound-cluster",

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -97,7 +97,9 @@ TagKeyValueList getOutboundTagMap(
   TagKeyValueList outboundMap = {
       {meshUIDKey(),
        unknownIfEmpty(flatbuffers::GetString(local_node_info.mesh_id()))},
-      {requestProtocolKey(), unknownIfEmpty(request_info.request_protocol)},
+      {requestProtocolKey(),
+       unknownIfEmpty(std::string(
+           ::Wasm::Common::ProtocolString(request_info.request_protocol)))},
       {serviceAuthenticationPolicyKey(),
        unknownIfEmpty(std::string(::Wasm::Common::AuthenticationPolicyString(
            request_info.service_auth_policy)))},
@@ -142,7 +144,9 @@ TagKeyValueList getInboundTagMap(
   TagKeyValueList inboundMap = {
       {meshUIDKey(),
        unknownIfEmpty(flatbuffers::GetString(local_node_info.mesh_id()))},
-      {requestProtocolKey(), unknownIfEmpty(request_info.request_protocol)},
+      {requestProtocolKey(),
+       unknownIfEmpty(std::string(
+           ::Wasm::Common::ProtocolString(request_info.request_protocol)))},
       {serviceAuthenticationPolicyKey(),
        unknownIfEmpty(std::string(::Wasm::Common::AuthenticationPolicyString(
            request_info.service_auth_policy)))},
@@ -227,13 +231,13 @@ uint32_t httpCodeFromGrpc(uint32_t grpc_status) {
 void addHttpSpecificTags(const ::Wasm::Common::RequestInfo& request_info,
                          TagKeyValueList& tag_map) {
   const auto& operation =
-      request_info.request_protocol == ::Wasm::Common::kProtocolGRPC
+      request_info.request_protocol == ::Wasm::Common::Protocol::GRPC
           ? request_info.request_url_path
           : request_info.request_operation;
   tag_map.emplace_back(Metric::requestOperationKey(), operation);
 
   const auto& response_code =
-      request_info.request_protocol == ::Wasm::Common::kProtocolGRPC
+      request_info.request_protocol == ::Wasm::Common::Protocol::GRPC
           ? httpCodeFromGrpc(request_info.grpc_status)
           : request_info.response_code;
   tag_map.emplace_back(Metric::responseCodeKey(),

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -573,12 +573,8 @@ void PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
   if (request_info.request_protocol == Protocol::TCP) {
     // For TCP, if peer metadata is not available, peer id is set as not found.
     // Otherwise, we wait for metadata exchange to happen before we report any
-    // metric.
-    // We keep waiting if response flags is zero, as that implies, there has
-    // been no error in connection.
-    uint64_t response_flags = 0;
-    getValue({"response", "flags"}, &response_flags);
-    if (peer_node_info.maybeWaiting() && response_flags == 0) {
+    // metric, until the end.
+    if (peer_node_info.maybeWaiting() && !end_stream) {
       return;
     }
     ::Wasm::Common::populateTCPRequestInfo(outbound_, &request_info);

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -567,6 +567,7 @@ void PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
                                bool end_stream) {
   // HTTP peer metadata should be done by the time report is called for a
   // request info. TCP metadata might still be awaiting.
+  // Upstream host should be selected for metadata fallback.
   Wasm::Common::PeerNodeInfo peer_node_info(peer_metadata_id_key_,
                                             peer_metadata_key_);
   if (request_info.request_protocol == Protocol::TCP) {
@@ -589,11 +590,6 @@ void PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
       ::Wasm::Common::populateHTTPRequestInfo(
           outbound_, useHostHeaderFallback(), &request_info);
     } else {
-      // Await for upstream host selection to resolve destination service.
-      int64_t port;
-      if (!getValue({"upstream", "port"}, &port)) {
-        return;
-      }
       ::Wasm::Common::populateRequestInfo(outbound_, useHostHeaderFallback(),
                                           &request_info);
       if (request_info.request_protocol == Protocol::GRPC) {

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -47,6 +47,7 @@ using ::Wasm::Common::JsonArrayIterate;
 using ::Wasm::Common::JsonGetField;
 using ::Wasm::Common::JsonObjectIterate;
 using ::Wasm::Common::JsonValueAs;
+using ::Wasm::Common::Protocol;
 
 namespace {
 
@@ -148,7 +149,8 @@ void map_request(IstioDimensions& instance,
   instance[destination_principal] = request.destination_principal;
   instance[destination_service] = request.destination_service_host;
   instance[destination_service_name] = request.destination_service_name;
-  instance[request_protocol] = request.request_protocol;
+  instance[request_protocol] =
+      ::Wasm::Common::ProtocolString(request.request_protocol);
   instance[response_code] = std::to_string(request.response_code);
   instance[response_flags] = request.response_flag;
   instance[connection_security_policy] = absl::AsciiStrToLower(std::string(
@@ -162,17 +164,11 @@ void map(IstioDimensions& instance, bool outbound,
   map_peer(instance, outbound, peer_node);
   map_request(instance, request);
   map_unknown_if_empty(instance);
-  if (request.request_protocol == "grpc") {
+  if (request.request_protocol == Protocol::GRPC) {
     instance[grpc_response_status] = std::to_string(request.grpc_status);
   } else {
     instance[grpc_response_status] = "";
   }
-}
-
-void clearTcpMetrics(::Wasm::Common::RequestInfo& request_info) {
-  request_info.tcp_connections_opened = 0;
-  request_info.tcp_sent_bytes = 0;
-  request_info.tcp_received_bytes = 0;
 }
 
 }  // namespace
@@ -190,60 +186,89 @@ const std::vector<MetricTag>& PluginRootContext::defaultTags() {
 const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
   static const std::vector<MetricFactory> default_metrics = {
       // HTTP, HTTP/2, and GRPC metrics
-      MetricFactory{
-          "requests_total", MetricType::Counter,
-          [](const ::Wasm::Common::RequestInfo&) -> uint64_t { return 1; },
-          false, count_standard_labels},
-      MetricFactory{
-          "request_duration_milliseconds", MetricType::Histogram,
-          [](const ::Wasm::Common::RequestInfo& request_info) -> uint64_t {
-            return request_info.duration /* in nanoseconds */ / 1000000;
-          },
-          false, count_standard_labels},
+      MetricFactory{"requests_total", MetricType::Counter,
+                    [](::Wasm::Common::RequestInfo&) -> uint64_t { return 1; },
+                    static_cast<uint32_t>(Protocol::HTTP) |
+                        static_cast<uint32_t>(Protocol::GRPC),
+                    count_standard_labels, false},
+      MetricFactory{"request_duration_milliseconds", MetricType::Histogram,
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      return request_info.duration /* in nanoseconds */ /
+                             1000000;
+                    },
+                    static_cast<uint32_t>(Protocol::HTTP) |
+                        static_cast<uint32_t>(Protocol::GRPC),
+                    count_standard_labels, false},
       MetricFactory{"request_bytes", MetricType::Histogram,
-                    [](const ::Wasm::Common::RequestInfo& request_info)
-                        -> uint64_t { return request_info.request_size; },
-                    false, count_standard_labels},
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      return request_info.request_size;
+                    },
+                    static_cast<uint32_t>(Protocol::HTTP) |
+                        static_cast<uint32_t>(Protocol::GRPC),
+                    count_standard_labels, false},
       MetricFactory{"response_bytes", MetricType::Histogram,
-                    [](const ::Wasm::Common::RequestInfo& request_info)
-                        -> uint64_t { return request_info.response_size; },
-                    false, count_standard_labels},
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      return request_info.response_size;
+                    },
+                    static_cast<uint32_t>(Protocol::HTTP) |
+                        static_cast<uint32_t>(Protocol::GRPC),
+                    count_standard_labels, false},
+
       // GRPC streaming metrics.
       // These metrics are dimensioned by peer labels as a minimum.
       // TODO: consider adding connection security policy
-      MetricFactory{
-          "request_messages_total", MetricType::Counter,
-          [](const ::Wasm::Common::RequestInfo& request_info) -> uint64_t {
-            return request_info.request_message_count;
-          },
-          false, count_peer_labels},
-      MetricFactory{
-          "response_messages_total", MetricType::Counter,
-          [](const ::Wasm::Common::RequestInfo& request_info) -> uint64_t {
-            return request_info.response_message_count;
-          },
-          false, count_peer_labels},
+      MetricFactory{"request_messages_total", MetricType::Counter,
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      uint64_t out = request_info.request_message_count -
+                                     request_info.last_request_message_count;
+                      request_info.last_request_message_count =
+                          request_info.request_message_count;
+                      return out;
+                    },
+                    static_cast<uint32_t>(Protocol::GRPC), count_peer_labels,
+                    true},
+      MetricFactory{"response_messages_total", MetricType::Counter,
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      uint64_t out = request_info.response_message_count -
+                                     request_info.last_response_message_count;
+                      request_info.last_response_message_count =
+                          request_info.response_message_count;
+                      return out;
+                    },
+                    static_cast<uint32_t>(Protocol::GRPC), count_peer_labels,
+                    true},
+
       // TCP metrics.
       MetricFactory{"tcp_sent_bytes_total", MetricType::Counter,
-                    [](const ::Wasm::Common::RequestInfo& request_info)
-                        -> uint64_t { return request_info.tcp_sent_bytes; },
-                    true, count_standard_labels},
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      uint64_t out = 0;
+                      std::swap(out, request_info.tcp_sent_bytes);
+                      return out;
+                    },
+                    static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
+                    true},
       MetricFactory{"tcp_received_bytes_total", MetricType::Counter,
-                    [](const ::Wasm::Common::RequestInfo& request_info)
-                        -> uint64_t { return request_info.tcp_received_bytes; },
-                    true, count_standard_labels},
-      MetricFactory{
-          "tcp_connections_opened_total", MetricType::Counter,
-          [](const ::Wasm::Common::RequestInfo& request_info) -> uint64_t {
-            return request_info.tcp_connections_opened;
-          },
-          true, count_standard_labels},
-      MetricFactory{
-          "tcp_connections_closed_total", MetricType::Counter,
-          [](const ::Wasm::Common::RequestInfo& request_info) -> uint64_t {
-            return request_info.tcp_connections_closed;
-          },
-          true, count_standard_labels},
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      uint64_t out = 0;
+                      std::swap(out, request_info.tcp_received_bytes);
+                      return out;
+                    },
+                    static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
+                    true},
+      MetricFactory{"tcp_connections_opened_total", MetricType::Counter,
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      uint8_t out = 0;
+                      std::swap(out, request_info.tcp_connections_opened);
+                      return out;
+                    },
+                    static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
+                    true},
+      MetricFactory{"tcp_connections_closed_total", MetricType::Counter,
+                    [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
+                      return request_info.tcp_connections_closed;
+                    },
+                    static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
+                    false},
   };
   return default_metrics;
 }
@@ -287,9 +312,8 @@ bool PluginRootContext::initializeDimensions(const json& j) {
         }
         auto& factory = factories[name];
         factory.name = name;
-        factory.extractor =
-            [token, name,
-             value](const ::Wasm::Common::RequestInfo&) -> uint64_t {
+        factory.extractor = [token, name,
+                             value](::Wasm::Common::RequestInfo&) -> uint64_t {
           int64_t result = 0;
           if (!evaluateExpression(token.value(), &result)) {
             LOG_TRACE(absl::StrCat("Failed to evaluate expression: <", value,
@@ -298,6 +322,9 @@ bool PluginRootContext::initializeDimensions(const json& j) {
           return result;
         };
         factory.type = MetricType::Counter;
+        factory.recurrent = false;
+        factory.protocols = static_cast<uint32_t>(Protocol::HTTP) |
+                            static_cast<uint32_t>(Protocol::GRPC);
         auto type =
             JsonGetField<std::string_view>(definition, "type").value_or("");
         if (type == "GAUGE") {
@@ -447,14 +474,6 @@ bool PluginRootContext::configure(size_t configuration_size) {
   }
 
   auto j = result.value();
-  if (outbound_) {
-    peer_metadata_id_key_ = ::Wasm::Common::kUpstreamMetadataIdKey;
-    peer_metadata_key_ = ::Wasm::Common::kUpstreamMetadataKey;
-  } else {
-    peer_metadata_id_key_ = ::Wasm::Common::kDownstreamMetadataIdKey;
-    peer_metadata_key_ = ::Wasm::Common::kDownstreamMetadataKey;
-  }
-
   use_host_header_fallback_ =
       !JsonGetField<bool>(j, "disable_host_header_fallback").value_or(false);
 
@@ -462,6 +481,7 @@ bool PluginRootContext::configure(size_t configuration_size) {
     return false;
   }
 
+  // TODO: rename to reporting_duration
   uint32_t tcp_report_duration_milis = kDefaultTCPReportDurationMilliseconds;
   auto tcp_reporting_duration_field =
       JsonGetField<std::string>(j, "tcp_reporting_duration");
@@ -526,10 +546,10 @@ bool PluginRootContext::onDone() {
 }
 
 void PluginRootContext::onTick() {
-  if (tcp_request_queue_.size() < 1) {
+  if (request_queue_.empty()) {
     return;
   }
-  for (auto const& item : tcp_request_queue_) {
+  for (auto const& item : request_queue_) {
     // requestinfo is null, so continue.
     if (item.second == nullptr) {
       continue;
@@ -539,20 +559,17 @@ void PluginRootContext::onTick() {
       continue;
     }
     context->setEffectiveContext();
-    if (report(*item.second, true)) {
-      // Clear existing data in TCP metrics, so that we don't double count the
-      // metrics.
-      clearTcpMetrics(*item.second);
-    }
+    report(*item.second, false);
   }
 }
 
-bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
-                               bool is_tcp) {
+void PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
+                               bool end_stream) {
+  // HTTP peer metadata should be done by the time report is called for a
+  // request info. TCP metadata might still be awaiting.
   Wasm::Common::PeerNodeInfo peer_node_info(peer_metadata_id_key_,
                                             peer_metadata_key_);
-
-  if (is_tcp) {
+  if (request_info.request_protocol == Protocol::TCP) {
     // For TCP, if peer metadata is not available, peer id is set as not found.
     // Otherwise, we wait for metadata exchange to happen before we report any
     // metric.
@@ -561,17 +578,32 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
     uint64_t response_flags = 0;
     getValue({"response", "flags"}, &response_flags);
     if (peer_node_info.maybeWaiting() && response_flags == 0) {
-      return false;
+      return;
     }
-    if (!request_info.is_populated) {
-      ::Wasm::Common::populateTCPRequestInfo(outbound_, &request_info);
-    }
+    ::Wasm::Common::populateTCPRequestInfo(outbound_, &request_info);
   } else {
-    ::Wasm::Common::populateHTTPRequestInfo(outbound_, useHostHeaderFallback(),
-                                            &request_info);
+    // Populate HTTP request info fully only at the end of the stream because
+    // onTick context has no access to request/response headers but can read
+    // from filter state.
+    if (end_stream) {
+      ::Wasm::Common::populateHTTPRequestInfo(
+          outbound_, useHostHeaderFallback(), &request_info);
+    } else {
+      // Await for upstream host selection to resolve destination service.
+      int64_t port;
+      if (!getValue({"upstream", "port"}, &port)) {
+        return;
+      }
+      ::Wasm::Common::populateRequestInfo(outbound_, useHostHeaderFallback(),
+                                          &request_info);
+      if (request_info.request_protocol == Protocol::GRPC) {
+        ::Wasm::Common::populateGRPCInfo(&request_info);
+      }
+    }
   }
 
   map(istio_dimensions_, outbound_, peer_node_info.get(), request_info);
+
   for (size_t i = 0; i < expressions_.size(); i++) {
     if (!evaluateExpression(expressions_[i].token,
                             &istio_dimensions_.at(count_standard_labels + i))) {
@@ -584,7 +616,9 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
   auto stats_it = metrics_.find(istio_dimensions_);
   if (stats_it != metrics_.end()) {
     for (auto& stat : stats_it->second) {
-      stat.record(request_info);
+      if (end_stream || stat.recurrent_) {
+        stat.record(request_info);
+      }
       LOG_DEBUG(
           absl::StrCat("metricKey cache hit ", ", stat=", stat.metric_id_));
     }
@@ -593,33 +627,35 @@ bool PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
       incrementMetric(cache_hits_, cache_hits_accumulator_);
       cache_hits_accumulator_ = 0;
     }
-    return true;
+    return;
   }
 
   std::vector<SimpleStat> stats;
   for (auto& statgen : stats_) {
-    if (statgen.is_tcp_metric() != is_tcp) {
+    if (!statgen.matchesProtocol(request_info.request_protocol)) {
       continue;
     }
     auto stat = statgen.resolve(istio_dimensions_);
     LOG_DEBUG(absl::StrCat("metricKey cache miss ", statgen.name(), " ",
-                           ", stat=", stat.metric_id_));
-    stat.record(request_info);
+                           ", stat=", stat.metric_id_,
+                           ", recurrent=", stat.recurrent_));
+    if (end_stream || stat.recurrent_) {
+      stat.record(request_info);
+    }
     stats.push_back(stat);
   }
 
   incrementMetric(cache_misses_, 1);
   metrics_.try_emplace(istio_dimensions_, stats);
-  return true;
 }
 
-void PluginRootContext::addToTCPRequestQueue(
-    uint32_t id, std::shared_ptr<::Wasm::Common::RequestInfo> request_info) {
-  tcp_request_queue_[id] = request_info;
+void PluginRootContext::addToRequestQueue(
+    uint32_t context_id, ::Wasm::Common::RequestInfo* request_info) {
+  request_queue_[context_id] = request_info;
 }
 
-void PluginRootContext::deleteFromTCPRequestQueue(uint32_t id) {
-  tcp_request_queue_.erase(id);
+void PluginRootContext::deleteFromRequestQueue(uint32_t context_id) {
+  request_queue_.erase(context_id);
 }
 
 #ifdef NULL_PLUGIN

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -190,7 +190,7 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                     [](::Wasm::Common::RequestInfo&) -> uint64_t { return 1; },
                     static_cast<uint32_t>(Protocol::HTTP) |
                         static_cast<uint32_t>(Protocol::GRPC),
-                    count_standard_labels, false},
+                    count_standard_labels, /* recurrent */ false},
       MetricFactory{"request_duration_milliseconds", MetricType::Histogram,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       return request_info.duration /* in nanoseconds */ /
@@ -198,21 +198,21 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                     },
                     static_cast<uint32_t>(Protocol::HTTP) |
                         static_cast<uint32_t>(Protocol::GRPC),
-                    count_standard_labels, false},
+                    count_standard_labels, /* recurrent */ false},
       MetricFactory{"request_bytes", MetricType::Histogram,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       return request_info.request_size;
                     },
                     static_cast<uint32_t>(Protocol::HTTP) |
                         static_cast<uint32_t>(Protocol::GRPC),
-                    count_standard_labels, false},
+                    count_standard_labels, /* recurrent */ false},
       MetricFactory{"response_bytes", MetricType::Histogram,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       return request_info.response_size;
                     },
                     static_cast<uint32_t>(Protocol::HTTP) |
                         static_cast<uint32_t>(Protocol::GRPC),
-                    count_standard_labels, false},
+                    count_standard_labels, /* recurrent */ false},
 
       // GRPC streaming metrics.
       // These metrics are dimensioned by peer labels as a minimum.
@@ -226,7 +226,7 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                       return out;
                     },
                     static_cast<uint32_t>(Protocol::GRPC), count_peer_labels,
-                    true},
+                    /* recurrent */ true},
       MetricFactory{"response_messages_total", MetricType::Counter,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       uint64_t out = request_info.response_message_count -
@@ -236,7 +236,7 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                       return out;
                     },
                     static_cast<uint32_t>(Protocol::GRPC), count_peer_labels,
-                    true},
+                    /* recurrent */ true},
 
       // TCP metrics.
       MetricFactory{"tcp_sent_bytes_total", MetricType::Counter,
@@ -246,7 +246,7 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                       return out;
                     },
                     static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
-                    true},
+                    /* recurrent */ true},
       MetricFactory{"tcp_received_bytes_total", MetricType::Counter,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       uint64_t out = 0;
@@ -254,7 +254,7 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                       return out;
                     },
                     static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
-                    true},
+                    /* recurrent */ true},
       MetricFactory{"tcp_connections_opened_total", MetricType::Counter,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       uint8_t out = 0;
@@ -262,13 +262,13 @@ const std::vector<MetricFactory>& PluginRootContext::defaultMetrics() {
                       return out;
                     },
                     static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
-                    true},
+                    /* recurrent */ true},
       MetricFactory{"tcp_connections_closed_total", MetricType::Counter,
                     [](::Wasm::Common::RequestInfo& request_info) -> uint64_t {
                       return request_info.tcp_connections_closed;
                     },
                     static_cast<uint32_t>(Protocol::TCP), count_tcp_labels,
-                    false},
+                    /* recurrent */ false},
   };
   return default_metrics;
 }

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -339,7 +339,9 @@ class PluginContext : public Context {
   // HTTP streams start with headers.
   FilterHeadersStatus onRequestHeaders(uint32_t, bool) override {
     ::Wasm::Common::populateRequestProtocol(&request_info_);
-    // Save host value for recurrent reporting
+    // Save host value for recurrent reporting.
+    // Beware that url_host and any other request headers are only available in this
+    // callback and onLog(), certainly not in onTick().
     if (rootContext()->useHostHeaderFallback()) {
       getValue({"request", "host"}, &request_info_.url_host);
     }

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -340,8 +340,8 @@ class PluginContext : public Context {
   FilterHeadersStatus onRequestHeaders(uint32_t, bool) override {
     ::Wasm::Common::populateRequestProtocol(&request_info_);
     // Save host value for recurrent reporting.
-    // Beware that url_host and any other request headers are only available in this
-    // callback and onLog(), certainly not in onTick().
+    // Beware that url_host and any other request headers are only available in
+    // this callback and onLog(), certainly not in onTick().
     if (rootContext()->useHostHeaderFallback()) {
       getValue({"request", "host"}, &request_info_.url_host);
     }

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -54,6 +54,8 @@ const std::string default_field_separator = ";.;";
 const std::string default_value_separator = "=.=";
 const std::string default_stat_prefix = "istio";
 
+// The order of the fields is important! The metrics indicate the cut-off line
+// using an index.
 #define STD_ISTIO_DIMENSIONS(FIELD_FUNC)     \
   FIELD_FUNC(reporter)                       \
   FIELD_FUNC(source_workload)                \

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -41,7 +41,6 @@ namespace Stats {
 
 template <typename K, typename V>
 using Map = std::unordered_map<K, V>;
-template <typename T>
 
 constexpr std::string_view Sep = "#@";
 
@@ -75,10 +74,10 @@ const std::string default_stat_prefix = "istio";
   FIELD_FUNC(destination_canonical_service)  \
   FIELD_FUNC(destination_canonical_revision) \
   FIELD_FUNC(request_protocol)               \
-  FIELD_FUNC(response_code)                  \
-  FIELD_FUNC(grpc_response_status)           \
   FIELD_FUNC(response_flags)                 \
-  FIELD_FUNC(connection_security_policy)
+  FIELD_FUNC(connection_security_policy)     \
+  FIELD_FUNC(response_code)                  \
+  FIELD_FUNC(grpc_response_status)
 
 // Aggregate metric values in a shared and reusable bag.
 using IstioDimensions = std::vector<std::string>;
@@ -95,11 +94,17 @@ enum class StandardLabels : int32_t {
 STD_ISTIO_DIMENSIONS(DECLARE_CONSTANT)
 #undef DECLARE_CONSTANT
 
+// All labels.
 const size_t count_standard_labels =
     static_cast<size_t>(StandardLabels::xxx_last_metric);
 
+// Labels related to peer information.
 const size_t count_peer_labels =
     static_cast<size_t>(StandardLabels::destination_canonical_revision) + 1;
+
+// Labels related to TCP streams, including peer information.
+const size_t count_tcp_labels =
+    static_cast<size_t>(StandardLabels::connection_security_policy) + 1;
 
 struct HashIstioDimensions {
   size_t operator()(const IstioDimensions& c) const {
@@ -112,16 +117,22 @@ struct HashIstioDimensions {
   }
 };
 
+// Value extractor can mutate the request info to flush data between multiple
+// reports.
 using ValueExtractorFn =
-    std::function<uint64_t(const ::Wasm::Common::RequestInfo& request_info)>;
+    std::function<uint64_t(::Wasm::Common::RequestInfo& request_info)>;
 
 // SimpleStat record a pre-resolved metric based on the values function.
 class SimpleStat {
  public:
-  SimpleStat(uint32_t metric_id, ValueExtractorFn value_fn, MetricType type)
-      : metric_id_(metric_id), value_fn_(value_fn), type_(type){};
+  SimpleStat(uint32_t metric_id, ValueExtractorFn value_fn, MetricType type,
+             bool recurrent)
+      : metric_id_(metric_id),
+        recurrent_(recurrent),
+        value_fn_(value_fn),
+        type_(type){};
 
-  inline void record(const ::Wasm::Common::RequestInfo& request_info) {
+  inline void record(::Wasm::Common::RequestInfo& request_info) {
     const uint64_t val = value_fn_(request_info);
     // Optimization: do not record 0 COUNTER values
     if (type_ == MetricType::Counter && val == 0) {
@@ -130,7 +141,8 @@ class SimpleStat {
     recordMetric(metric_id_, val);
   };
 
-  uint32_t metric_id_;
+  const uint32_t metric_id_;
+  const bool recurrent_;
 
  private:
   ValueExtractorFn value_fn_;
@@ -142,8 +154,10 @@ struct MetricFactory {
   std::string name;
   MetricType type;
   ValueExtractorFn extractor;
-  bool is_tcp;
+  uint32_t protocols;
   size_t count_labels;
+  // True for metrics supporting reporting mid-stream.
+  bool recurrent;
 };
 
 // StatGen creates a SimpleStat based on resolved metric_id.
@@ -155,7 +169,8 @@ class StatGen {
                    const std::vector<size_t>& indexes,
                    const std::string& field_separator,
                    const std::string& value_separator)
-      : is_tcp_(metric_factory.is_tcp),
+      : recurrent_(metric_factory.recurrent),
+        protocols_(metric_factory.protocols),
         indexes_(indexes),
         extractor_(metric_factory.extractor),
         metric_(metric_factory.type,
@@ -168,7 +183,9 @@ class StatGen {
 
   StatGen() = delete;
   inline std::string_view name() const { return metric_.name; };
-  inline bool is_tcp_metric() const { return is_tcp_; }
+  inline bool matchesProtocol(::Wasm::Common::Protocol protocol) const {
+    return (protocols_ & static_cast<uint32_t>(protocol)) != 0;
+  }
 
   // Resolve metric based on provided dimension values by
   // combining the tags with the indexed dimensions and resolving
@@ -188,11 +205,6 @@ class StatGen {
     n.reserve(s);
     n.append(metric_.prefix);
     for (size_t i = 0; i < metric_.tags.size(); i++) {
-      // Don't add response_code and grpc_response_status labels for TCP.
-      if ((metric_.tags[i].name == "response_code" ||
-           metric_.tags[i].name == "grpc_response_status") &&
-          is_tcp_)
-        continue;
       n.append(metric_.tags[i].name);
       n.append(metric_.value_separator);
       n.append(instance[indexes_[i]]);
@@ -200,13 +212,15 @@ class StatGen {
     }
     n.append(metric_.name);
     auto metric_id = metric_.resolveFullName(n);
-    return SimpleStat(metric_id, extractor_, metric_.type);
+    return SimpleStat(metric_id, extractor_, metric_.type, recurrent_);
   };
 
+  const bool recurrent_;
+
  private:
-  bool is_tcp_;
-  std::vector<size_t> indexes_;
-  ValueExtractorFn extractor_;
+  const uint32_t protocols_;
+  const std::vector<size_t> indexes_;
+  const ValueExtractorFn extractor_;
   Metric metric_;
 };
 
@@ -223,6 +237,13 @@ class PluginRootContext : public RootContext {
     cache_hits_ = cache_count.resolve("stats_filter", "hit");
     cache_misses_ = cache_count.resolve("stats_filter", "miss");
     empty_node_info_ = ::Wasm::Common::extractEmptyNodeFlatBuffer();
+    if (outbound_) {
+      peer_metadata_id_key_ = ::Wasm::Common::kUpstreamMetadataIdKey;
+      peer_metadata_key_ = ::Wasm::Common::kUpstreamMetadataKey;
+    } else {
+      peer_metadata_id_key_ = ::Wasm::Common::kDownstreamMetadataIdKey;
+      peer_metadata_key_ = ::Wasm::Common::kDownstreamMetadataKey;
+    }
   }
 
   ~PluginRootContext() = default;
@@ -231,15 +252,11 @@ class PluginRootContext : public RootContext {
   bool configure(size_t);
   bool onDone() override;
   void onTick() override;
-  // Report will return false when peer metadata exchange is not found for TCP,
-  // so that we wait to report metrics till we find peer metadata or get
-  // information that it's not available.
-  bool report(::Wasm::Common::RequestInfo& request_info, bool is_tcp);
+  void report(::Wasm::Common::RequestInfo& request_info, bool end_stream);
   bool useHostHeaderFallback() const { return use_host_header_fallback_; };
-  void addToTCPRequestQueue(
-      uint32_t id, std::shared_ptr<::Wasm::Common::RequestInfo> request_info);
-  void deleteFromTCPRequestQueue(uint32_t id);
-  bool initialized() const { return initialized_; };
+  void addToRequestQueue(uint32_t context_id,
+                         ::Wasm::Common::RequestInfo* request_info);
+  void deleteFromRequestQueue(uint32_t context_id);
 
  protected:
   const std::vector<MetricTag>& defaultTags();
@@ -271,9 +288,9 @@ class PluginRootContext : public RootContext {
   // Int expressions evaluated to metric values
   std::vector<uint32_t> int_expressions_;
 
+  const bool outbound_;
   std::string_view peer_metadata_id_key_;
   std::string_view peer_metadata_key_;
-  bool outbound_;
   bool use_host_header_fallback_;
 
   int64_t cache_hits_accumulator_ = 0;
@@ -285,8 +302,7 @@ class PluginRootContext : public RootContext {
   std::unordered_map<IstioDimensions, std::vector<SimpleStat>,
                      HashIstioDimensions>
       metrics_;
-  Map<uint32_t, std::shared_ptr<::Wasm::Common::RequestInfo>>
-      tcp_request_queue_;
+  Map<uint32_t, ::Wasm::Common::RequestInfo*> request_queue_;
   // Peer stats to be generated for a dimensioned metrics set.
   std::vector<StatGen> stats_;
   bool initialized_ = false;
@@ -307,45 +323,47 @@ class PluginRootContextInbound : public PluginRootContext {
 // Per-stream context.
 class PluginContext : public Context {
  public:
-  explicit PluginContext(uint32_t id, RootContext* root)
-      : Context(id, root), is_tcp_(false) {
-    request_info_ = std::make_shared<::Wasm::Common::RequestInfo>();
-  }
+  explicit PluginContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
+  // Called for both HTTP and TCP streams, as a final data callback.
   void onLog() override {
-    if (!rootContext()->initialized()) {
-      return;
+    rootContext()->deleteFromRequestQueue(id());
+    if (request_info_.request_protocol == ::Wasm::Common::Protocol::TCP) {
+      request_info_.tcp_connections_closed++;
     }
-    if (is_tcp_) {
-      cleanupTCPOnClose();
-    }
-    rootContext()->report(*request_info_, is_tcp_);
+    rootContext()->report(request_info_, true);
   };
 
-  FilterStatus onNewConnection() override {
-    if (!rootContext()->initialized()) {
-      return FilterStatus::Continue;
+  // HTTP streams start with headers.
+  // Metadata should be available (if any) at the time of adding to the queue.
+  // Since HTTP metadata exchange happens in onRequestHeaders, this is a safe
+  // place to register.
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override {
+    ::Wasm::Common::populateRequestProtocol(&request_info_);
+    // Save host value for recurrent reporting
+    if (rootContext()->useHostHeaderFallback()) {
+      getValue({"request", "host"}, &request_info_.url_host);
     }
-    is_tcp_ = true;
-    request_info_->tcp_connections_opened++;
-    rootContext()->addToTCPRequestQueue(id(), request_info_);
+    rootContext()->addToRequestQueue(id(), &request_info_);
+    return FilterHeadersStatus::Continue;
+  }
+
+  // TCP streams start with new connections.
+  FilterStatus onNewConnection() override {
+    request_info_.request_protocol = ::Wasm::Common::Protocol::TCP;
+    request_info_.tcp_connections_opened++;
+    rootContext()->addToRequestQueue(id(), &request_info_);
     return FilterStatus::Continue;
   }
 
   // Called on onData call, so counting the data that is received.
   FilterStatus onDownstreamData(size_t size, bool) override {
-    if (!rootContext()->initialized()) {
-      return FilterStatus::Continue;
-    }
-    request_info_->tcp_received_bytes += size;
+    request_info_.tcp_received_bytes += size;
     return FilterStatus::Continue;
   }
   // Called on onWrite call, so counting the data that is sent.
   FilterStatus onUpstreamData(size_t size, bool) override {
-    if (!rootContext()->initialized()) {
-      return FilterStatus::Continue;
-    }
-    request_info_->tcp_sent_bytes += size;
+    request_info_.tcp_sent_bytes += size;
     return FilterStatus::Continue;
   }
 
@@ -354,13 +372,7 @@ class PluginContext : public Context {
     return dynamic_cast<PluginRootContext*>(this->root());
   };
 
-  void cleanupTCPOnClose() {
-    rootContext()->deleteFromTCPRequestQueue(id());
-    request_info_->tcp_connections_closed++;
-  }
-
-  bool is_tcp_;
-  std::shared_ptr<::Wasm::Common::RequestInfo> request_info_;
+  ::Wasm::Common::RequestInfo request_info_;
 };
 
 #ifdef NULL_PLUGIN

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -337,15 +337,19 @@ class PluginContext : public Context {
   };
 
   // HTTP streams start with headers.
-  // Metadata should be available (if any) at the time of adding to the queue.
-  // Since HTTP metadata exchange uses headers in both directions, this is a
-  // safe place to register for both inbound and outbound streams.
-  FilterHeadersStatus onResponseHeaders(uint32_t, bool) override {
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override {
     ::Wasm::Common::populateRequestProtocol(&request_info_);
     // Save host value for recurrent reporting
     if (rootContext()->useHostHeaderFallback()) {
       getValue({"request", "host"}, &request_info_.url_host);
     }
+    return FilterHeadersStatus::Continue;
+  }
+
+  // Metadata should be available (if any) at the time of adding to the queue.
+  // Since HTTP metadata exchange uses headers in both directions, this is a
+  // safe place to register for both inbound and outbound streams.
+  FilterHeadersStatus onResponseHeaders(uint32_t, bool) override {
     rootContext()->addToRequestQueue(id(), &request_info_);
     return FilterHeadersStatus::Continue;
   }

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -338,9 +338,9 @@ class PluginContext : public Context {
 
   // HTTP streams start with headers.
   // Metadata should be available (if any) at the time of adding to the queue.
-  // Since HTTP metadata exchange happens in onRequestHeaders, this is a safe
-  // place to register.
-  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override {
+  // Since HTTP metadata exchange uses headers in both directions, this is a
+  // safe place to register for both inbound and outbound streams.
+  FilterHeadersStatus onResponseHeaders(uint32_t, bool) override {
     ::Wasm::Common::populateRequestProtocol(&request_info_);
     // Save host value for recurrent reporting
     if (rootContext()->useHostHeaderFallback()) {

--- a/test/envoye2e/driver/scenario.go
+++ b/test/envoye2e/driver/scenario.go
@@ -61,6 +61,8 @@ type (
 		Fore Step
 		Back Step
 	}
+	// Lambda captured step
+	StepFunction func(p *Params) error
 )
 
 func NewTestParams(t *testing.T, vars map[string]string, inv *env.TestInventory) *Params {
@@ -151,6 +153,12 @@ func (f *Fork) Run(p *Params) error {
 	return <-done
 }
 func (f *Fork) Cleanup() {}
+
+func (s StepFunction) Run(p *Params) error {
+	return s(p)
+}
+
+func (s StepFunction) Cleanup() {}
 
 var _ Step = &Scenario{}
 

--- a/testdata/metric/client_request_messages.yaml.tmpl
+++ b/testdata/metric/client_request_messages.yaml.tmpl
@@ -40,3 +40,5 @@ metric:
     value: server
   - name: destination_service_namespace
     value: default
+  - name: configurable_metric_a
+    value: v1

--- a/testdata/metric/client_response_messages.yaml.tmpl
+++ b/testdata/metric/client_response_messages.yaml.tmpl
@@ -40,3 +40,5 @@ metric:
     value: server
   - name: destination_service_namespace
     value: default
+  - name: configurable_metric_a
+    value: v1

--- a/testdata/stats/client_config.yaml
+++ b/testdata/stats/client_config.yaml
@@ -1,4 +1,3 @@
-debug: "false"
 field_separator: ";.;"
 metrics:
 - dimensions:

--- a/testdata/stats/client_config_customized.yaml.tmpl
+++ b/testdata/stats/client_config_customized.yaml.tmpl
@@ -1,4 +1,3 @@
-debug: "false"
 field_separator: ";.;"
 definitions:
 - name: requests_total

--- a/testdata/stats/client_config_disable_header_fallback.yaml
+++ b/testdata/stats/client_config_disable_header_fallback.yaml
@@ -1,4 +1,3 @@
-debug: "false"
 field_separator: ";.;"
 disable_host_header_fallback: "true"
 metrics:

--- a/testdata/stats/client_config_grpc.yaml.tmpl
+++ b/testdata/stats/client_config_grpc.yaml.tmpl
@@ -1,0 +1,4 @@
+tcp_reporting_duration: 1s
+metrics:
+  - dimensions:
+      configurable_metric_a: node.metadata.LABELS.version

--- a/testdata/stats/request_classification_config.yaml
+++ b/testdata/stats/request_classification_config.yaml
@@ -1,4 +1,3 @@
-debug: "true"
 field_separator: ";.;"
 metrics:
   - name: requests_total

--- a/testdata/stats/server_config.yaml
+++ b/testdata/stats/server_config.yaml
@@ -1,2 +1,1 @@
-debug: false
 field_separator: ";.;"

--- a/testdata/stats/server_config_grpc.yaml.tmpl
+++ b/testdata/stats/server_config_grpc.yaml.tmpl
@@ -1,0 +1,1 @@
+tcp_reporting_duration: 1s


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Apologizing beforehand for the size of this PR.
This change enables recurrent reporting for all metrics, not just TCP. It is used specifically by gRPC streaming metrics.

There is also a bunch of other blocking issues and cleanups combined:
- define protocol enum to compress storage and enable union/intersect operations
- define recurrent property in metric families, that enables reporting mid-stream
- pre-populate request info with protocol and host before detaching it to root context
- metric extractor function mutates individual info fields instead of resetting in bulk
- await for response headers (not just request headers) before placing on the queue to make sure HTTP metadata is exchanged; upstream host should be selected at this time for the fallback
- cleanup: remove shared pointer for request_info, stream context should always call `onLog` ( if it doesn't, that's a critical bug)
- cleanup: remove special handling of labels in TCP by changing the end index in the metric
- cleanup: delete empty stubs