### PR TITLE
Add explicit build dependency for authenticator extension

### DIFF
--- a/src/envoy/http/authn/BUILD
+++ b/src/envoy/http/authn/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//src/envoy/utils:utils_lib",
         "//src/istio/authn:context_proto_cc_proto",
         "@envoy//source/common/http:headers_lib",
+        "@envoy//source/extensions/filters/http:well_known_names",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: bazel build is failing without explicit build dep

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
