### PR TITLE
Update to use latest commit of envoyproxy/envoy release/v1.18 branch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,13 +38,13 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # Note: this is needed by release builder to resolve envoy dep sha to tag.
-# Commit date: 2021-04-20
+# Commit date: 2021-04-16
 
-ENVOY_SHA = "f0864a252089b54c4d97ac6e4b3e3edeb312ebbc"
+ENVOY_SHA = "d362e791eb9e4efa8d87f6d878740e72dc8330ac"
 
-ENVOY_SHA256 = "3e0f8a158d5320bacb7d9b8083465e6ace2039c6c2b734818dd92ec675a3c8d8"
+ENVOY_SHA256 = "755f4692c68f6423eb28e65c5903d56907a8cc7fae1a967823ea8e198885b0c7"
 
-ENVOY_ORG = "istio"
+ENVOY_ORG = "envoyproxy"
 
 ENVOY_REPO = "envoy"
 

--- a/scripts/update_envoy.sh
+++ b/scripts/update_envoy.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 
-# Update the Envoy SHA in istio/proxy WORKSPACE with the first argument (aka ENVOY_SHA) and
-# the second argument (aka ENVOY_SHA commit date)
+# Update the Envoy SHA in istio/proxy WORKSPACE with the latest commit of the
+# $UPDATE_BRANCH of the specified ENVOY_ORG/ENVOY_REPO
 
 # Exit immediately for non zero status
 set -e


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the workspace to use envoyproxy/envoy commits, and updates it to the latest commit on the `release/v1.181 branch. It represents the 1.18.2 release.

Separate automation is added in a test-infra PR to periodically check if there is a later commit and update the WORKSPACE file with that commit. Thus as changes are picked to the envoyproxy/envoy release branch we will get them.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
