### PR TITLE
Add comments to commonly used steps.

### DIFF
--- a/test/envoye2e/driver/check.go
+++ b/test/envoye2e/driver/check.go
@@ -29,6 +29,7 @@ const (
 	Any            = "*"
 )
 
+// HTTPCall sends a HTTP request to a localhost port, and then check the response code, and response headers.
 type HTTPCall struct {
 	// Method
 	Method string

--- a/test/envoye2e/driver/envoy.go
+++ b/test/envoye2e/driver/envoy.go
@@ -39,6 +39,7 @@ import (
 	"istio.io/proxy/test/envoye2e/env"
 )
 
+// Envoy starts up a Envoy process locally.
 type Envoy struct {
 	// template for the bootstrap
 	Bootstrap string
@@ -60,6 +61,7 @@ type Envoy struct {
 
 var _ Step = &Envoy{}
 
+// Run starts a Envoy process.
 func (e *Envoy) Run(p *Params) error {
 	bootstrap, err := p.Fill(e.Bootstrap)
 	if err != nil {
@@ -128,6 +130,7 @@ func (e *Envoy) Run(p *Params) error {
 	return env.WaitForHTTPServer(url)
 }
 
+// Cleanup stops the Envoy process.
 func (e *Envoy) Cleanup() {
 	log.Printf("stop envoy ...\n")
 	defer os.Remove(e.tmpFile)

--- a/test/envoye2e/driver/xds.go
+++ b/test/envoye2e/driver/xds.go
@@ -46,6 +46,7 @@ type XDSServer struct {
 
 var _ Step = &XDS{}
 
+// Run starts up an Envoy XDS server.
 func (x *XDS) Run(p *Params) error {
 	log.Printf("XDS server starting on %d\n", p.Ports.XDSPort)
 	x.grpc = grpc.NewServer()
@@ -65,6 +66,7 @@ func (x *XDS) Run(p *Params) error {
 	return nil
 }
 
+// Cleanup stops the XDS server.
 func (x *XDS) Cleanup() {
 	log.Println("stopping XDS server")
 	x.grpc.GracefulStop()


### PR DESCRIPTION
The comment might be useful when people go through integration test instruction and look at godoc.