### PR TITLE
Use default channel credential when sts is not enabled.

### DIFF
--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -20,6 +20,7 @@ licenses(["notice"])
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
+    "envoy_cc_test",
 )
 
 envoy_cc_library(
@@ -57,6 +58,17 @@ envoy_cc_library(
         "//extensions/common:context",
         "@com_google_googleapis//google/monitoring/v3:monitoring_cc_proto",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_test(
+    name = "utils_test",
+    size = "small",
+    srcs = ["utils_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":utils",
+        "@envoy//source/extensions/common/wasm:wasm_lib",
     ],
 )
 

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -66,6 +66,8 @@ void buildEnvoyGrpcService(const StackdriverStubOption &stub_option,
                                   ? kSTSSubjectTokenPath
                                   : stub_option.test_token_path);
   auto initial_metadata = grpc_service->add_initial_metadata();
+  // When using p4sa/sts, google backend needs `x-goog-user-project` in initial
+  // metadata to differentiate which project the call should be accounted for.
   initial_metadata->set_key("x-goog-user-project");
   initial_metadata->set_value(stub_option.project_id);
 

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -45,36 +45,37 @@ void buildEnvoyGrpcService(const StackdriverStubOption &stub_option,
     // for testing.
     grpc_service->mutable_google_grpc()->set_target_uri(
         stub_option.insecure_endpoint);
-  } else {
-    grpc_service->mutable_google_grpc()->set_target_uri(
-        stub_option.secure_endpoint.empty() ? stub_option.default_endpoint
-                                            : stub_option.secure_endpoint);
-    if (stub_option.sts_port.empty()) {
-      // Security token exchange is not enabled. Use default GCE credential.
-      grpc_service->mutable_google_grpc()
-          ->add_call_credentials()
-          ->mutable_google_compute_engine();
-    } else {
-      setSTSCallCredentialOptions(grpc_service->mutable_google_grpc()
-                                      ->add_call_credentials()
-                                      ->mutable_sts_service(),
-                                  stub_option.sts_port,
-                                  stub_option.test_token_path.empty()
-                                      ? kSTSSubjectTokenPath
-                                      : stub_option.test_token_path);
-      auto initial_metadata = grpc_service->add_initial_metadata();
-      initial_metadata->set_key("x-goog-user-project");
-      initial_metadata->set_value(stub_option.project_id);
-    }
-
+    return;
+  }
+  grpc_service->mutable_google_grpc()->set_target_uri(
+      stub_option.secure_endpoint.empty() ? stub_option.default_endpoint
+                                          : stub_option.secure_endpoint);
+  if (stub_option.sts_port.empty()) {
+    // Security token exchange is not enabled. Use default Google credential.
     grpc_service->mutable_google_grpc()
         ->mutable_channel_credentials()
-        ->mutable_ssl_credentials()
-        ->mutable_root_certs()
-        ->set_filename(stub_option.test_root_pem_path.empty()
-                           ? kDefaultRootCertFile
-                           : stub_option.test_root_pem_path);
+        ->mutable_google_default();
+    return;
   }
+
+  setSTSCallCredentialOptions(grpc_service->mutable_google_grpc()
+                                  ->add_call_credentials()
+                                  ->mutable_sts_service(),
+                              stub_option.sts_port,
+                              stub_option.test_token_path.empty()
+                                  ? kSTSSubjectTokenPath
+                                  : stub_option.test_token_path);
+  auto initial_metadata = grpc_service->add_initial_metadata();
+  initial_metadata->set_key("x-goog-user-project");
+  initial_metadata->set_value(stub_option.project_id);
+
+  grpc_service->mutable_google_grpc()
+      ->mutable_channel_credentials()
+      ->mutable_ssl_credentials()
+      ->mutable_root_certs()
+      ->set_filename(stub_option.test_root_pem_path.empty()
+                         ? kDefaultRootCertFile
+                         : stub_option.test_root_pem_path);
 }
 
 bool isRawGCEInstance(const ::Wasm::Common::FlatNode &node) {

--- a/extensions/stackdriver/common/utils_test.cc
+++ b/extensions/stackdriver/common/utils_test.cc
@@ -15,11 +15,11 @@
 
 #include "extensions/stackdriver/common/utils.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "google/protobuf/util/message_differencer.h"
 #include "extensions/stackdriver/common/constants.h"
+#include "gmock/gmock.h"
 #include "google/protobuf/util/json_util.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
 
 namespace Extensions {
 namespace Stackdriver {
@@ -28,31 +28,32 @@ namespace Common {
 using google::protobuf::util::MessageDifferencer;
 
 TEST(UtilsTest, TestEnvoyGrpcInsecure) {
-    GrpcService expected_envoy_grpc_service;
-    std::string envoy_google_grpc_json = R"({
+  GrpcService expected_envoy_grpc_service;
+  std::string envoy_google_grpc_json = R"({
         "google_grpc": {
             "target_uri": "test"
         }
     })";
-    google::protobuf::util::JsonParseOptions options;
-    JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service, options);
+  google::protobuf::util::JsonParseOptions options;
+  JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service,
+                      options);
 
-    StackdriverStubOption opt;
-    opt.insecure_endpoint = "test";
-    GrpcService envoy_grpc_service;
-    buildEnvoyGrpcService(opt, &envoy_grpc_service);
+  StackdriverStubOption opt;
+  opt.insecure_endpoint = "test";
+  GrpcService envoy_grpc_service;
+  buildEnvoyGrpcService(opt, &envoy_grpc_service);
 
-    std::string diff;
-    MessageDifferencer differ;
-    differ.ReportDifferencesToString(&diff);
-    if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
-        FAIL() << "unexpected envoy grpc service " << diff << "\n";
-    }
+  std::string diff;
+  MessageDifferencer differ;
+  differ.ReportDifferencesToString(&diff);
+  if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
+    FAIL() << "unexpected envoy grpc service " << diff << "\n";
+  }
 }
 
 TEST(UtilsTest, TestEnvoyGrpcSTS) {
-    GrpcService expected_envoy_grpc_service;
-    std::string envoy_google_grpc_json = R"({
+  GrpcService expected_envoy_grpc_service;
+  std::string envoy_google_grpc_json = R"({
         "google_grpc": {
             "target_uri": "secure",
             "channel_credentials": {
@@ -76,27 +77,28 @@ TEST(UtilsTest, TestEnvoyGrpcSTS) {
             "value": "project"
         }
     })";
-    google::protobuf::util::JsonParseOptions options;
-    JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service, options);
+  google::protobuf::util::JsonParseOptions options;
+  JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service,
+                      options);
 
