### PR TITLE
Add a default rbac catch all regex

### DIFF
--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -177,7 +177,7 @@ bool fillAuthInfo(const std::string& response_details,
         absl::StrCat(policy_namespace, ".", policy_name);
     (*label_map)["policy_rule"] = policy_rule_index;
     return true;
-  } else if (RE2::PartialMatch(response_details,rbac_denied_match_default)){
+  } else if (RE2::PartialMatch(response_details, rbac_denied_match_default)) {
     (*label_map)["response_details"] = kRbacAccessDenied;
   }
 

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -15,6 +15,7 @@
 
 #include "extensions/stackdriver/log/logger.h"
 
+#include "absl/strings/match.h"
 #include "extensions/stackdriver/common/constants.h"
 #include "google/logging/v2/log_entry.pb.h"
 #include "google/protobuf/util/time_util.h"

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -38,6 +38,7 @@ namespace {
 const RE2 rbac_denied_match(
     "rbac_access_denied_matched_policy\\[ns\\[(.*)\\]-policy\\[(.*)\\]-rule\\[("
     ".*)\\]\\]");
+const RE2 rbac_denied_match_default("rbac_access_denied_matched_policy");
 constexpr char kRbacAccessDenied[] = "AuthzDenied";
 void setSourceCanonicalService(
     const ::Wasm::Common::FlatNode& peer_node_info,
@@ -176,6 +177,8 @@ bool fillAuthInfo(const std::string& response_details,
         absl::StrCat(policy_namespace, ".", policy_name);
     (*label_map)["policy_rule"] = policy_rule_index;
     return true;
+  } else if (RE2::PartialMatch(response_details,rbac_denied_match_default)){
+    (*label_map)["response_details"] = kRbacAccessDenied;
   }
 
   return false;

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -177,8 +177,10 @@ bool fillAuthInfo(const std::string& response_details,
         absl::StrCat(policy_namespace, ".", policy_name);
     (*label_map)["policy_rule"] = policy_rule_index;
     return true;
-  } else if (RE2::PartialMatch(response_details, rbac_denied_match_default)) {
+  }
+  if (RE2::PartialMatch(response_details, rbac_denied_match_default)) {
     (*label_map)["response_details"] = kRbacAccessDenied;
+    return true;
   }
 
   return false;

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -170,7 +170,7 @@ void fillExtraLabels(
 bool fillAuthInfo(const std::string& response_details,
                   google::protobuf::Map<std::string, std::string>* label_map) {
   std::string policy_name, policy_namespace, policy_rule_index;
-  if (response_details.find(rbac_denied_match_prefix)) {
+  if (absl::StartsWith(response_details, rbac_denied_match_prefix)) {
     (*label_map)["response_details"] = kRbacAccessDenied;
     if (RE2::PartialMatch(response_details, rbac_denied_match,
                           &policy_namespace, &policy_name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a default rbac catch all regex. This is to catch errors like when none of the policies match.
In this scenario, response_code_details will contain `rbac_access_denied_matched_policy[none]`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
