### PR TITLE
envoy: initial skeleton for tcp proxy metadata upstream

### DIFF
--- a/src/envoy/upstreams/tcp_proxy/BUILD
+++ b/src/envoy/upstreams/tcp_proxy/BUILD
@@ -1,0 +1,50 @@
+# Copyright 2021 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_cc_test",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "upstream_lib",
+    srcs = ["upstream.cc"],
+    hdrs = ["upstream.h"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//include/envoy/tcp:conn_pool_interface",
+        "@envoy//source/common/tcp_proxy:upstream_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "upstream_test",
+    srcs = ["upstream_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":upstream_lib",
+        "@envoy//source/common/http:header_map_lib",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//test/mocks/http:http_mocks",
+        "@envoy//test/mocks/tcp:tcp_mocks",
+        "@envoy_api//envoy/extensions/filters/network/tcp_proxy/v3:pkg_cc_proto",
+    ],
+)

--- a/src/envoy/upstreams/tcp_proxy/upstream.cc
+++ b/src/envoy/upstreams/tcp_proxy/upstream.cc
@@ -1,0 +1,16 @@
+/* Copyright 2021 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/upstreams/tcp_proxy/upstream.h"

--- a/src/envoy/upstreams/tcp_proxy/upstream.h
+++ b/src/envoy/upstreams/tcp_proxy/upstream.h
@@ -1,0 +1,34 @@
+/* Copyright 2021 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "common/tcp_proxy/upstream.h"
+#include "envoy/tcp/conn_pool.h"
+
+namespace Envoy {
+namespace Upstreams {
+namespace TcpProxy {
+
+class MetadataUpstream : public Envoy::TcpProxy::Http2Upstream {
+ public:
+  MetadataUpstream(Tcp::ConnectionPool::UpstreamCallbacks& callbacks,
+                   const TunnelingConfig& config)
+      : Http2Upstream(callbacks, config) {}
+};
+
+}  // namespace TcpProxy
+}  // namespace Upstreams
+}  // namespace Envoy

--- a/src/envoy/upstreams/tcp_proxy/upstream_test.cc
+++ b/src/envoy/upstreams/tcp_proxy/upstream_test.cc
@@ -1,0 +1,72 @@
+/* Copyright 2021 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/upstreams/tcp_proxy/upstream.h"
+
+#include <memory>
+
+#include "common/http/header_map_impl.h"
+#include "common/http/headers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/mocks/http/mocks.h"
+#include "test/mocks/http/stream_encoder.h"
+#include "test/mocks/tcp/mocks.h"
+
+namespace Envoy {
+namespace Upstreams {
+namespace TcpProxy {
+namespace {
+using envoy::extensions::filters::network::tcp_proxy::v3::
+    TcpProxy_TunnelingConfig;
+
+class MetadataUpstreamRequestEncoderTest : public testing::Test {
+ public:
+  MetadataUpstreamRequestEncoderTest() {
+    EXPECT_CALL(encoder_, getStream()).Times(::testing::AnyNumber());
+    config_.set_hostname("default.host.com:443");
+  }
+
+  void setupUpstream() {
+    upstream_ = std::make_unique<MetadataUpstream>(callbacks_, config_);
+  }
+
+  Http::MockRequestEncoder encoder_;
+  ::testing::NiceMock<Tcp::ConnectionPool::MockUpstreamCallbacks> callbacks_;
+  std::unique_ptr<MetadataUpstream> upstream_;
+  TcpProxy_TunnelingConfig config_;
+};
+
+TEST_F(MetadataUpstreamRequestEncoderTest, RequestEncoder) {
+  setupUpstream();
+  std::unique_ptr<Http::RequestHeaderMapImpl> expected_headers;
+  expected_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>({
+      {Http::Headers::get().Method, "CONNECT"},
+      {Http::Headers::get().Host, config_.hostname()},
+      {Http::Headers::get().Path, "/"},
+      {Http::Headers::get().Scheme, Http::Headers::get().SchemeValues.Http},
+      {Http::Headers::get().Protocol,
+       Http::Headers::get().ProtocolValues.Bytestream},
+  });
+
+  EXPECT_CALL(encoder_,
+              encodeHeaders(HeaderMapEqualRef(expected_headers.get()), false));
+  upstream_->setRequestEncoder(encoder_, false);
+}
+
+}  // namespace
+}  // namespace TcpProxy
+}  // namespace Upstreams
+}  // namespace Envoy


### PR DESCRIPTION
**What this PR does / why we need it**: Start of TCP proxy upstream for istio/istio#31444

**Special notes for your reviewer**: Keeping PR size small for easier reviews. Next (for TCP proxy) would be the connection pool. When the API for adding headers is implemented, similar unit tests can be added/extended