-    StackdriverStubOption opt;
-    opt.secure_endpoint = "secure";
-    opt.sts_port = "1234";
-    opt.project_id = "project";
-    GrpcService envoy_grpc_service;
-    buildEnvoyGrpcService(opt, &envoy_grpc_service);
+  StackdriverStubOption opt;
+  opt.secure_endpoint = "secure";
+  opt.sts_port = "1234";
+  opt.project_id = "project";
+  GrpcService envoy_grpc_service;
+  buildEnvoyGrpcService(opt, &envoy_grpc_service);
 
-    std::string diff;
-    MessageDifferencer differ;
-    differ.ReportDifferencesToString(&diff);
-    if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
-        FAIL() << "unexpected envoy grpc service " << diff << "\n";
-    }
+  std::string diff;
+  MessageDifferencer differ;
+  differ.ReportDifferencesToString(&diff);
+  if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
+    FAIL() << "unexpected envoy grpc service " << diff << "\n";
+  }
 }
 
 TEST(UtilsTest, TestEnvoyGrpcDefaultCredential) {
-    GrpcService expected_envoy_grpc_service;
-    std::string envoy_google_grpc_json = R"({
+  GrpcService expected_envoy_grpc_service;
+  std::string envoy_google_grpc_json = R"({
         "google_grpc": {
             "target_uri": "secure",
             "channel_credentials": {
@@ -104,20 +106,21 @@ TEST(UtilsTest, TestEnvoyGrpcDefaultCredential) {
             }
         }
     })";
-    google::protobuf::util::JsonParseOptions options;
-    JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service, options);
+  google::protobuf::util::JsonParseOptions options;
+  JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service,
+                      options);
 
-    StackdriverStubOption opt;
-    opt.secure_endpoint = "secure";
-    GrpcService envoy_grpc_service;
-    buildEnvoyGrpcService(opt, &envoy_grpc_service);
+  StackdriverStubOption opt;
+  opt.secure_endpoint = "secure";
+  GrpcService envoy_grpc_service;
+  buildEnvoyGrpcService(opt, &envoy_grpc_service);
 
