### PR TITLE
Fix stackdriver requestUrl mapping

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -380,7 +380,7 @@ const ::Wasm::Common::FlatNode& PeerNodeInfo::get() const {
 void populateHTTPRequestInfo(bool outbound, bool use_host_header_fallback,
                              RequestInfo* request_info) {
   populateRequestProtocol(request_info);
-  getValue({"request", "url_path"}, &request_info->request_url_path);
+  getValue({"request", "url_path"}, &request_info->url_path);
   populateRequestInfo(outbound, use_host_header_fallback, request_info);
 
   int64_t response_code = 0;
@@ -446,7 +446,7 @@ void populateExtendedHTTPRequestInfo(RequestInfo* request_info) {
     request_info->b3_trace_sampled = true;
   }
 
-  getValue({"request", "url_path"}, &request_info->url_path);
+  getValue({"request", "path"}, &request_info->path);
   getValue({"request", "host"}, &request_info->url_host);
   getValue({"request", "scheme"}, &request_info->url_scheme);
   std::string response_details;

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -138,9 +138,6 @@ struct RequestInfo {
   // Operation of the request, i.e. HTTP method or gRPC API method.
   std::string request_operation;
 
-  // The path portion of the URL without the query string.
-  std::string request_url_path;
-
   std::string upstream_transport_failure_reason;
 
   // Service authentication policy (NONE, MUTUAL_TLS)
@@ -178,6 +175,9 @@ struct RequestInfo {
   bool b3_trace_sampled = false;
 
   // HTTP URL related attributes.
+  // The path portion of the URL including the query string.
+  std::string path;
+  // The path portion of the URL without the query string.
   std::string url_path;
   std::string url_host;
   std::string url_scheme;

--- a/extensions/stackdriver/log/logger.cc
+++ b/extensions/stackdriver/log/logger.cc
@@ -491,7 +491,7 @@ void Logger::fillHTTPRequestInLogEntry(
   auto http_request = log_entry->mutable_http_request();
   http_request->set_request_method(request_info.request_operation);
   http_request->set_request_url(request_info.url_scheme + "://" +
-                                request_info.url_host + request_info.url_path);
+                                request_info.url_host + request_info.path);
   http_request->set_request_size(request_info.request_size);
   http_request->set_status(request_info.response_code);
   http_request->set_response_size(request_info.response_size);

--- a/extensions/stackdriver/log/logger_test.cc
+++ b/extensions/stackdriver/log/logger_test.cc
@@ -116,6 +116,7 @@ const ::Wasm::Common::FlatNode& peerNodeInfo(
   request_info.url_scheme = "http";
   request_info.url_host = "httpbin.org";
   request_info.url_path = "/headers";
+  request_info.path = "/headers?retry=true";
   request_info.request_id = "123";
   request_info.b3_trace_id = "123abc";
   request_info.b3_span_id = "abc123";
@@ -155,7 +156,7 @@ std::string write_audit_request_json = R"({
      {
         "httpRequest":{
            "requestMethod":"GET",
-           "requestUrl":"http://httpbin.org/headers",
+           "requestUrl":"http://httpbin.org/headers?retry=true",
            "userAgent":"chrome",
            "remoteIp":"1.1.1.1",
            "referer":"www.google.com",
@@ -204,7 +205,7 @@ std::string write_log_request_json = R"({
      {
         "httpRequest":{
            "requestMethod":"GET",
-           "requestUrl":"http://httpbin.org/headers",
+           "requestUrl":"http://httpbin.org/headers?retry=true",
            "userAgent":"chrome",
            "remoteIp":"1.1.1.1",
            "referer":"www.google.com",

--- a/extensions/stackdriver/metric/record.cc
+++ b/extensions/stackdriver/metric/record.cc
@@ -232,7 +232,7 @@ void addHttpSpecificTags(const ::Wasm::Common::RequestInfo& request_info,
                          TagKeyValueList& tag_map) {
   const auto& operation =
       request_info.request_protocol == ::Wasm::Common::Protocol::GRPC
-          ? request_info.request_url_path
+          ? request_info.url_path
           : request_info.request_operation;
   tag_map.emplace_back(Metric::requestOperationKey(), operation);
 


### PR DESCRIPTION
[Cloud Loggin.LogEntry#HttpRequest](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) specifies that `requestUrl` should be `The scheme (http, https), the host name, the path and the query portion of the URL that was requested` 

The current version did not include the query string.

Note: Also removed `request_url_path` which was duplicated in `url_path`
