### PR TITLE
Remove duplicated XDS port from Params struct.

### DIFF
--- a/test/envoye2e/driver/scenario.go
+++ b/test/envoye2e/driver/scenario.go
@@ -34,7 +34,6 @@ import (
 
 type (
 	Params struct {
-		XDS    int
 		Config XDSServer
 		Ports  *env.Ports
 		Vars   map[string]string
@@ -71,7 +70,6 @@ func NewTestParams(t *testing.T, vars map[string]string, inv *env.TestInventory)
 	return &Params{
 		Vars:  vars,
 		Ports: ports,
-		XDS:   int(ports.XDSPort),
 	}
 }
 

--- a/test/envoye2e/driver/xds.go
+++ b/test/envoye2e/driver/xds.go
@@ -47,14 +47,14 @@ type XDSServer struct {
 var _ Step = &XDS{}
 
 func (x *XDS) Run(p *Params) error {
-	log.Printf("XDS server starting on %d\n", p.XDS)
+	log.Printf("XDS server starting on %d\n", p.Ports.XDSPort)
 	x.grpc = grpc.NewServer()
 	p.Config.Extensions = extensionserver.New(context.Background())
 	extensionservice.RegisterExtensionConfigDiscoveryServiceServer(x.grpc, p.Config.Extensions)
 	p.Config.Cache = cache.NewSnapshotCache(false, cache.IDHash{}, x)
 	xdsServer := server.NewServer(context.Background(), p.Config.Cache, nil)
 	discovery.RegisterAggregatedDiscoveryServiceServer(x.grpc, xdsServer)
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", p.XDS))
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", p.Ports.XDSPort))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While writing instruction for integration test, I found this duplicated information about xds port in the params struct, which is kind of confusing.