### PR TITLE
stackdriver: fix tcp bytes metrics aggregation

### DIFF
--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -225,6 +225,18 @@ StackdriverOptions getStackdriverOptions(
     view_descriptor.RegisterForExport();                            \
   }
 
+#define REGISTER_TCP_SUM_VIEW(_v)                                 \
+  void register##_v##View(absl::Duration expiry_duration) {       \
+    const ViewDescriptor view_descriptor =                        \
+        ViewDescriptor()                                          \
+            .set_name(k##_v##View)                                \
+            .set_measure(k##_v##Measure)                          \
+            .set_expiry_duration(expiry_duration)                 \
+            .set_aggregation(Aggregation::Sum()) ADD_COMMON_TAGS; \
+    View view(view_descriptor);                                   \
+    view_descriptor.RegisterForExport();                          \
+  }
+
 #define REGISTER_DISTRIBUTION_VIEW(_v)                              \
   void register##_v##View(absl::Duration expiry_duration) {         \
     const ViewDescriptor view_descriptor =                          \
@@ -289,12 +301,12 @@ REGISTER_BYTES_DISTRIBUTION_VIEW(ClientResponseBytes)
 REGISTER_DISTRIBUTION_VIEW(ClientRoundtripLatencies)
 REGISTER_TCP_COUNT_VIEW(ServerConnectionsOpenCount)
 REGISTER_TCP_COUNT_VIEW(ServerConnectionsCloseCount)
-REGISTER_TCP_COUNT_VIEW(ServerReceivedBytesCount)
-REGISTER_TCP_COUNT_VIEW(ServerSentBytesCount)
+REGISTER_TCP_SUM_VIEW(ServerReceivedBytesCount)
+REGISTER_TCP_SUM_VIEW(ServerSentBytesCount)
 REGISTER_TCP_COUNT_VIEW(ClientConnectionsOpenCount)
 REGISTER_TCP_COUNT_VIEW(ClientConnectionsCloseCount)
-REGISTER_TCP_COUNT_VIEW(ClientReceivedBytesCount)
-REGISTER_TCP_COUNT_VIEW(ClientSentBytesCount)
+REGISTER_TCP_SUM_VIEW(ClientReceivedBytesCount)
+REGISTER_TCP_SUM_VIEW(ClientSentBytesCount)
 
 /*
  * measure function macros

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -72,7 +72,7 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 				sd.Lock()
 				sd.tsReq = append(sd.tsReq, req)
 				for _, ts := range req.TimeSeries {
-					if strings.HasSuffix(ts.Metric.Type, "request_count") || strings.HasSuffix(ts.Metric.Type, "connection_open_count") {
+					if strings.HasSuffix(ts.Metric.Type, "request_count") || strings.HasSuffix(ts.Metric.Type, "connection_open_count") || strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
 						ts.Points[0].Interval = nil
 						sd.ts[proto.MarshalTextString(ts)] = struct{}{}

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -72,7 +72,9 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 				sd.Lock()
 				sd.tsReq = append(sd.tsReq, req)
 				for _, ts := range req.TimeSeries {
-					if strings.HasSuffix(ts.Metric.Type, "request_count") || strings.HasSuffix(ts.Metric.Type, "connection_open_count") || strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
+					if strings.HasSuffix(ts.Metric.Type, "request_count") ||
+						strings.HasSuffix(ts.Metric.Type, "connection_open_count") ||
+						strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
 						ts.Points[0].Interval = nil
 						sd.ts[proto.MarshalTextString(ts)] = struct{}{}

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -618,7 +618,11 @@ func TestStackdriverTCPMetadataExchange(t *testing.T) {
 						Step: &driver.TCPConnection{},
 					},
 					sd.Check(params,
-						[]string{"testdata/stackdriver/client_tcp_connection_count.yaml.tmpl", "testdata/stackdriver/server_tcp_connection_count.yaml.tmpl"},
+						[]string{
+							"testdata/stackdriver/client_tcp_connection_count.yaml.tmpl",
+							"testdata/stackdriver/client_tcp_received_bytes_count.yaml.tmpl",
+							"testdata/stackdriver/server_tcp_received_bytes_count.yaml.tmpl",
+							"testdata/stackdriver/server_tcp_connection_count.yaml.tmpl"},
 						[]SDLogEntry{
 							{
 								LogBaseFile: "testdata/stackdriver/server_access_log.yaml.tmpl",

--- a/testdata/stackdriver/client_tcp_received_bytes_count.yaml.tmpl
+++ b/testdata/stackdriver/client_tcp_received_bytes_count.yaml.tmpl
@@ -1,0 +1,53 @@
+metric:
+  labels:
+    {{- if .Vars.DestinationUnknown }}
+    destination_canonical_revision: latest
+    destination_canonical_service_name: "unknown"
+    destination_canonical_service_namespace: "unknown"
+    destination_owner: "unknown"
+    destination_port: '{{ .Ports.ServerPort }}'
+    destination_service_namespace: "unknown"
+    destination_workload_name: "unknown"
+    destination_workload_namespace: "unknown"
+    {{- else }}
+    destination_canonical_revision: version-1
+    destination_canonical_service_name: ratings
+    destination_canonical_service_namespace: default
+    destination_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/ratings-v1
+    destination_port: '{{ .Ports.ServerPort }}'
+    destination_service_namespace: default
+    destination_workload_name: ratings-v1
+    destination_workload_namespace: default
+    {{- end }}
+    destination_service_name: server
+    {{- if .Vars.DestinationPrincipal }}
+    destination_principal: "{{ .Vars.DestinationPrincipal }}"
+    {{- else }}
+    destination_principal: unknown
+    {{- end }}
+    mesh_uid: proj-123
+    request_protocol: tcp
+    service_authentication_policy: unknown # TODO: upstream TLS indicator is not reported
+    source_canonical_revision: version-1
+    source_canonical_service_name: productpage-v1
+    source_canonical_service_namespace: default
+    source_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/productpage-v1
+    {{- if .Vars.SourcePrincipal }}
+    source_principal: "{{ .Vars.SourcePrincipal }}"
+    {{- else }}
+    source_principal: unknown
+    {{- end }}
+    source_workload_name: productpage-v1
+    source_workload_namespace: default
+  type: istio.io/service/client/received_bytes_count
+points:
+- value:
+    int64Value: "60"
+resource:
+  labels:
+    cluster_name: test-cluster
+    location: us-east4-b
+    namespace_name: default
+    pod_name: productpage-v1-84975bc778-pxz2w
+    project_id: test-project
+  type: k8s_pod

--- a/testdata/stackdriver/server_tcp_received_bytes_count.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_received_bytes_count.yaml.tmpl
@@ -1,0 +1,52 @@
+metric:
+  labels:
+    destination_canonical_revision: version-1
+    destination_canonical_service_name: ratings
+    destination_canonical_service_namespace: default
+    destination_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/ratings-v1
+    destination_port: '{{ .Ports.ServerPort }}'
+    {{- if .Vars.DestinationPrincipal }}
+    destination_principal: "{{ .Vars.DestinationPrincipal }}"
+    {{- else }}
+    destination_principal: unknown
+    {{- end }}
+    destination_service_name: server
+    destination_service_namespace: default
+    destination_workload_name: ratings-v1
+    destination_workload_namespace: default
+    mesh_uid: proj-123
+    request_protocol: tcp
+    service_authentication_policy: {{ .Vars.ServiceAuthenticationPolicy }}
+    {{- if .Vars.SourceUnknown }}
+    source_canonical_revision: latest
+    source_canonical_service_name: "unknown"
+    source_canonical_service_namespace: "unknown"
+    source_owner: "unknown"
+    source_workload_name: "unknown"
+    source_workload_namespace: "unknown"
+    {{- else }}
+    source_canonical_revision: version-1
+    source_canonical_service_name: productpage-v1
+    source_canonical_service_namespace: default
+    source_owner: kubernetes://apis/apps/v1/namespaces/default/deployments/productpage-v1
+    source_workload_name: productpage-v1
+    source_workload_namespace: default
+    {{- end }}
+    {{- if .Vars.SourcePrincipal }}
+    source_principal: "{{ .Vars.SourcePrincipal }}"
+    {{- else }}
+    source_principal: unknown
+    {{- end }}
+  type: istio.io/service/server/received_bytes_count
+points:
+- value:
+    int64Value: "60"
+resource:
+  labels:
+    cluster_name: test-cluster
+    container_name: server
+    location: us-east4-b
+    namespace_name: default
+    pod_name: ratings-v1-84975bc778-pxz2w
+    project_id: test-project
+  type: k8s_container


### PR DESCRIPTION
The aggregation for bytes received/sent metrics for Stackdriver is incorrect. It should be `Sum` and not `Count`. As `Count`, it will merely record the number of times bytes were counted.
