### PR TITLE
Fix sha verification breakage

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -208,7 +208,7 @@ def istioapi_dependencies():
 def docker_dependencies():
     http_archive(
         name = "io_bazel_rules_docker",
-        sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
-        strip_prefix = "rules_docker-0.15.0",
-        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
+        sha256 = "59d5b42ac315e7eadffa944e86e90c2990110a1c8075f1cd145f487e999d22b3",
+        strip_prefix = "rules_docker-0.17.0",
+        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.17.0/rules_docker-v0.17.0.tar.gz"],
     )


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_docker/issues/1814

tl;dr we cannot build proxy due to a SHA mismatch. This is because some
dependency has some magic file that dynamically sets a value when a
github archive is created.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
