### PR TITLE
Avoid specifying root cert at Stackdriver gRPC client.

### DIFF
--- a/extensions/stackdriver/common/constants.h
+++ b/extensions/stackdriver/common/constants.h
@@ -96,7 +96,6 @@ constexpr std::string_view kGCECreatedByKey = "gcp_gce_instance_created_by";
 // Misc
 constexpr char kIstioProxyContainerName[] = "istio-proxy";
 constexpr double kNanosecondsPerMillisecond = 1000000.0;
-constexpr char kDefaultRootCertFile[] = "/etc/ssl/certs/ca-certificates.crt";
 
 // Stackdriver root context id.
 constexpr char kOutboundRootContextId[] = "stackdriver_outbound";

--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -71,13 +71,13 @@ void buildEnvoyGrpcService(const StackdriverStubOption &stub_option,
   initial_metadata->set_key("x-goog-user-project");
   initial_metadata->set_value(stub_option.project_id);
 
-  grpc_service->mutable_google_grpc()
-      ->mutable_channel_credentials()
-      ->mutable_ssl_credentials()
-      ->mutable_root_certs()
-      ->set_filename(stub_option.test_root_pem_path.empty()
-                         ? kDefaultRootCertFile
-                         : stub_option.test_root_pem_path);
+  auto *ssl_creds = grpc_service->mutable_google_grpc()
+                        ->mutable_channel_credentials()
+                        ->mutable_ssl_credentials();
+  if (!stub_option.test_root_pem_path.empty()) {
+    ssl_creds->mutable_root_certs()->set_filename(
+        stub_option.test_root_pem_path);
+  }
 }
 
 bool isRawGCEInstance(const ::Wasm::Common::FlatNode &node) {

--- a/extensions/stackdriver/common/utils_test.cc
+++ b/extensions/stackdriver/common/utils_test.cc
@@ -57,11 +57,7 @@ TEST(UtilsTest, TestEnvoyGrpcSTS) {
         "google_grpc": {
             "target_uri": "secure",
             "channel_credentials": {
-                "ssl_credentials": {
-                    "root_certs": {
-                        "filename": "/etc/ssl/certs/ca-certificates.crt"
-                    }
-                }
+                "ssl_credentials": {}
             },
             "call_credentials": {
                 "sts_service": {

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -86,13 +86,13 @@ StackdriverOptions getStackdriverOptions(
   }
 
   auto ssl_creds_options = grpc::SslCredentialsOptions();
-  std::ifstream file(stub_option.test_root_pem_path.empty()
-                         ? kDefaultRootCertFile
-                         : stub_option.test_root_pem_path);
-  if (!file.fail()) {
-    std::stringstream file_string;
-    file_string << file.rdbuf();
-    ssl_creds_options.pem_root_certs = file_string.str();
+  if (!stub_option.test_root_pem_path.empty()) {
+    std::ifstream file(stub_option.test_root_pem_path);
+    if (!file.fail()) {
+      std::stringstream file_string;
+      file_string << file.rdbuf();
+      ssl_creds_options.pem_root_certs = file_string.str();
+    }
   }
   auto channel_creds = grpc::SslCredentials(ssl_creds_options);
 


### PR DESCRIPTION
I've tested that this works fine with real sd backend.

cc @williamaronli @howardjohn 