### PR TITLE
Make extension doc generates snake case.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -133,7 +133,7 @@ lint: lint-copyright-banner format-go lint-go tidy-go lint-scripts
 	@scripts/check-style.sh
 
 protoc = protoc -I common-protos -I extensions
-protoc_gen_docs_plugin := --docs_out=warnings=true,per_file=true,mode=html_fragment_with_front_matter:$(repo_dir)/
+protoc_gen_docs_plugin := --docs_out=camel_case_fields=false,warnings=true,per_file=true,mode=html_fragment_with_front_matter:$(repo_dir)/
 
 attributegen_path := extensions/attributegen
 attributegen_protos := $(wildcard $(attributegen_path)/*.proto)

--- a/extensions/access_log_policy/config/v1alpha1/access_log_policy_config.pb.html
+++ b/extensions/access_log_policy/config/v1alpha1/access_log_policy_config.pb.html
@@ -32,7 +32,7 @@ attribute is set.</p>
 </thead>
 <tbody>
 <tr id="AccessLogPolicyConfig-log_window_duration">
-<td><code>logWindowDuration</code></td>
+<td><code>log_window_duration</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>Optional. Allows specifying logging window for successful requests.
@@ -44,7 +44,7 @@ No
 </td>
 </tr>
 <tr id="AccessLogPolicyConfig-max_client_cache_size">
-<td><code>maxClientCacheSize</code></td>
+<td><code>max_client_cache_size</code></td>
 <td><code>int32</code></td>
 <td>
 <p>Optional. Allows specifying max client cache size.

--- a/extensions/attributegen/config.pb.html
+++ b/extensions/attributegen/config.pb.html
@@ -160,7 +160,7 @@ No
 </thead>
 <tbody>
 <tr id="AttributeGeneration-output_attribute">
-<td><code>outputAttribute</code></td>
+<td><code>output_attribute</code></td>
 <td><code>string</code></td>
 <td>
 <p>The name of the attribute that is populated on a successful match.

--- a/extensions/metadata_exchange/config.pb.html
+++ b/extensions/metadata_exchange/config.pb.html
@@ -20,7 +20,7 @@ number_of_entries: 2
 </thead>
 <tbody>
 <tr id="PluginConfig-max_peer_cache_size">
-<td><code>maxPeerCacheSize</code></td>
+<td><code>max_peer_cache_size</code></td>
 <td><code><a href="#google-protobuf-UInt32Value">UInt32Value</a></code></td>
 <td>
 <p>maximum size of the peer metadata cache.

--- a/extensions/metadata_exchange/declare_property.pb.html
+++ b/extensions/metadata_exchange/declare_property.pb.html
@@ -64,34 +64,6 @@ No
 </tbody>
 </table>
 </section>
-<h2 id="LifeSpan">LifeSpan</h2>
-<section>
-<table class="enum-values">
-<thead>
-<tr>
-<th>Name</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr id="LifeSpan-FilterChain">
-<td><code>FilterChain</code></td>
-<td>
-</td>
-</tr>
-<tr id="LifeSpan-DownstreamRequest">
-<td><code>DownstreamRequest</code></td>
-<td>
-</td>
-</tr>
-<tr id="LifeSpan-DownstreamConnection">
-<td><code>DownstreamConnection</code></td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-</section>
 <h2 id="WasmType">WasmType</h2>
 <section>
 <table class="enum-values">
@@ -119,6 +91,34 @@ No
 </tr>
 <tr id="WasmType-Protobuf">
 <td><code>Protobuf</code></td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="LifeSpan">LifeSpan</h2>
+<section>
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="LifeSpan-FilterChain">
+<td><code>FilterChain</code></td>
+<td>
+</td>
+</tr>
+<tr id="LifeSpan-DownstreamRequest">
+<td><code>DownstreamRequest</code></td>
+<td>
+</td>
+</tr>
+<tr id="LifeSpan-DownstreamConnection">
+<td><code>DownstreamConnection</code></td>
 <td>
 </td>
 </tr>

--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.pb.html
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.pb.html
@@ -53,7 +53,7 @@ No
 </thead>
 <tbody>
 <tr id="PluginConfig-max_log_batch_size_in_bytes">
-<td><code>maxLogBatchSizeInBytes</code></td>
+<td><code>max_log_batch_size_in_bytes</code></td>
 <td><code>int32</code></td>
 <td>
 <p>Optional. Allows configuration of the size of the LogWrite request. The
@@ -66,7 +66,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-log_report_duration">
-<td><code>logReportDuration</code></td>
+<td><code>log_report_duration</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>Optional. Allows configuration of the time between calls out to the
@@ -80,7 +80,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-enable_audit_log">
-<td><code>enableAuditLog</code></td>
+<td><code>enable_audit_log</code></td>
 <td><code>bool</code></td>
 <td>
 <p>Optional. Controls whether to export audit log.</p>
@@ -91,7 +91,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-destination_service_name">
-<td><code>destinationServiceName</code></td>
+<td><code>destination_service_name</code></td>
 <td><code>string</code></td>
 <td>
 <p>Optional. FQDN of destination service that the request routed to, e.g.
@@ -104,7 +104,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-enable_mesh_edges_reporting">
-<td><code>enableMeshEdgesReporting</code></td>
+<td><code>enable_mesh_edges_reporting</code></td>
 <td><code>bool</code></td>
 <td>
 <p>Optional. Controls whether or not to export mesh edges to a mesh edges
@@ -116,7 +116,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-mesh_edges_reporting_duration">
-<td><code>meshEdgesReportingDuration</code></td>
+<td><code>mesh_edges_reporting_duration</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>Optional. Allows configuration of the time between calls out to the mesh
@@ -133,7 +133,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-max_peer_cache_size">
-<td><code>maxPeerCacheSize</code></td>
+<td><code>max_peer_cache_size</code></td>
 <td><code>int32</code></td>
 <td>
 <p>maximum size of the peer metadata cache.
@@ -146,7 +146,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-disable_host_header_fallback">
-<td><code>disableHostHeaderFallback</code></td>
+<td><code>disable_host_header_fallback</code></td>
 <td><code>bool</code></td>
 <td>
 <p>Optional: Disable using host header as a fallback if destination service is
@@ -159,7 +159,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-max_edges_batch_size">
-<td><code>maxEdgesBatchSize</code></td>
+<td><code>max_edges_batch_size</code></td>
 <td><code>int32</code></td>
 <td>
 <p>Optional. Allows configuration of the number of traffic assertions to batch
@@ -171,7 +171,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-disable_http_size_metrics">
-<td><code>disableHttpSizeMetrics</code></td>
+<td><code>disable_http_size_metrics</code></td>
 <td><code>bool</code></td>
 <td>
 <p>Optional. Allows disabling of reporting of the request and response size
@@ -184,7 +184,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-enable_log_compression">
-<td><code>enableLogCompression</code></td>
+<td><code>enable_log_compression</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#boolvalue">BoolValue</a></code></td>
 <td>
 <p>Optional. Allows enabling log compression for stackdriver access logs.</p>
@@ -195,7 +195,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-access_logging">
-<td><code>accessLogging</code></td>
+<td><code>access_logging</code></td>
 <td><code><a href="#PluginConfig-AccessLogging">AccessLogging</a></code></td>
 <td>
 <p>Optional. Controls what type of logs to export..</p>
@@ -206,7 +206,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-custom_log_config">
-<td><code>customLogConfig</code></td>
+<td><code>custom_log_config</code></td>
 <td><code><a href="#CustomConfig">CustomConfig</a></code></td>
 <td>
 <p>(Optional) Collection of tag names and tag expressions to include in the
@@ -218,8 +218,23 @@ supplied values. Does not apply to audit logs.</p>
 No
 </td>
 </tr>
+<tr id="PluginConfig-metric_expiry_duration">
+<td><code>metric_expiry_duration</code></td>
+<td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
+<td>
+<p>Optional. Controls the metric expiry duration. If a metric time series is
+not updated for the given duration, it will be purged from time series
+cache as well as metric reporting. If this is not set or set to 0, time
+series will never be expired. This option is useful to avoid unbounded
+metric label explodes proxy memory.</p>
+
+</td>
+<td>
+No
+</td>
+</tr>
 <tr id="PluginConfig-disable_server_access_logging" class="deprecated ">
-<td><code>disableServerAccessLogging</code></td>
+<td><code>disable_server_access_logging</code></td>
 <td><code>bool</code></td>
 <td>
 <p>Optional. Controls whether to export server access log.

--- a/extensions/stats/config.pb.html
+++ b/extensions/stats/config.pb.html
@@ -52,7 +52,7 @@ No
 </td>
 </tr>
 <tr id="MetricConfig-tags_to_remove">
-<td><code>tagsToRemove</code></td>
+<td><code>tags_to_remove</code></td>
 <td><code>string[]</code></td>
 <td>
 <p>(Optional) A list of tags to remove.</p>
@@ -142,7 +142,8 @@ No
 <td>
 <p>next id: 7
 The following settings should be rarely used.
-Enable debug for this filter.</p>
+Enable debug for this filter.
+DEPRECATED.</p>
 
 </td>
 <td>
@@ -150,7 +151,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-max_peer_cache_size">
-<td><code>maxPeerCacheSize</code></td>
+<td><code>max_peer_cache_size</code></td>
 <td><code>int32</code></td>
 <td>
 <p>maximum size of the peer metadata cache.
@@ -164,7 +165,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-stat_prefix">
-<td><code>statPrefix</code></td>
+<td><code>stat_prefix</code></td>
 <td><code>string</code></td>
 <td>
 <p>prefix to add to stats emitted by the plugin.
@@ -176,7 +177,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-field_separator">
-<td><code>fieldSeparator</code></td>
+<td><code>field_separator</code></td>
 <td><code>string</code></td>
 <td>
 <p>Stats api squashes dimensions in a single string.
@@ -190,7 +191,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-value_separator">
-<td><code>valueSeparator</code></td>
+<td><code>value_separator</code></td>
 <td><code>string</code></td>
 <td>
 <p>default: &ldquo;==&rdquo;</p>
@@ -201,7 +202,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-disable_host_header_fallback">
-<td><code>disableHostHeaderFallback</code></td>
+<td><code>disable_host_header_fallback</code></td>
 <td><code>bool</code></td>
 <td>
 <p>Optional: Disable using host header as a fallback if destination service is
@@ -214,7 +215,7 @@ No
 </td>
 </tr>
 <tr id="PluginConfig-tcp_reporting_duration">
-<td><code>tcpReportingDuration</code></td>
+<td><code>tcp_reporting_duration</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
 <p>Optional. Allows configuration of the time between calls out to for TCP


### PR DESCRIPTION
Proxy extension is configured with snake case field name instead of camel case. Update doc gen to clarify it.