### PR TITLE
Update the upstream envoy version as well as to fix some breakage.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,10 +38,10 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # Note: this is needed by release builder to resolve envoy dep sha to tag.
-# Commit date: 2021-06-18
-ENVOY_SHA = "c7c53b675c5a1337964403d91a2575c18075173c"
+# Commit date: 2021-07-07
+ENVOY_SHA = "ea9ef5f8bcb5544913b6a79484944a677629a3a8"
 
-ENVOY_SHA256 = "d5fe518e092a6466657102c75fb0b4717f7614ba812ab9b2b332c367cc6a4ca0"
+ENVOY_SHA256 = "cab97a3b0531d5e0e88ae399b394ae5f66ad1408ea96f5cae08994e18ce77dbc"
 
 ENVOY_ORG = "envoyproxy"
 

--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -10,6 +10,9 @@
 # Startup options cannot be selected via config.
 startup --host_jvm_args=-Xmx2g
 
+run --color=yes
+
+build --color=yes
 build --workspace_status_command="bash bazel/get_workspace_status"
 build --experimental_strict_action_env=true
 build --host_force_python=PY3

--- a/extensions/attributegen/plugin_test.cc
+++ b/extensions/attributegen/plugin_test.cc
@@ -64,9 +64,9 @@ using WasmFilterConfig = envoy::extensions::filters::http::wasm::v3::Wasm;
 class TestFilter : public Envoy::Extensions::Common::Wasm::Context {
  public:
   TestFilter(Wasm* wasm, uint32_t root_context_id,
-             Envoy::Extensions::Common::Wasm::PluginSharedPtr plugin)
+             Envoy::Extensions::Common::Wasm::PluginHandleSharedPtr plugin_handle)
       : Envoy::Extensions::Common::Wasm::Context(wasm, root_context_id,
-                                                 plugin) {}
+                                                 plugin_handle) {}
   void log(const Http::RequestHeaderMap* request_headers,
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
@@ -197,7 +197,7 @@ class WasmHttpFilterTest : public testing::TestWithParam<TestParams> {
             *root_context = new TestRoot(wasm, plugin);
             return *root_context;
           });
-      wasm_ = plugin_handle_->wasmHandleForTest();
+      wasm_ = plugin_handle_->wasmHandle();
     }
     if (!c.do_not_add_filter) {
       setupFilter();
@@ -207,7 +207,7 @@ class WasmHttpFilterTest : public testing::TestWithParam<TestParams> {
   void setupFilter() {
     auto wasm = wasm_ ? wasm_->wasm().get() : nullptr;
     int root_context_id = wasm ? wasm->getRootContext(plugin_, false)->id() : 0;
-    filter_ = std::make_unique<TestFilter>(wasm, root_context_id, plugin_);
+    filter_ = std::make_unique<TestFilter>(wasm, root_context_id, plugin_handle_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
 

--- a/src/envoy/extensions/wasm/context.h
+++ b/src/envoy/extensions/wasm/context.h
@@ -27,8 +27,8 @@ class IstioContext : public Context {
   IstioContext(Wasm* wasm, const PluginSharedPtr& plugin)
       : Context(wasm, plugin) {}
   IstioContext(Wasm* wasm, uint32_t root_context_id,
-               const PluginSharedPtr& plugin)
-      : Context(wasm, root_context_id, plugin) {}
+          PluginHandleSharedPtr plugin_handle): Context(
+              wasm, root_context_id, plugin_handle) {}
   ~IstioContext() = default;
 };
 }  // namespace Istio


### PR DESCRIPTION
https://github.com/istio/istio/issues/33809

https://github.com/envoyproxy/envoy/pull/16795/files updated the constructor so we need to refactor internal usage of the context constructor accordingly.
