### PR TITLE
Makefile: fix shell target to be phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ default:
 shell:
 	@$(RUN) /bin/bash
 
-.PHONY: default
+.PHONY: default shell
 
 else
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes "shell" target to be phony. This fixes the following issue if there is a file with name shell:

```
$ BUILD_WITH_CONTAINER=1 make shell
make: 'shell' is up to date.
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
