### PR TITLE
Fix rbac dry run integration test flake.

### DIFF
--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -71,6 +71,8 @@ func init() {
 			"TestStatsECDS/envoy.wasm.runtime.v8",
 			"TestStatsECDS/envoy.wasm.runtime.v8#01",
 			"TestHTTPLocalRatelimit",
+			"TestStackdriverRbacTCPDryRun/BaseCase",
+			"TestStackdriverRbacTCPDryRun/NoAlpn",
 		},
 	}
 }


### PR DESCRIPTION
Flake due to port conflict. See some example failures at https://github.com/istio/proxy/pull/3245