### PR TITLE
rate limit: add HTTP local rate limit example with descriptors

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,10 +38,10 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # Note: this is needed by release builder to resolve envoy dep sha to tag.
-# Commit date: 2020-01-11
-ENVOY_SHA = "5c801b25cae04f06bf48248c90e87d623d7a6283"
+# Commit date: 2020-01-20
+ENVOY_SHA = "f2f6943f8ec40e99ee5dbf2383bfe6014c6dc518"
 
-ENVOY_SHA256 = "37eb3e62ac58bb3575f69dc59c3c8458007b7ed52aee2a8842f34fae6aefd7ee"
+ENVOY_SHA256 = "15fb0cb8b8e751c1762c6153633282a7693bcb6c9d76d695523b6f287249d0a7"
 
 ENVOY_ORG = "envoyproxy"
 

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module istio.io/proxy
 go 1.15
 
 require (
-	github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354
+	github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403
 	github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263
-	github.com/envoyproxy/go-control-plane v0.9.7-0.20200814205829-ae1dbc93dd82
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210119155807-0a0735cd4c6a
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354 h1:9kRtNpqLHbZVO/NNxhHp2ymxFxsHOe3x2efJGn//Tas=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263 h1:Ot817IZ8L+/ZlkfVJ0ZnngYA6GnmcvcxR7lrIz/iZDc=
 github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -25,6 +27,9 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7-0.20200814205829-ae1dbc93dd82 h1:oE5/gSvFC1KMVbi6cgm8Zm5S1/mHaYdfqyJoao+APnE=
 github.com/envoyproxy/go-control-plane v0.9.7-0.20200814205829-ae1dbc93dd82/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
+github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210119155807-0a0735cd4c6a h1:MyqftB1euVwzCCllrWOWvqD/0Mpk8tmpZAN203JzXrM=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210119155807-0a0735cd4c6a/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -69,6 +69,7 @@ func init() {
 			"TestStatsECDS/envoy.wasm.runtime.null",
 			"TestStatsECDS/envoy.wasm.runtime.v8",
 			"TestStatsECDS/envoy.wasm.runtime.v8#01",
+			"TestHTTPLocalRatelimit",
 		},
 	}
 }

