### PR TITLE
Update update_envoy as it had a second value for sha256

### DIFF
--- a/scripts/update_envoy.sh
+++ b/scripts/update_envoy.sh
@@ -36,8 +36,7 @@ ENVOY_REPO="$(grep -Pom1 "^ENVOY_REPO = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
 # Get ENVOY_SHA256
 URL="https://github.com/${ENVOY_ORG}/${ENVOY_REPO}/archive/${1}.tar.gz"
 GETSHA=$(wget "${URL}" && sha256sum "${1}".tar.gz)
-SHAArr=("${GETSHA}")
-SHA256=${SHAArr[0]}
+SHA256=$(echo ${GETSHA} | cut -d " " -f1 | sed "s/'//")
 
 # Update ENVOY_SHA commit date
 sed -i "s/Commit date: .*/Commit date: ${2}/" "${WORKSPACE}"

--- a/scripts/update_envoy.sh
+++ b/scripts/update_envoy.sh
@@ -36,7 +36,8 @@ ENVOY_REPO="$(grep -Pom1 "^ENVOY_REPO = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
 # Get ENVOY_SHA256
 URL="https://github.com/${ENVOY_ORG}/${ENVOY_REPO}/archive/${1}.tar.gz"
 GETSHA=$(wget "${URL}" && sha256sum "${1}".tar.gz)
-SHA256=$(echo ${GETSHA} | cut -d " " -f1 | sed "s/'//")
+SHA256=$(echo "${GETSHA}" | cut -d " " -f1 | sed "s/'//")
+rm "${1}".tar.gz
 
 # Update ENVOY_SHA commit date
 sed -i "s/Commit date: .*/Commit date: ${2}/" "${WORKSPACE}"


### PR DESCRIPTION
The automated update had a sha256 value of 'faf2b24fa95ef43d1a9e66e31b1cfe56fd9dfc8dbab0324b49a50f8bc1803c33  e5a3c358771977783a8ef2bf3a1000dc9b5e5d2a.tar.gz'.

This change grabs the first field (space delimited) and strips the "'".