### PR TITLE
envoy: http connection pool factory for metadata upstream extension

### DIFF
--- a/src/envoy/upstreams/http/metadata/BUILD
+++ b/src/envoy/upstreams/http/metadata/BUILD
@@ -25,6 +25,23 @@ load(
 envoy_package()
 
 envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":upstream_request_lib",
+        "@com_google_absl//absl/types:optional",
+        "@envoy//include/envoy/registry",
+        "@envoy//include/envoy/router:router_interface",
+        "@envoy//include/envoy/upstream:load_balancer_interface",
+        "@envoy//include/envoy/upstream:thread_local_cluster_interface",
+        "@envoy//source/common/protobuf",
+    ],
+)
+
+envoy_cc_library(
     name = "upstream_request_lib",
     srcs = ["upstream_request.cc"],
     hdrs = ["upstream_request.h"],
@@ -38,6 +55,21 @@ envoy_cc_library(
         "@envoy//include/envoy/upstream:load_balancer_interface",
         "@envoy//include/envoy/upstream:thread_local_cluster_interface",
         "@envoy//source/extensions/upstreams/http/http:upstream_request_lib",
+    ],
+)
+
+envoy_cc_test(
+    name = "integration_test",
+    srcs = ["integration_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":config",
+        "@envoy//include/envoy/network:address_interface",
+        "@envoy//source/common/http:codec_client_lib",
+        "@envoy//test/integration:http_integration_lib",
+        "@envoy//test/test_common:environment_lib",
+        "@envoy//test/test_common:registry_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
     ],
 )
 

--- a/src/envoy/upstreams/http/metadata/config.cc
+++ b/src/envoy/upstreams/http/metadata/config.cc
@@ -36,10 +36,7 @@ MetadataGenericConnPoolFactory::createGenericConnPool(
     const Router::RouteEntry& route_entry,
     absl::optional<Envoy::Http::Protocol> downstream_protocol,
     Upstream::LoadBalancerContext* ctx) const {
-  if (is_connect) {
-    // TODO(tbarrella)
-    return nullptr;
-  }
+  ASSERT(!is_connect);
   auto ret = std::make_unique<MetadataConnPool>(
       thread_local_cluster, is_connect, route_entry, downstream_protocol, ctx);
   return ret->valid() ? std::move(ret) : nullptr;

--- a/src/envoy/upstreams/http/metadata/config.cc
+++ b/src/envoy/upstreams/http/metadata/config.cc
@@ -1,0 +1,53 @@
+/* Copyright 2021 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/envoy/upstreams/http/metadata/config.h"
+
+#include <memory>
+
+#include "absl/types/optional.h"
+#include "envoy/http/protocol.h"
+#include "envoy/registry/registry.h"
+#include "envoy/router/router.h"
+#include "envoy/upstream/load_balancer.h"
+#include "envoy/upstream/thread_local_cluster.h"
+#include "src/envoy/upstreams/http/metadata/upstream_request.h"
+
+namespace Envoy {
+namespace Upstreams {
+namespace Http {
+namespace Metadata {
+
+Router::GenericConnPoolPtr
+MetadataGenericConnPoolFactory::createGenericConnPool(
+    Upstream::ThreadLocalCluster& thread_local_cluster, bool is_connect,
+    const Router::RouteEntry& route_entry,
+    absl::optional<Envoy::Http::Protocol> downstream_protocol,
+    Upstream::LoadBalancerContext* ctx) const {
+  if (is_connect) {
+    return nullptr;
+  }
+  auto ret = std::make_unique<MetadataConnPool>(
+      thread_local_cluster, is_connect, route_entry, downstream_protocol, ctx);
+  return ret->valid() ? std::move(ret) : nullptr;
+}
+
+REGISTER_FACTORY(MetadataGenericConnPoolFactory,
+                 Router::GenericConnPoolFactory);
+
+}  // namespace Metadata
+}  // namespace Http
+}  // namespace Upstreams
+}  // namespace Envoy

--- a/src/envoy/upstreams/http/metadata/config.cc
+++ b/src/envoy/upstreams/http/metadata/config.cc
@@ -37,6 +37,7 @@ MetadataGenericConnPoolFactory::createGenericConnPool(
     absl::optional<Envoy::Http::Protocol> downstream_protocol,
     Upstream::LoadBalancerContext* ctx) const {
   if (is_connect) {
+    // TODO(tbarrella)
     return nullptr;
   }
   auto ret = std::make_unique<MetadataConnPool>(

--- a/src/envoy/upstreams/http/metadata/config.h
+++ b/src/envoy/upstreams/http/metadata/config.h
@@ -32,7 +32,7 @@ namespace Metadata {
 
 /**
  * Config registration for the MetadataConnPool.
- * This extension is meant to be used to make only HTTP2 requests downstream.
+ * This extension is meant to be used to make only HTTP2 requests upstream.
  * Thus it does not support CONNECT and `is_connect` must be `false`.
  * @see Router::GenericConnPoolFactory
  */

--- a/src/envoy/upstreams/http/metadata/config.h
+++ b/src/envoy/upstreams/http/metadata/config.h
@@ -1,0 +1,60 @@
+/* Copyright 2021 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "absl/types/optional.h"
+#include "common/protobuf/protobuf.h"
+#include "envoy/http/protocol.h"
+#include "envoy/registry/registry.h"
+#include "envoy/router/router.h"
+#include "envoy/upstream/load_balancer.h"
+#include "envoy/upstream/thread_local_cluster.h"
+
+namespace Envoy {
+namespace Upstreams {
+namespace Http {
+namespace Metadata {
+
+/**
+ * Config registration for the MetadataConnPool.
+ * @see Router::GenericConnPoolFactory
+ */
+class MetadataGenericConnPoolFactory : public Router::GenericConnPoolFactory {
+ public:
+  std::string name() const override {
+    return "istio.filters.connection_pools.http.metadata";
+  }
+  std::string category() const override { return "istio.upstreams"; }
+
+  Router::GenericConnPoolPtr createGenericConnPool(
+      Upstream::ThreadLocalCluster& thread_local_cluster, bool is_connect,
+      const Router::RouteEntry& route_entry,
+      absl::optional<Envoy::Http::Protocol> downstream_protocol,
+      Upstream::LoadBalancerContext* ctx) const override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<ProtobufWkt::Struct>();
+  }
+};
+
+DECLARE_FACTORY(MetadataGenericConnPoolFactory);
+
+}  // namespace Metadata
+}  // namespace Http
+}  // namespace Upstreams
+}  // namespace Envoy