--- a/test/envoye2e/ratelimit/ratelimit_test.go
+++ b/test/envoye2e/ratelimit/ratelimit_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimit_test
+
+import (
+	"testing"
+	"time"
+
+	"istio.io/proxy/test/envoye2e"
+	"istio.io/proxy/test/envoye2e/driver"
+)
+
+// TestHTTPLocalRatelimit validates that envoy can rate limit based on:
+// - source attribute
+// - request header
+func TestHTTPLocalRatelimit(t *testing.T) {
+	params := driver.NewTestParams(t, map[string]string{}, envoye2e.ProxyE2ETests)
+	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
+	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
+	params.Vars["ClientHTTPFilters"] = params.LoadTestData("testdata/filters/mx_outbound.yaml.tmpl")
+	params.Vars["ServerHTTPFilters"] = params.LoadTestData("testdata/filters/mx_inbound.yaml.tmpl") + "\n" +
+		params.LoadTestData("testdata/filters/local_ratelimit_inbound.yaml.tmpl")
+	params.Vars["ServerRouteRateLimits"] = `
+rate_limits:
+- actions:
+  - request_headers:
+      header_name: user-id
+      descriptor_key: id
+  - extension:
+      name: custom
+      typed_config:
+        "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+        type_url: type.googleapis.com/envoy.extensions.rate_limit_descriptors.expr.v3.Descriptor
+        value:
+          descriptor_key: app
+          text: filter_state['wasm.downstream_peer'].labels['app'].value`
+	if err := (&driver.Scenario{
+		[]driver.Step{
+			&driver.XDS{},
+			&driver.Update{Node: "client", Version: "0", Listeners: []string{driver.LoadTestData("testdata/listener/client.yaml.tmpl")}},
+			&driver.Update{Node: "server", Version: "0", Listeners: []string{driver.LoadTestData("testdata/listener/server.yaml.tmpl")}},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
+			&driver.Sleep{1 * time.Second},
+			&driver.HTTPCall{
+				Port: params.Ports.ClientPort,
+				Body: "hello, world!",
+			},
+			// Only first call should pass with 1req/minute
+			&driver.HTTPCall{
+				Port:           params.Ports.ClientPort,
+				RequestHeaders: map[string]string{"user-id": "foo"},
+				ResponseCode:   200,
+			},
+			&driver.HTTPCall{
+				Port:           params.Ports.ClientPort,
+				RequestHeaders: map[string]string{"user-id": "foo"},
+				ResponseCode:   429,
+				Body:           "local_rate_limited",
+			},
+		},
+	}).Run(params); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/envoye2e/ratelimit/ratelimit_test.go
+++ b/test/envoye2e/ratelimit/ratelimit_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // TestHTTPLocalRatelimit validates that envoy can rate limit based on:
-// - source attribute
+// - source attribute, produced by MX extension
 // - request header
 func TestHTTPLocalRatelimit(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{}, envoye2e.ProxyE2ETests)

--- a/testdata/filters/local_ratelimit_inbound.yaml.tmpl
+++ b/testdata/filters/local_ratelimit_inbound.yaml.tmpl
@@ -1,0 +1,26 @@
+- name: ratelimit
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+    value:
+      stat_prefix: rate_limit
+      token_bucket:
+        max_tokens: 1000
+        tokens_per_fill: 1000
+        fill_interval: 1s
+      filter_enabled:
+        runtime_key: local_rate_limit_enabled
+        default_value: { numerator: 100, denominator: HUNDRED }
+      filter_enforced:
+        runtime_key: local_rate_limit_enforced
+        default_value: { numerator: 100, denominator: HUNDRED }
+      descriptors:
+       - entries:
+         - key: id
+           value: foo
+         - key: app
+           value: productpage
+         token_bucket:
+           max_tokens: 1
+           tokens_per_fill: 1
+           fill_interval: 60s

--- a/testdata/listener/server.yaml.tmpl
+++ b/testdata/listener/server.yaml.tmpl
@@ -28,5 +28,6 @@ filter_chains:
             route:
               cluster: server-inbound-cluster
               timeout: 0s
+{{ .Vars.ServerRouteRateLimits | fill | indent 14 }}
 {{ .Vars.ServerTLSContext | indent 2 }}
 {{- end }}

--- a/tools/extensionserver/convert.go
+++ b/tools/extensionserver/convert.go
@@ -56,8 +56,8 @@ func Convert(ext *Extension) (*core.TypedExtensionConfig, error) {
 	plugin := &wasm.Wasm{
 		Config: &v3.PluginConfig{
 			RootId: ext.RootID,
-			VmConfig: &v3.PluginConfig_InlineVmConfig{
-				InlineVmConfig: &v3.VmConfig{
+			Vm: &v3.PluginConfig_VmConfig{
+				VmConfig: &v3.VmConfig{
 					VmId:    ext.VMID,
 					Runtime: runtime,
 					Code: &core.AsyncDataSource{

--- a/tools/extensionserver/server.go
+++ b/tools/extensionserver/server.go
@@ -42,7 +42,7 @@ var _ extensionservice.ExtensionConfigDiscoveryServiceServer = &ExtensionServer{
 
 func New(ctx context.Context) *ExtensionServer {
 	out := &ExtensionServer{}
-	out.cache = cache.NewLinearCache(APIType, nil)
+	out.cache = cache.NewLinearCache(APIType)
 	out.Server = server.NewServer(ctx, out.cache, out)
 	return out
 }


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Add an example of server-side rate limiting based on combination of:
- source attribute: app label, expressed as `filter_state['wasm.downstream_peer'].labels['app'].value`
- request header: `user-id` header