-    std::string diff;
-    MessageDifferencer differ;
-    differ.ReportDifferencesToString(&diff);
-    if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
-        FAIL() << "unexpected envoy grpc service " << diff << "\n";
-    }
+  std::string diff;
+  MessageDifferencer differ;
+  differ.ReportDifferencesToString(&diff);
+  if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
+    FAIL() << "unexpected envoy grpc service " << diff << "\n";
+  }
 }
 
 }  // namespace Common

--- a/extensions/stackdriver/common/utils_test.cc
+++ b/extensions/stackdriver/common/utils_test.cc
@@ -1,0 +1,125 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "extensions/stackdriver/common/utils.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "extensions/stackdriver/common/constants.h"
+#include "google/protobuf/util/json_util.h"
+
+namespace Extensions {
+namespace Stackdriver {
+namespace Common {
+
+using google::protobuf::util::MessageDifferencer;
+
+TEST(UtilsTest, TestEnvoyGrpcInsecure) {
+    GrpcService expected_envoy_grpc_service;
+    std::string envoy_google_grpc_json = R"({
+        "google_grpc": {
+            "target_uri": "test"
+        }
+    })";
+    google::protobuf::util::JsonParseOptions options;
+    JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service, options);
+
+    StackdriverStubOption opt;
+    opt.insecure_endpoint = "test";
+    GrpcService envoy_grpc_service;
+    buildEnvoyGrpcService(opt, &envoy_grpc_service);
+
+    std::string diff;
+    MessageDifferencer differ;
+    differ.ReportDifferencesToString(&diff);
+    if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
+        FAIL() << "unexpected envoy grpc service " << diff << "\n";
+    }
+}
+
+TEST(UtilsTest, TestEnvoyGrpcSTS) {
+    GrpcService expected_envoy_grpc_service;
+    std::string envoy_google_grpc_json = R"({
+        "google_grpc": {
+            "target_uri": "secure",
+            "channel_credentials": {
+                "ssl_credentials": {
+                    "root_certs": {
+                        "filename": "/etc/ssl/certs/ca-certificates.crt"
+                    }
+                }
+            },
+            "call_credentials": {
+                "sts_service": {
+                    "token_exchange_service_uri": "http://localhost:1234/token",
+                    "subject_token_path": "/var/run/secrets/tokens/istio-token",
+                    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+                    "scope": "https://www.googleapis.com/auth/cloud-platform"
+                }
+            }
+        },
+        "initial_metadata": {
+            "key": "x-goog-user-project", 
+            "value": "project"
+        }
+    })";
+    google::protobuf::util::JsonParseOptions options;
+    JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service, options);
+
+    StackdriverStubOption opt;
+    opt.secure_endpoint = "secure";
+    opt.sts_port = "1234";
+    opt.project_id = "project";
+    GrpcService envoy_grpc_service;
+    buildEnvoyGrpcService(opt, &envoy_grpc_service);
+
+    std::string diff;
+    MessageDifferencer differ;
+    differ.ReportDifferencesToString(&diff);
+    if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
+        FAIL() << "unexpected envoy grpc service " << diff << "\n";
+    }
+}
+
+TEST(UtilsTest, TestEnvoyGrpcDefaultCredential) {
+    GrpcService expected_envoy_grpc_service;
+    std::string envoy_google_grpc_json = R"({
+        "google_grpc": {
+            "target_uri": "secure",
+            "channel_credentials": {
+                "google_default": {}
+            }
+        }
+    })";
+    google::protobuf::util::JsonParseOptions options;
+    JsonStringToMessage(envoy_google_grpc_json, &expected_envoy_grpc_service, options);
+
+    StackdriverStubOption opt;
+    opt.secure_endpoint = "secure";
+    GrpcService envoy_grpc_service;
+    buildEnvoyGrpcService(opt, &envoy_grpc_service);
+
+    std::string diff;
+    MessageDifferencer differ;
+    differ.ReportDifferencesToString(&diff);
+    if (!differ.Compare(expected_envoy_grpc_service, envoy_grpc_service)) {
+        FAIL() << "unexpected envoy grpc service " << diff << "\n";
+    }
+}
+
+}  // namespace Common
+}  // namespace Stackdriver
+}  // namespace Extensions


### PR DESCRIPTION
This should be equivalent to google cloud engine when running on gce, and will look up GOOGLE_APPLICATION_CREDENTIALS when running on other platforms.