### PR TITLE
Re-enable RBE cache for CentOS. (#3173)

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -47,8 +47,8 @@ fi
 BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/k8-fastbuild/bin"
 export BAZEL_OUT
 
-# Disable RBE execution due to failures like https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_proxy/2633/release-test_proxy/211
-export BAZEL_BUILD_RBE_JOBS=0
+# Disable RBE execution until we have LARGE_MACHINE instances provisioned for building V8.
+export BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-0}"
 
 # Use GCP service account when available.
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
@@ -57,7 +57,7 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
 
   # Use RBE when logged in.
   BAZEL_BUILD_RBE_INSTANCE="${BAZEL_BUILD_RBE_INSTANCE-projects/istio-testing/instances/default_instance}"
-  BAZEL_BUILD_RBE_CACHE="${BAZEL_BUILD_RBE_CACHE:-grpcs://remotebuildexecution.googleapis.com}"
+  BAZEL_BUILD_RBE_CACHE="${BAZEL_BUILD_RBE_CACHE-grpcs://remotebuildexecution.googleapis.com}"
   BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-200}"
   if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
     if [[ "${BAZEL_BUILD_RBE_JOBS}" -gt 0 ]]; then

--- a/prow/proxy-postsubmit-centos.sh
+++ b/prow/proxy-postsubmit-centos.sh
@@ -20,6 +20,10 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 ########################################
 # Postsubmit script triggered by Prow. #
 ########################################
+
+# Do not use RBE execution with Ubuntu toolchain, but still use RBE cache.
+export BAZEL_BUILD_RBE_JOBS=0
+
 # shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"
 

--- a/prow/proxy-presubmit-centos-release.sh
+++ b/prow/proxy-presubmit-centos-release.sh
@@ -20,8 +20,9 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-# Do not use RBE for this, RBE will run ubuntu instance
-export BAZEL_BUILD_RBE_INSTANCE=""
+
+# Do not use RBE execution with Ubuntu toolchain, but still use RBE cache.
+export BAZEL_BUILD_RBE_JOBS=0
 
 # shellcheck disable=SC1090
 source "${WD}/proxy-common.inc"


### PR DESCRIPTION
Cherry-pick of #3173 with envoy.bazelrc from istio/envoy:release-1.8.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>