### PR TITLE
Manual update of Envoy - with change needed for new build image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,10 +38,10 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # Note: this is needed by release builder to resolve envoy dep sha to tag.
-# Commit date: 2021-04-12
-ENVOY_SHA = "50c8be5d7d766b45ec69e8392a3ba10f338b0268"
+# Commit date: 2021-04-14
+ENVOY_SHA = "d31ba23d494c310973ceaf1e053393697821e4d3"
 
-ENVOY_SHA256 = "937dabee9cf0b1697ddf19ff5c0cf0455479ab352eb5bc8c23c35a2faf9ddfd2"
+ENVOY_SHA256 = "e26bcb60a4e439b0446e9ee079473a11a3f1d2ccd312f56e8df8de969c4bf2a3"
 
 ENVOY_ORG = "envoyproxy"
 

--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -72,8 +72,6 @@ build:clang-asan --linkopt -fuse-ld=lld
 
 # macOS ASAN/UBSAN
 build:macos --cxxopt=-std=c++17
-build:macos --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a
-build:macos --action_env=BAZEL_LINKOPTS=-lm
 
 build:macos-asan --config=asan
 # Workaround, see https://github.com/bazelbuild/bazel/issues/6932

--- a/scripts/check-style.sh
+++ b/scripts/check-style.sh
@@ -18,7 +18,7 @@
 #
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-CLANG_VERSION_REQUIRED="10.0.1"
+CLANG_VERSION_REQUIRED="11.0.1"
 CLANG_FORMAT=$(command -v clang-format)
 CLANG_VERSION="$(${CLANG_FORMAT} -version 2>/dev/null | cut -d ' ' -f 3 | cut -d '-' -f 1)"
 if [[ ! -x "${CLANG_FORMAT}" || "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

See if the clang version will fix test failure.
Replaces https://github.com/istio/proxy/pull/3286

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
