### PR TITLE
Remove filename from SHA256 output

### DIFF
--- a/scripts/update_envoy.sh
+++ b/scripts/update_envoy.sh
@@ -35,7 +35,7 @@ ENVOY_REPO="$(grep -Pom1 "^ENVOY_REPO = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
 
 # Get ENVOY_SHA256
 URL="https://github.com/${ENVOY_ORG}/${ENVOY_REPO}/archive/${1}.tar.gz"
-GETSHA=$(wget "${URL}" && sha256sum "${1}".tar.gz)
+GETSHA=$(wget "${URL}" && sha256sum "${1}".tar.gz | awk '{ print $1 }')
 SHAArr=("${GETSHA}")
 SHA256=${SHAArr[0]}
 


### PR DESCRIPTION
Fix for the update_envoy script to remove the filename. 

The current automation ends up with (see #3171):
```
ENVOY_SHA256 = "5d8552be5cd2760e2dbabf9c25b7912a002d77486ae9a22d1ebee85449c183cc  96b216696bf69fa83bc65285a0f816cc41b079e6.tar.gz"
``` 
with the filename added.