### PR TITLE
Fix export cache

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -187,9 +187,10 @@ push_release_centos:
 
 # Used by build container to export the build output from the docker volume cache
 exportcache:
-	mkdir -p /work/out/linux_amd64
-	cp -a /work/bazel-bin/src/envoy/envoy /work/out/linux_amd64
-	cp -a /work/bazel-bin/extensions/*wasm /work/out/linux_amd64
+	@mkdir -p /work/out/linux_amd64
+	@cp -a /work/bazel-bin/src/envoy/envoy /work/out/linux_amd64
+	@chmod +w /work/out/linux_amd64/envoy
+	@cp -a /work/bazel-bin/**/*wasm /work/out/linux_amd64 &> /dev/null || true
 
 .PHONY: build clean test check artifacts extensions-proto
 


### PR DESCRIPTION
Currently it copys a non-writeable file, so next time we export it
fails. Also do not fail if wasm is not there, as its optional.

**What this PR does / why we need it**:

s**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
