### PR TITLE
ci: blindly run v8//:build in build target of make

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -70,8 +70,10 @@ CENTOS_BUILD_ARGS ?= --cxxopt -D_GLIBCXX_USE_CXX11_ABI=1 --cxxopt -DENVOY_IGNORE
 CENTOS_BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS} -tools/deb/... -tools/docker/... -extensions:stats.wasm -extensions:metadata_exchange.wasm -extensions:attributegen.wasm
 
 build:
-	#TODO(lambdai): check dependency of BAZEL_TARGETS and prerun v8//:build
-	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) $(BAZEL_TARGETS)
+	#TODO(lambdai): Prerun v8//:build if and only if BAZEL_TARGETS depends on v8.
+	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
+	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) @com_googlesource_chromium_v8//:build && \
+	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) $(BAZEL_TARGETS)
 
 build_envoy:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \


### PR DESCRIPTION
Introduce the overhead for anyone who runs `make build` but not building envoy. Chances are small and they can always run `bazel build` directly.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
