### PR TITLE
Added option to disable following http redirects within the e2e envoy driver

### DIFF
--- a/test/envoye2e/driver/check.go
+++ b/test/envoye2e/driver/check.go
@@ -47,6 +47,8 @@ type HTTPCall struct {
 	ResponseHeaders map[string]string
 	// Timeout (must be set to avoid the default)
 	Timeout time.Duration
+	// DisableRedirect prevents the client from following redirects and returns the original response.
+	DisableRedirect bool
 }
 
 func Get(port uint16, body string) Step {
@@ -73,6 +75,11 @@ func (g *HTTPCall) Run(_ *Params) error {
 	log.Printf("HTTP request:\n%s", string(dump))
 
 	client := &http.Client{Timeout: g.Timeout}
+	if g.DisableRedirect {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
The current implementation of the e2e envoy driver is to automatically follow redirects. This prevents testing for redirect responses (301, 302). This PR adds the options to disable following redirects and to return the original response. The default value is false and will continue to follow redirects.