--- a/src/envoy/upstreams/http/metadata/config.h
+++ b/src/envoy/upstreams/http/metadata/config.h
@@ -39,7 +39,7 @@ class MetadataGenericConnPoolFactory : public Router::GenericConnPoolFactory {
   std::string name() const override {
     return "istio.filters.connection_pools.http.metadata";
   }
-  std::string category() const override { return "istio.upstreams"; }
+  std::string category() const override { return "envoy.upstreams"; }
 
   Router::GenericConnPoolPtr createGenericConnPool(
       Upstream::ThreadLocalCluster& thread_local_cluster, bool is_connect,

--- a/src/envoy/upstreams/http/metadata/config.h
+++ b/src/envoy/upstreams/http/metadata/config.h
@@ -32,6 +32,8 @@ namespace Metadata {
 
 /**
  * Config registration for the MetadataConnPool.
+ * This extension is meant to be used to make only HTTP2 requests downstream.
+ * Thus it does not support CONNECT and `is_connect` must be `false`.
  * @see Router::GenericConnPoolFactory
  */
 class MetadataGenericConnPoolFactory : public Router::GenericConnPoolFactory {

--- a/src/envoy/upstreams/http/metadata/integration_test.cc
+++ b/src/envoy/upstreams/http/metadata/integration_test.cc
@@ -1,0 +1,74 @@
+/* Copyright 2021 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/http/codec_client.h"
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/network/address.h"
+#include "envoy/router/router.h"
+#include "gtest/gtest.h"
+#include "src/envoy/upstreams/http/metadata/config.h"
+#include "test/integration/http_integration.h"
+#include "test/test_common/environment.h"
+#include "test/test_common/registry.h"
+#include "test/test_common/utility.h"
+
+namespace Envoy {
+namespace {
+
+class MetadataIntegrationTest
+    : public testing::TestWithParam<Network::Address::IpVersion>,
+      public HttpIntegrationTest {
+ public:
+  MetadataIntegrationTest()
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {}
+
+  void initialize() override {
+    config_helper_.addConfigModifier(
+        [](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+          auto* cluster =
+              bootstrap.mutable_static_resources()->mutable_clusters(0);
+          cluster->mutable_upstream_config()->set_name(
+              "istio.filters.connection_pools.http.metadata");
+          cluster->mutable_upstream_config()->mutable_typed_config();
+        });
+    HttpIntegrationTest::initialize();
+  }
+
+  Upstreams::Http::Metadata::MetadataGenericConnPoolFactory factory_;
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    IpVersions, MetadataIntegrationTest,
+    testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+    TestUtility::ipTestParamsToString);
+
+TEST_P(MetadataIntegrationTest, Basic) {
+  initialize();
+  Registry::InjectFactory<Router::GenericConnPoolFactory> registration(
+      factory_);
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = sendRequestAndWaitForResponse(
+      default_request_headers_, 0,
+      Http::TestResponseHeaderMapImpl{{":status", "200"}}, 0);
+  EXPECT_TRUE(upstream_request_->complete());
+
+  ASSERT_TRUE(response->waitForEndStream());
+  ASSERT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+}
+
+}  // namespace
+}  // namespace Envoy


### PR DESCRIPTION
**What this PR does / why we need it**: Next step for istio/istio#31444

**Special notes for your reviewer**: Basic structure/testing before implementing the metadata -> headers mapping. See https://github.com/envoyproxy/envoy/blob/v1.18.0/test/integration/upstreams/per_host_upstream_config.h and https://github.com/envoyproxy/envoy/blob/v1.18.0/test/integration/cluster_upstream_extension_integration_test.cc