### PR TITLE
authz: add initial authz dry-run implementation

### DIFF
--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -33,30 +33,14 @@ namespace Extensions {
 namespace Stackdriver {
 namespace Log {
 namespace {
-
-using namespace proxy_wasm::null_plugin;
-
 // Matches Rbac Access denied string.
 // It is of the format:
 // "rbac_access_denied_matched_policy[ns[NAMESPACE]-policy[POLICY]-rule[POLICY_INDEX]]"
 const RE2 rbac_denied_match(
     "rbac_access_denied_matched_policy\\[ns\\[(.*)\\]-policy\\[(.*)\\]-rule\\[("
     ".*)\\]\\]");
-const RE2 authz_name_match(
-    "\\[ns\\[(.*)\\]-policy\\[(.*)\\]-rule\\[(.*)\\]\\]");
 constexpr char rbac_denied_match_prefix[] = "rbac_access_denied_matched_policy";
-constexpr char kRbacAccessAllowed[] = "AuthzAllowed";
 constexpr char kRbacAccessDenied[] = "AuthzDenied";
-constexpr char kRBACHttpFilterName[] = "envoy.filters.http.rbac";
-constexpr char kRBACNetworkFilterName[] = "envoy.filters.network.rbac";
-constexpr char kDryRunDenyShadowEngineResult[] =
-    "istio_dry_run_deny_shadow_engine_result";
-constexpr char kDryRunAllowShadowEngineResult[] =
-    "istio_dry_run_allow_shadow_engine_result";
-constexpr char kDryRunDenyShadowEffectiveId[] =
-    "istio_dry_run_deny_shadow_effective_policy_id";
-constexpr char kDryRunAllowShadowEffectiveId[] =
-    "istio_dry_run_allow_shadow_effective_policy_id";
 void setSourceCanonicalService(
     const ::Wasm::Common::FlatNode& peer_node_info,
     google::protobuf::Map<std::string, std::string>* label_map) {
@@ -182,82 +166,6 @@ void fillExtraLabels(
   for (const auto& extra_label : extra_labels) {
     (*label_map)[extra_label.first] = extra_label.second;
   }
-}
-
-void fillAuthzDryRunInfo(
-    google::protobuf::Map<std::string, std::string>* label_map) {
-  auto md = getProperty({"metadata", "filter_metadata", kRBACHttpFilterName});
-  if (!md.has_value()) {
-    md = getProperty({"metadata", "filter_metadata", kRBACNetworkFilterName});
-    if (!md.has_value()) {
-      LOG_DEBUG("RBAC metadata not found");
-      return;
-    }
-  }
-
-  bool shadow_deny_result = false;
-  bool shadow_allow_result = false;
-  bool has_shadow_metadata = false;
-  std::string shadow_deny_policy = "";
-  std::string shadow_allow_policy = "";
-  for (const auto& [key, val] : md.value()->pairs()) {
-    LOG_DEBUG(absl::StrCat("RBAC metadata found: key=", key, ", value=", val));
-    if (key == kDryRunDenyShadowEngineResult) {
-      shadow_deny_result = (val == "allowed");
-    } else if (key == kDryRunAllowShadowEngineResult) {
-      shadow_allow_result = (val == "allowed");
-    } else if (key == kDryRunDenyShadowEffectiveId) {
-      shadow_deny_policy = val;
-    } else if (key == kDryRunAllowShadowEffectiveId) {
-      shadow_allow_policy = val;
-    } else {
-      continue;
-    }
-    has_shadow_metadata = true;
-  }
-
-  if (!has_shadow_metadata) {
-    LOG_DEBUG("RBAC dry-run metadata not found");
-    return;
-  }
-
-  bool shadow_result = false;
-  std::string shadow_effective_policy = "";
-  if (shadow_deny_result && shadow_allow_result) {
-    // If allowed by both DENY and ALLOW policy, the final shadow_result should
-    // be true (allow) and the shadow_effective_policy should be from the ALLOW
-    // policy.
-    shadow_result = true;
-    shadow_effective_policy = shadow_allow_policy;
-  } else {
-    // If denied by either DENY or ALLOW policy, the final shadow_reulst should
-    // be false (denied).
-    shadow_result = false;
-    if (!shadow_deny_result) {
-      // If denied by DENY policy, the shadow_effective_policy should be from
-      // the DENY policy.
-      shadow_effective_policy = shadow_deny_policy;
-    } else {
-      // If denied by ALLOW policy, the shadow_effective_policy shold be from
-      // the ALLOW policy.
-      shadow_effective_policy = shadow_allow_policy;
-    }
-  }
-
-  (*label_map)["dry_run_result"] =
-      shadow_result ? kRbacAccessAllowed : kRbacAccessDenied;
-  std::string policy_name, policy_namespace, policy_rule_index;
-  if (RE2::PartialMatch(shadow_effective_policy, authz_name_match,
-                        &policy_namespace, &policy_name, &policy_rule_index)) {
-    (*label_map)["dry_run_policy_name"] =
-        absl::StrCat(policy_namespace, ".", policy_name);
-    (*label_map)["dry_run_policy_rule"] = policy_rule_index;
-  }
-  LOG_DEBUG(absl::StrCat(
-      "authorization policy dry-run result: dry_run_result=",
-      (*label_map)["dry_run_policy_result"],
-      ", dry_run_policy_name=", (*label_map)["dry_run_policy_name"],
-      ", dry_run_policy_rule=", (*label_map)["dry_run_policy_rule"]));
 }
 
 bool fillAuthInfo(const std::string& response_details,
@@ -465,7 +373,6 @@ void Logger::fillAndFlushLogEntry(
         (*label_map)["response_details"] = request_info.response_details;
       }
     }
-    fillAuthzDryRunInfo(label_map);
   }
 
   // Insert trace headers, if exist.

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -25,6 +25,7 @@
 #include "extensions/stackdriver/edges/mesh_edges_service_client.h"
 #include "extensions/stackdriver/log/exporter.h"
 #include "extensions/stackdriver/metric/registry.h"
+#include "re2/re2.h"
 
 #ifndef NULL_PLUGIN
 #include "api/wasm/cpp/proxy_wasm_intrinsics.h"
@@ -61,6 +62,20 @@ constexpr char kExporterRegistered[] = "registered";
 constexpr int kDefaultTickerMilliseconds = 10000;  // 10s
 
 namespace {
+
+const RE2 authz_name_match("ns\\[(.*)\\]-policy\\[(.*)\\]-rule\\[(.*)\\]");
+constexpr char kRbacAccessAllowed[] = "AuthzAllowed";
+constexpr char kRbacAccessDenied[] = "AuthzDenied";
+constexpr char kRBACHttpFilterName[] = "envoy.filters.http.rbac";
+constexpr char kRBACNetworkFilterName[] = "envoy.filters.network.rbac";
+constexpr char kDryRunDenyShadowEngineResult[] =
+    "istio_dry_run_deny_shadow_engine_result";
+constexpr char kDryRunAllowShadowEngineResult[] =
+    "istio_dry_run_allow_shadow_engine_result";
+constexpr char kDryRunDenyShadowEffectiveId[] =
+    "istio_dry_run_deny_shadow_effective_policy_id";
+constexpr char kDryRunAllowShadowEffectiveId[] =
+    "istio_dry_run_allow_shadow_effective_policy_id";
 
 // Get metric export interval from node metadata. Returns 60 seconds if interval
 // is not found in metadata.
@@ -204,6 +219,78 @@ flatbuffers::DetachedBuffer getLocalNodeMetadata() {
     }
   }
   return ::Wasm::Common::extractNodeFlatBufferFromStruct(node);
+}
+
+void fillAuthzDryRunInfo(
+    std::unordered_map<std::string, std::string>& extra_labels) {
+  auto md = getProperty({"metadata", "filter_metadata", kRBACHttpFilterName});
+  if (!md.has_value()) {
+    md = getProperty({"metadata", "filter_metadata", kRBACNetworkFilterName});
+    if (!md.has_value()) {
+      LOG_DEBUG("RBAC metadata not found");
+      return;
+    }
+  }
+
+  bool shadow_deny_result = false;
+  bool shadow_allow_result = false;
+  bool has_shadow_metadata = false;
+  std::string shadow_deny_policy = "";
+  std::string shadow_allow_policy = "";
+  for (const auto& [key, val] : md.value()->pairs()) {
+    LOG_DEBUG(absl::StrCat("RBAC metadata found: key=", key, ", value=", val));
+    if (key == kDryRunDenyShadowEngineResult) {
+      shadow_deny_result = (val == "allowed");
+    } else if (key == kDryRunAllowShadowEngineResult) {
+      shadow_allow_result = (val == "allowed");
+    } else if (key == kDryRunDenyShadowEffectiveId) {
+      shadow_deny_policy = val;
+    } else if (key == kDryRunAllowShadowEffectiveId) {
+      shadow_allow_policy = val;
+    } else {
+      continue;
+    }
+    has_shadow_metadata = true;
+  }
+
+  if (!has_shadow_metadata) {
+    LOG_DEBUG("RBAC dry-run metadata not found");
+    return;
+  }
+
+  LOG_DEBUG("RBAC dry-run result found");
+  bool shadow_result = false;
+  std::string shadow_effective_policy = "";
+  if (shadow_deny_result && shadow_allow_result) {
+    // If allowed by both DENY and ALLOW policy, the final shadow_result should
+    // be true (allow) and the shadow_effective_policy should be from the ALLOW
+    // policy.
+    shadow_result = true;
+    shadow_effective_policy = shadow_allow_policy;
+  } else {
+    // If denied by either DENY or ALLOW policy, the final shadow_reulst should
+    // be false (denied).
+    shadow_result = false;
+    if (!shadow_deny_result) {
+      // If denied by DENY policy, the shadow_effective_policy should be from
+      // the DENY policy.
+      shadow_effective_policy = shadow_deny_policy;
+    } else {
+      // If denied by ALLOW policy, the shadow_effective_policy shold be from
+      // the ALLOW policy.
+      shadow_effective_policy = shadow_allow_policy;
+    }
+  }
+
+  extra_labels["dry_run_result"] =
+      shadow_result ? kRbacAccessAllowed : kRbacAccessDenied;
+  std::string policy_name, policy_namespace, policy_rule_index;
+  if (RE2::PartialMatch(shadow_effective_policy, authz_name_match,
+                        &policy_namespace, &policy_name, &policy_rule_index)) {
+    extra_labels["dry_run_policy_name"] =
+        absl::StrCat(policy_namespace, ".", policy_name);
+    extra_labels["dry_run_policy_rule"] = policy_rule_index;
+  }
 }
 
 }  // namespace
@@ -463,6 +550,7 @@ void StackdriverRootContext::record() {
     std::unordered_map<std::string, std::string> extra_labels;
     evaluateExpressions(extra_labels);
     extended_info_populated = true;
+    fillAuthzDryRunInfo(extra_labels);
     logger_->addLogEntry(request_info, peer_node_info.get(), extra_labels,
                          outbound, false /* audit */);
   }
@@ -534,6 +622,7 @@ bool StackdriverRootContext::recordTCP(uint32_t id) {
       evaluateExpressions(record_info.extra_log_labels);
       record_info.expressions_evaluated = true;
     }
+    fillAuthzDryRunInfo(record_info.extra_log_labels);
     // It's possible that for a short lived TCP connection, we log TCP
     // Connection Open log entry on connection close.
     if (!record_info.tcp_open_entry_logged &&

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -47,6 +47,7 @@ func init() {
 			"TestStackdriverAttributeGen",
 			"TestStackdriverCustomAccessLog",
 			"TestStackdriverRbacAccessDenied",
+			"TestStackdriverRbacTCPDryRun",
 			"TestStackdriverMetricExpiry",
 			"TestStatsPayload/Default/envoy.wasm.runtime.null",
 			"TestStatsPayload/Customized/envoy.wasm.runtime.null",

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -849,6 +849,7 @@ func TestStackdriverRbacAccessDenied(t *testing.T) {
 		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
 		"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
 		"RbacAccessDenied":            "true",
+		"RbacDryRun":                  "true",
 	}, envoye2e.ProxyE2ETests)
 
 	sdPort := params.Ports.Max + 1
@@ -859,6 +860,7 @@ func TestStackdriverRbacAccessDenied(t *testing.T) {
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
 	params.Vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_outbound.yaml.tmpl")
 	params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_inbound.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/rbac_dry_run.yaml.tmpl") + "\n" +
 		driver.LoadTestData("testdata/filters/rbac.yaml.tmpl") + "\n" +
 		driver.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
 	sd := &Stackdriver{Port: sdPort}

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -902,6 +902,108 @@ func TestStackdriverRbacAccessDenied(t *testing.T) {
 	}
 }
 
+func TestStackdriverRbacTCPDryRun(t *testing.T) {
+	t.Parallel()
+	var TestCases = []struct {
+		name               string
+		alpnProtocol       string
+		sourceUnknown      string
+		destinationUnknown string
+	}{
+		{"BaseCase", "mx-protocol", "", ""},
+		{"NoAlpn", "some-protocol", "true", "true"},
+	}
+
+	for _, tt := range TestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			params := driver.NewTestParams(t, map[string]string{
+				"ServiceAuthenticationPolicy": "MUTUAL_TLS",
+				"SDLogStatusCode":             "200",
+				"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
+				"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
+				"SourcePrincipal":             "spiffe://cluster.local/ns/default/sa/client",
+				"DestinationPrincipal":        "spiffe://cluster.local/ns/default/sa/server",
+				"DisableDirectResponse":       "true",
+				"AlpnProtocol":                tt.alpnProtocol,
+				"StatsConfig":                 driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
+				"SourceUnknownOnClose":        tt.sourceUnknown,
+				"SourceUnknownOnOpen":         tt.sourceUnknown,
+				"DestinationUnknown":          tt.destinationUnknown,
+				"SourceUnknown":               tt.sourceUnknown,
+				"RbacDryRun":                  "true",
+			}, envoye2e.ProxyE2ETests)
+
+			sdPort := params.Ports.Max + 1
+			stsPort := params.Ports.Max + 2
+			params.Vars["SDPort"] = strconv.Itoa(int(sdPort))
+			params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
+			params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
+			params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
+			params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_mx_network_filter.yaml.tmpl") + "\n" +
+				params.LoadTestData("testdata/filters/rbac_tcp.yaml.tmpl") + "\n" +
+				params.LoadTestData("testdata/filters/stackdriver_network_inbound.yaml.tmpl")
+			params.Vars["ClientUpstreamFilters"] = params.LoadTestData("testdata/filters/client_mx_network_filter.yaml.tmpl")
+			params.Vars["ClientNetworkFilters"] = params.LoadTestData("testdata/filters/stackdriver_network_outbound.yaml.tmpl")
+			params.Vars["ClientClusterTLSContext"] = params.LoadTestData("testdata/transport_socket/client.yaml.tmpl")
+			params.Vars["ServerListenerTLSContext"] = params.LoadTestData("testdata/transport_socket/server.yaml.tmpl")
+
+			sd := &Stackdriver{Port: sdPort}
+
+			if err := (&driver.Scenario{
+				Steps: []driver.Step{
+					&driver.XDS{},
+					sd,
+					&SecureTokenService{Port: stsPort},
+					&driver.Update{
+						Node:      "client",
+						Version:   "0",
+						Clusters:  []string{params.LoadTestData("testdata/cluster/tcp_client.yaml.tmpl")},
+						Listeners: []string{params.LoadTestData("testdata/listener/tcp_client.yaml.tmpl")},
+					},
+					&driver.Update{
+						Node:      "server",
+						Version:   "0",
+						Clusters:  []string{params.LoadTestData("testdata/cluster/tcp_server.yaml.tmpl")},
+						Listeners: []string{params.LoadTestData("testdata/listener/tcp_server.yaml.tmpl")},
+					},
+					&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
+					&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
+					&driver.Sleep{Duration: 1 * time.Second},
+					&driver.TCPServer{Prefix: "hello"},
+					&driver.Repeat{
+						N:    10,
+						Step: &driver.TCPConnection{},
+					},
+					sd.Check(params,
+						[]string{
+							"testdata/stackdriver/client_tcp_connection_count.yaml.tmpl",
+							"testdata/stackdriver/client_tcp_received_bytes_count.yaml.tmpl",
+							"testdata/stackdriver/server_tcp_received_bytes_count.yaml.tmpl",
+							"testdata/stackdriver/server_tcp_connection_count.yaml.tmpl"},
+						[]SDLogEntry{
+							{
+								LogBaseFile: "testdata/stackdriver/server_access_log.yaml.tmpl",
+								LogEntryFile: []string{"testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl",
+									"testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl"},
+								LogEntryCount: 10,
+							},
+							{
+								LogBaseFile: "testdata/stackdriver/client_access_log.yaml.tmpl",
+								LogEntryFile: []string{"testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl",
+									"testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl"},
+								LogEntryCount: 10,
+							},
+						},
+						nil, false,
+					),
+				},
+			}).Run(params); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestStackdriverMetricExpiry(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{
 		"ServiceAuthenticationPolicy": "NONE",

--- a/testdata/filters/rbac_dry_run.yaml.tmpl
+++ b/testdata/filters/rbac_dry_run.yaml.tmpl
@@ -1,0 +1,28 @@
+- name: envoy.filters.http.rbac
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.http.rbac.v3.RBAC
+    value:
+      shadowRulesStatPrefix: istio_dry_run_deny_
+      shadowRules:
+        action: DENY
+        policies:
+          ns[foo]-policy[httpbin-dryrun-deny]-rule[0]:
+            permissions:
+              - any: true
+            principals:
+              - any: true
+- name: envoy.filters.http.rbac
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.http.rbac.v3.RBAC
+    value:
+      shadowRulesStatPrefix: istio_dry_run_allow_
+      shadowRules:
+        action: ALLOW
+        policies:
+          ns[foo]-policy[httpbin-dryrun-allow]-rule[0]:
+            permissions:
+              - any: true
+            principals:
+              - any: true

--- a/testdata/filters/rbac_tcp.yaml.tmpl
+++ b/testdata/filters/rbac_tcp.yaml.tmpl
@@ -1,0 +1,30 @@
+- name: envoy.filters.network.rbac
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.network.rbac.v3.RBAC
+    value:
+      statPrefix: tcp.
+      shadowRulesStatPrefix: istio_dry_run_deny_
+      shadowRules:
+        action: DENY
+        policies:
+          ns[foo]-policy[tcp-dryrun-deny]-rule[0]:
+            permissions:
+              - any: true
+            principals:
+              - any: true
+- name: envoy.filters.network.rbac
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.network.rbac.v3.RBAC
+    value:
+      statPrefix: tcp.
+      shadowRulesStatPrefix: istio_dry_run_allow_
+      shadowRules:
+        action: ALLOW
+        policies:
+          ns[foo]-policy[tcp-dryrun-allow]-rule[0]:
+            permissions:
+              - any: true
+            principals:
+              - any: true

--- a/testdata/stackdriver/server_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_access_log_entry.yaml.tmpl
@@ -48,4 +48,9 @@ labels:
   response_details: "via_upstream"
   route_name: server_route
   {{- end }}
+  {{- if .Vars.RbacDryRun }}
+  dry_run_result: "AuthzDenied"
+  dry_run_policy_name: "foo.httpbin-dryrun-deny"
+  dry_run_policy_rule: "0"
+  {{-  end }}
 severity: INFO

--- a/testdata/stackdriver/server_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_access_log_entry.yaml.tmpl
@@ -52,5 +52,5 @@ labels:
   dry_run_result: "AuthzDenied"
   dry_run_policy_name: "foo.httpbin-dryrun-deny"
   dry_run_policy_rule: "0"
-  {{-  end }}
+  {{- end }}
 severity: INFO

--- a/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl
@@ -34,6 +34,11 @@ labels:
   log_sampled: "false"
   upstream_cluster: "inbound|9080|tcp|server.default.svc.cluster.local"
   requested_server_name: "server.com"
+  {{- if .Vars.RbacDryRun }}
+  dry_run_result: "AuthzDenied"
+  dry_run_policy_name: "foo.tcp-dryrun-deny"
+  dry_run_policy_rule: "0"
+  {{- end }}
 severity: INFO
 {{- if .Vars.SourceUnknownOnClose }}
 text_payload: " --> ratings"

--- a/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl
@@ -34,6 +34,11 @@ labels:
   log_sampled: "false"
   upstream_cluster: "inbound|9080|tcp|server.default.svc.cluster.local"
   requested_server_name: "server.com"
+  {{- if .Vars.RbacDryRun }}
+  dry_run_result: "AuthzDenied"
+  dry_run_policy_name: "foo.tcp-dryrun-deny"
+  dry_run_policy_rule: "0"
+  {{- end }}
 severity: INFO
 {{- if .Vars.SourceUnknownOnOpen }}
 text_payload: " --> ratings"


### PR DESCRIPTION
**What this PR does / why we need it**: 

Adds the initial support of dry-run authorization policy.

Currently 3 custom labels are added if dry-run is used: `dry_run_result`, `dry_run_policy_name` and `dry_run_policy_rule`, this follows the same name used in the authz deny logging, could be updated later if needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
