### PR TITLE
envoy: add port header with metadata upstream extension

### DIFF
--- a/src/envoy/upstreams/http/metadata/BUILD
+++ b/src/envoy/upstreams/http/metadata/BUILD
@@ -37,7 +37,6 @@ envoy_cc_library(
         "@envoy//include/envoy/router:router_interface",
         "@envoy//include/envoy/upstream:load_balancer_interface",
         "@envoy//include/envoy/upstream:thread_local_cluster_interface",
-        "@envoy//source/common/protobuf",
     ],
 )
 
@@ -47,14 +46,20 @@ envoy_cc_library(
     hdrs = ["upstream_request.h"],
     repository = "@envoy",
     deps = [
+        "@com_google_absl//absl/strings",
         "@com_google_absl//absl/types:optional",
         "@envoy//include/envoy/http:codec_interface",
+        "@envoy//include/envoy/http:header_map_interface",
         "@envoy//include/envoy/router:router_interface",
         "@envoy//include/envoy/stream_info:stream_info_interface",
         "@envoy//include/envoy/upstream:host_description_interface",
         "@envoy//include/envoy/upstream:load_balancer_interface",
         "@envoy//include/envoy/upstream:thread_local_cluster_interface",
+        "@envoy//source/common/http:header_map_lib",
+        "@envoy//source/common/http:status_lib",
+        "@envoy//source/common/protobuf",
         "@envoy//source/extensions/upstreams/http/http:upstream_request_lib",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 
@@ -80,8 +85,10 @@ envoy_cc_test(
     deps = [
         ":upstream_request_lib",
         "@envoy//test/common/http:common_lib",
-        "@envoy//test/mocks/http:stream_encoder_mock",
+        "@envoy//test/mocks/http:http_mocks",
         "@envoy//test/mocks/router:router_mocks",
+        "@envoy//test/mocks/upstream:cluster_info_mocks",
+        "@envoy//test/mocks/upstream:host_mocks",
         "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/src/envoy/upstreams/http/metadata/upstream_request.cc
+++ b/src/envoy/upstreams/http/metadata/upstream_request.cc
@@ -36,7 +36,7 @@ void MetadataConnPool::onPoolReady(
     absl::optional<Envoy::Http::Protocol> protocol) {
   conn_pool_stream_handle_ = nullptr;
   auto upstream = std::make_unique<MetadataUpstream>(
-      callbacks_->upstreamToDownstream(), &request_encoder);
+      callbacks_->upstreamToDownstream(), &request_encoder, host);
   callbacks_->onPoolReady(std::move(upstream), host,
                           request_encoder.getStream().connectionLocalAddress(),
                           info, protocol);

--- a/src/envoy/upstreams/http/metadata/upstream_request.h
+++ b/src/envoy/upstreams/http/metadata/upstream_request.h
@@ -15,8 +15,14 @@
 
 #pragma once
 
+#include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/status.h"
+#include "common/protobuf/protobuf.h"
+#include "envoy/config/core/v3/base.pb.h"
 #include "envoy/http/codec.h"
+#include "envoy/http/header_map.h"
 #include "envoy/http/protocol.h"
 #include "envoy/router/router.h"
 #include "envoy/stream_info/stream_info.h"
@@ -29,6 +35,31 @@ namespace Envoy {
 namespace Upstreams {
 namespace Http {
 namespace Metadata {
+
+namespace {
+
+const std::string kIstioMetadataKey = "istio";
+const std::string kOriginalPortHeader = "x-istio-original-port";
+const std::string kOriginalPortKey = "default_original_port";
+
+void addHeader(Envoy::Http::RequestHeaderMap& headers,
+               absl::string_view header_name,
+               const envoy::config::core::v3::Metadata& metadata,
+               absl::string_view key) {
+  Envoy::Http::LowerCaseString header((std::string(header_name)));
+  headers.remove(header);
+  if (auto filter_metadata = metadata.filter_metadata().find(kIstioMetadataKey);
+      filter_metadata != metadata.filter_metadata().end()) {
+    const ProtobufWkt::Struct& data = filter_metadata->second;
+    const auto& fields = data.fields();
+    if (auto iter = fields.find(key); iter != fields.end()) {
+      if (iter->second.kind_case() == ProtobufWkt::Value::kStringValue) {
+        headers.setCopy(header, iter->second.string_value());
+      }
+    }
+  }
+}
+}  // namespace
 
 class MetadataConnPool
     : public Extensions::Upstreams::Http::Http::HttpConnPool {
@@ -50,8 +81,21 @@ class MetadataUpstream
     : public Extensions::Upstreams::Http::Http::HttpUpstream {
  public:
   MetadataUpstream(Router::UpstreamToDownstream& upstream_request,
-                   Envoy::Http::RequestEncoder* encoder)
-      : HttpUpstream(upstream_request, encoder) {}
+                   Envoy::Http::RequestEncoder* encoder,
+                   Upstream::HostDescriptionConstSharedPtr host)
+      : HttpUpstream(upstream_request, encoder), host_(host) {}
+
+  Envoy::Http::Status encodeHeaders(
+      const Envoy::Http::RequestHeaderMap& headers, bool end_stream) override {
+    auto dup = Envoy::Http::RequestHeaderMapImpl::create();
+    Envoy::Http::HeaderMapImpl::copyFrom(*dup, headers);
+    addHeader(*dup, kOriginalPortHeader, host_->cluster().metadata(),
+              kOriginalPortKey);
+    return HttpUpstream::encodeHeaders(*dup, end_stream);
+  }
+
+ private:
+  Upstream::HostDescriptionConstSharedPtr host_;
 };
 
 }  // namespace Metadata

--- a/src/envoy/upstreams/http/metadata/upstream_request_test.cc
+++ b/src/envoy/upstreams/http/metadata/upstream_request_test.cc
@@ -17,12 +17,19 @@
 
 #include <memory>
 
+#include "envoy/config/core/v3/base.pb.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "test/common/http/common.h"
+#include "test/mocks/http/mocks.h"
 #include "test/mocks/http/stream_encoder.h"
 #include "test/mocks/router/mocks.h"
+#include "test/mocks/upstream/cluster_info.h"
+#include "test/mocks/upstream/host.h"
 #include "test/test_common/utility.h"
+
+using testing::NiceMock;
+using testing::ReturnRef;
 
 namespace Envoy {
 namespace Upstreams {
@@ -30,16 +37,44 @@ namespace Http {
 namespace Metadata {
 
 class MetadataUpstreamTest : public ::testing::Test {
+ public:
+  MetadataUpstreamTest() {
+    cluster_metadata_ = std::make_shared<envoy::config::core::v3::Metadata>(
+        TestUtility::parseYaml<envoy::config::core::v3::Metadata>(
+            R"EOF(
+            filter_metadata:
+              istio:
+                default_original_port: "8080"
+            )EOF"));
+  }
+
  protected:
   Router::MockUpstreamToDownstream upstream_to_downstream_;
-  ::testing::NiceMock<Envoy::Http::MockRequestEncoder> encoder_;
+  NiceMock<Envoy::Http::MockRequestEncoder> encoder_;
+  std::shared_ptr<Upstream::MockHost> host_{new NiceMock<Upstream::MockHost>()};
+  std::shared_ptr<Upstream::MockClusterInfo> info_{
+      new NiceMock<Upstream::MockClusterInfo>()};
+  std::shared_ptr<envoy::config::core::v3::Metadata> cluster_metadata_;
 };
 
 TEST_F(MetadataUpstreamTest, Basic) {
   Envoy::Http::TestRequestHeaderMapImpl headers;
   HttpTestUtility::addDefaultHeaders(headers);
-  auto upstream =
-      std::make_unique<MetadataUpstream>(upstream_to_downstream_, &encoder_);
+  auto upstream = std::make_unique<MetadataUpstream>(upstream_to_downstream_,
+                                                     &encoder_, host_);
+  EXPECT_TRUE(upstream->encodeHeaders(headers, false).ok());
+}
+
+TEST_F(MetadataUpstreamTest, TestAddClusterInfo) {
+  ON_CALL(*host_, cluster()).WillByDefault(ReturnRef(*info_));
+  ON_CALL(*info_, metadata()).WillByDefault(ReturnRef(*cluster_metadata_));
+  auto upstream = std::make_unique<MetadataUpstream>(upstream_to_downstream_,
+                                                     &encoder_, host_);
+  Envoy::Http::TestRequestHeaderMapImpl headers;
+  HttpTestUtility::addDefaultHeaders(headers);
+  EXPECT_CALL(
+      encoder_,
+      encodeHeaders(HeaderHasValueRef("x-istio-original-port", "8080"), false));
   EXPECT_TRUE(upstream->encodeHeaders(headers, false).ok());
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Next step for istio/istio#31444

**Special notes for your reviewer**: Minimal functionality for using HBONE for HTTP requests. Using x-istio-original-port instead of :authority to defer needing to convert :authority and x-forwarded-host at the server proxy