### PR TITLE
envoy: add -fno-omit-frame-pointer for asan build

### DIFF
--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -62,6 +62,8 @@ build:asan --copt -D__SANITIZE_ADDRESS__
 build:asan --test_env=ASAN_OPTIONS=handle_abort=1:allow_addr2line=true:check_initialization_order=true:strict_init_order=true:detect_odr_violation=1
 build:asan --test_env=UBSAN_OPTIONS=halt_on_error=true:print_stacktrace=1
 build:asan --test_env=ASAN_SYMBOLIZER_PATH
+# See https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+build:asan --copt -fno-omit-frame-pointer
 # ASAN needs -O1 to get reasonable performance.
 build:asan --copt -O1
 build:asan --copt -fno-optimize-sibling-calls


### PR DESCRIPTION
**What this PR does / why we need it**: See https://github.com/google/sanitizers/wiki/AddressSanitizerFlags

**Special notes for your reviewer**:
Needs to be specified because https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html says that `-O1` turns on `-fomit-frame-pointer` (the opposite)