### PR TITLE
stackdriver: harden against invalid utf8

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -436,10 +436,11 @@ void populateExtendedHTTPRequestInfo(RequestInfo* request_info) {
   if (getValue({"request", "headers", "x-b3-sampled"}, &trace_sampled) &&
       trace_sampled == "1") {
     if (getValue({"request", "headers", "x-b3-traceid"},
-             &request_info->b3_trace_id)) {
+                 &request_info->b3_trace_id)) {
       sanitizeBytes(&request_info->b3_trace_id);
     }
-    if (getValue({"request", "headers", "x-b3-spanid"}, &request_info->b3_span_id)) {
+    if (getValue({"request", "headers", "x-b3-spanid"},
+                 &request_info->b3_span_id)) {
       sanitizeBytes(&request_info->b3_span_id);
     }
     request_info->b3_trace_sampled = true;
@@ -534,8 +535,8 @@ bool getAuditPolicy() {
 }
 
 bool sanitizeBytes(std::string* buf) {
-  char *start = buf->data();
-  const char *const end = start + buf->length();
+  char* start = buf->data();
+  const char* const end = start + buf->length();
   bool modified = false;
   while (start < end) {
     if (flatbuffers::FromUTF8(const_cast<const char**>(&start)) < 0) {

--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -539,10 +539,13 @@ bool sanitizeBytes(std::string* buf) {
   const char* const end = start + buf->length();
   bool modified = false;
   while (start < end) {
-    if (flatbuffers::FromUTF8(const_cast<const char**>(&start)) < 0) {
+    char* s = start;
+    if (flatbuffers::FromUTF8(const_cast<const char**>(&s)) < 0) {
       *start = ' ';
       start += 1;
       modified = true;
+    } else {
+      start = s;
     }
   }
   return modified;

--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -19,6 +19,7 @@
 #include "absl/strings/str_split.h"
 #include "extensions/common/node_info_bfbs_generated.h"
 #include "extensions/common/util.h"
+#include "flatbuffers/util.h"
 
 // WASM_PROLOG
 #ifndef NULL_PLUGIN
@@ -422,15 +423,25 @@ std::string_view nodeInfoSchema() {
 void populateExtendedHTTPRequestInfo(RequestInfo* request_info) {
   populateExtendedRequestInfo(request_info);
 
-  getValue({"request", "referer"}, &request_info->referer);
-  getValue({"request", "useragent"}, &request_info->user_agent);
-  getValue({"request", "id"}, &request_info->request_id);
+  if (getValue({"request", "referer"}, &request_info->referer)) {
+    sanitizeBytes(&request_info->referer);
+  }
+  if (getValue({"request", "useragent"}, &request_info->user_agent)) {
+    sanitizeBytes(&request_info->user_agent);
+  }
+  if (getValue({"request", "id"}, &request_info->request_id)) {
+    sanitizeBytes(&request_info->request_id);
+  }
   std::string trace_sampled;
   if (getValue({"request", "headers", "x-b3-sampled"}, &trace_sampled) &&
       trace_sampled == "1") {
-    getValue({"request", "headers", "x-b3-traceid"},
-             &request_info->b3_trace_id);
-    getValue({"request", "headers", "x-b3-spanid"}, &request_info->b3_span_id);
+    if (getValue({"request", "headers", "x-b3-traceid"},
+             &request_info->b3_trace_id)) {
+      sanitizeBytes(&request_info->b3_trace_id);
+    }
+    if (getValue({"request", "headers", "x-b3-spanid"}, &request_info->b3_span_id)) {
+      sanitizeBytes(&request_info->b3_span_id);
+    }
     request_info->b3_trace_sampled = true;
   }
 
@@ -456,10 +467,12 @@ void populateExtendedRequestInfo(RequestInfo* request_info) {
       WasmHeaderMapType::RequestHeaders, kEnvoyOriginalPathKey);
   request_info->x_envoy_original_path =
       envoy_original_path ? envoy_original_path->toString() : "";
+  sanitizeBytes(&request_info->x_envoy_original_path);
   auto envoy_original_dst_host = getHeaderMapValue(
       WasmHeaderMapType::RequestHeaders, kEnvoyOriginalDstHostKey);
   request_info->x_envoy_original_dst_host =
       envoy_original_dst_host ? envoy_original_dst_host->toString() : "";
+  sanitizeBytes(&request_info->x_envoy_original_dst_host);
   getValue({"upstream", "transport_failure_reason"},
            &request_info->upstream_transport_failure_reason);
   std::string response_details;
@@ -518,6 +531,20 @@ bool getAuditPolicy() {
   }
 
   return shouldAudit;
+}
+
+bool sanitizeBytes(std::string* buf) {
+  char *start = buf->data();
+  const char *const end = start + buf->length();
+  bool modified = false;
+  while (start < end) {
+    if (flatbuffers::FromUTF8(const_cast<const char**>(&start)) < 0) {
+      *start = ' ';
+      start += 1;
+      modified = true;
+    }
+  }
+  return modified;
 }
 
 }  // namespace Common

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -298,5 +298,10 @@ static inline std::string_view GetStringView(const flatbuffers::String* str) {
   return str ? std::string_view(str->c_str(), str->size()) : std::string_view();
 }
 
+// Sanitizes a possible UTF-8 byte buffer to a UTF-8 string.
+// Invalid byte sequences are replaced by spaces.
+// Returns true if the string was modified.
+bool sanitizeBytes(std::string* buf);
+
 }  // namespace Common
 }  // namespace Wasm

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -38,6 +38,7 @@ func init() {
 			"TestStackdriverPayload",
 			"TestStackdriverPayloadGateway",
 			"TestStackdriverPayloadWithTLS",
+			"TestStackdriverPayloadUtf8",
 			"TestStackdriverReload",
 			"TestStackdriverVMReload",
 			"TestStackdriverParallel",

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -1086,7 +1086,7 @@ func TestStackdriverPayloadUtf8(t *testing.T) {
 
 	sd := &Stackdriver{Port: sdPort}
 
-	bad := "va\xFFlue"
+	bad := "va\xC0lue"
 	get := &driver.HTTPCall{
 		Method: "GET",
 		Port:   params.Ports.ClientPort,

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -1065,3 +1065,75 @@ func TestStackdriverMetricExpiry(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestStackdriverPayloadUtf8(t *testing.T) {
+	t.Parallel()
+	params := driver.NewTestParams(t, map[string]string{
+		"ServiceAuthenticationPolicy": "NONE",
+		"SDLogStatusCode":             "200",
+		"StackdriverRootCAFile":       driver.TestPath("testdata/certs/stackdriver.pem"),
+		"StackdriverTokenFile":        driver.TestPath("testdata/certs/access-token"),
+		"StatsConfig":                 driver.LoadTestData("testdata/bootstrap/stats.yaml.tmpl"),
+	}, envoye2e.ProxyE2ETests)
+
+	sdPort := params.Ports.Max + 1
+	stsPort := params.Ports.Max + 2
+	params.Vars["SDPort"] = strconv.Itoa(int(sdPort))
+	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
+	params.Vars["ClientMetadata"] = driver.LoadTestData("testdata/client_node_metadata.json.tmpl")
+	params.Vars["ServerMetadata"] = driver.LoadTestData("testdata/server_node_metadata.json.tmpl")
+	enableStackDriver(t, params.Vars)
+
+	sd := &Stackdriver{Port: sdPort}
+
+	bad := "va\xFFlue"
+	get := &driver.HTTPCall{
+		Method: "GET",
+		Port:   params.Ports.ClientPort,
+		Body:   "hello, world!",
+		RequestHeaders: map[string]string{
+			"referer":                   bad,
+			"user-agent":                bad,
+			"x-envoy-original-path":     bad,
+			"x-envoy-original-dst-host": bad,
+			"x-request-id":              bad,
+			"x-b3-traceid":              bad,
+			"x-b3-spanid":               bad,
+		},
+	}
+
+	if err := (&driver.Scenario{
+		[]driver.Step{
+			&driver.XDS{},
+			sd,
+			&SecureTokenService{Port: stsPort},
+			&driver.Update{Node: "client", Version: "0", Listeners: []string{driver.LoadTestData("testdata/listener/client.yaml.tmpl")}},
+			&driver.Update{Node: "server", Version: "0", Listeners: []string{driver.LoadTestData("testdata/listener/server.yaml.tmpl")}},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
+			&driver.Sleep{1 * time.Second},
+			&driver.Repeat{N: 10, Step: get},
+			sd.Check(params,
+				[]string{"testdata/stackdriver/client_request_count.yaml.tmpl", "testdata/stackdriver/server_request_count.yaml.tmpl"},
+				[]SDLogEntry{
+					{
+						LogBaseFile:   "testdata/stackdriver/server_access_log.yaml.tmpl",
+						LogEntryFile:  []string{"testdata/stackdriver/utf8_server_access_log_entry.yaml.tmpl"},
+						LogEntryCount: 10,
+					},
+					{
+						LogBaseFile:   "testdata/stackdriver/client_access_log.yaml.tmpl",
+						LogEntryFile:  []string{"testdata/stackdriver/utf8_client_access_log_entry.yaml.tmpl"},
+						LogEntryCount: 10,
+					},
+				},
+				[]string{"testdata/stackdriver/traffic_assertion.yaml.tmpl"}, true,
+			),
+			&driver.Stats{params.Ports.ServerAdmin, map[string]driver.StatMatcher{
+				"envoy_type_logging_success_true_export_call": &driver.ExactStat{"testdata/metric/stackdriver_callout_metric.yaml.tmpl"},
+			}},
+		},
+	}).Run(params); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/testdata/stackdriver/utf8_client_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/utf8_client_access_log_entry.yaml.tmpl
@@ -1,0 +1,31 @@
+http_request:
+  request_method: "GET"
+  request_url: "http://127.0.0.1:{{ .Ports.ClientPort }}/{{ .Vars.RequestPath }}"
+  server_ip: "127.0.0.1:{{ .Ports.ClientPort }}"
+  protocol: "http"
+  status: {{ .Vars.SDLogStatusCode }}
+  user_agent: va lue
+  referer: va lue
+labels:
+  destination_principal: "{{ .Vars.DestinationPrincipal }}"
+  destination_service_host: server.default.svc.cluster.local
+  destination_service_name: server
+  response_flag: "-"
+  service_authentication_policy: ""
+  source_principal: "{{ .Vars.SourcePrincipal }}"
+  destination_name: ratings-v1-84975bc778-pxz2w
+  destination_namespace: default
+  destination_workload: ratings-v1
+  destination_app: ratings
+  destination_canonical_service: ratings
+  destination_canonical_revision: version-1
+  destination_service_name: server
+  destination_version: v1
+  protocol: http
+  log_sampled: "false"
+  upstream_cluster: "server-outbound-cluster"
+  route_name: client_route
+  response_details: "via_upstream"
+  x-envoy-original-path: va lue
+  x-envoy-original-dst-host: va lue
+severity: INFO

--- a/testdata/stackdriver/utf8_server_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/utf8_server_access_log_entry.yaml.tmpl
@@ -1,0 +1,30 @@
+http_request:
+  request_method: "GET"
+  request_url: "http://127.0.0.1:{{ .Ports.ClientPort }}/{{ .Vars.RequestPath }}"
+  server_ip: "127.0.0.1:{{ .Ports.ServerPort }}"
+  protocol: "http"
+  status: {{ .Vars.SDLogStatusCode }}
+  user_agent: va lue
+  referer: va lue
+labels:
+  destination_principal: "{{ .Vars.DestinationPrincipal }}"
+  destination_service_host: server.default.svc.cluster.local
+  destination_service_name: server
+  response_flag: "-"
+  service_authentication_policy: {{ .Vars.ServiceAuthenticationPolicy }}
+  source_principal: "{{ .Vars.SourcePrincipal }}"
+  source_name: productpage-v1-84975bc778-pxz2w
+  source_namespace: default
+  source_workload: productpage-v1
+  source_app: productpage
+  source_canonical_service: productpage-v1
+  source_canonical_revision: version-1
+  source_version: v1
+  protocol: http
+  log_sampled: "false"
+  upstream_cluster: "server-inbound-cluster"
+  response_details: "via_upstream"
+  route_name: server_route
+  x-envoy-original-path: va lue
+  x-envoy-original-dst-host: va lue
+severity: INFO


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Per my experiments, Envoy hardens host and path already, so we sanitize the remaining headers.