### PR TITLE
stackdriver: fix units for connection counts

### DIFF
--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -316,13 +316,11 @@ MEASURE_FUNC(clientRequestBytes, ClientRequestBytes, By, Int64)
 MEASURE_FUNC(clientResponseBytes, ClientResponseBytes, By, Int64)
 MEASURE_FUNC(clientRoundtripLatencies, ClientRoundtripLatencies, ms, Double)
 MEASURE_FUNC(serverConnectionsOpenCount, ServerConnectionsOpenCount, 1, Int64)
-MEASURE_FUNC(serverConnectionsCloseCount, ServerConnectionsCloseCount, 1,
-             Int64)
+MEASURE_FUNC(serverConnectionsCloseCount, ServerConnectionsCloseCount, 1, Int64)
 MEASURE_FUNC(serverReceivedBytesCount, ServerReceivedBytesCount, By, Int64)
 MEASURE_FUNC(serverSentBytesCount, ServerSentBytesCount, By, Int64)
 MEASURE_FUNC(clientConnectionsOpenCount, ClientConnectionsOpenCount, 1, Int64)
-MEASURE_FUNC(clientConnectionsCloseCount, ClientConnectionsCloseCount, 1,
-             Int64)
+MEASURE_FUNC(clientConnectionsCloseCount, ClientConnectionsCloseCount, 1, Int64)
 MEASURE_FUNC(clientReceivedBytesCount, ClientReceivedBytesCount, By, Int64)
 MEASURE_FUNC(clientSentBytesCount, ClientSentBytesCount, By, Int64)
 

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -315,13 +315,13 @@ MEASURE_FUNC(clientRequestCount, ClientRequestCount, 1, Int64)
 MEASURE_FUNC(clientRequestBytes, ClientRequestBytes, By, Int64)
 MEASURE_FUNC(clientResponseBytes, ClientResponseBytes, By, Int64)
 MEASURE_FUNC(clientRoundtripLatencies, ClientRoundtripLatencies, ms, Double)
-MEASURE_FUNC(serverConnectionsOpenCount, ServerConnectionsOpenCount, By, Int64)
-MEASURE_FUNC(serverConnectionsCloseCount, ServerConnectionsCloseCount, By,
+MEASURE_FUNC(serverConnectionsOpenCount, ServerConnectionsOpenCount, 1, Int64)
+MEASURE_FUNC(serverConnectionsCloseCount, ServerConnectionsCloseCount, 1,
              Int64)
 MEASURE_FUNC(serverReceivedBytesCount, ServerReceivedBytesCount, By, Int64)
 MEASURE_FUNC(serverSentBytesCount, ServerSentBytesCount, By, Int64)
-MEASURE_FUNC(clientConnectionsOpenCount, ClientConnectionsOpenCount, By, Int64)
-MEASURE_FUNC(clientConnectionsCloseCount, ClientConnectionsCloseCount, By,
+MEASURE_FUNC(clientConnectionsOpenCount, ClientConnectionsOpenCount, 1, Int64)
+MEASURE_FUNC(clientConnectionsCloseCount, ClientConnectionsCloseCount, 1,
              Int64)
 MEASURE_FUNC(clientReceivedBytesCount, ClientReceivedBytesCount, By, Int64)
 MEASURE_FUNC(clientSentBytesCount, ClientSentBytesCount, By, Int64)


### PR DESCRIPTION
A count of connections should not have a unit of bytes. This corrects that issue.