### PR TITLE
clear route cache after JWT validation

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -104,8 +104,8 @@ cc_library(
 # 1) find the ISTIO_API SHA you want in git
 # 2) wget https://github.com/istio/api/archive/$ISTIO_API_SHA.tar.gz && sha256sum $ISTIO_API_SHA.tar.gz
 #
-ISTIO_API = "31d048906d97fb7f6b1fa8e250d3fa07456c5acc"
-ISTIO_API_SHA256 = "5bf68ef13f4b9e769b7ca0a9ce83d9da5263eed9b1223c4cbb388a6ad5520e01"
+ISTIO_API = "75bb24b620144218d26b92afedbb428e4d84e506"
+ISTIO_API_SHA256 = "c72602c38f7ab10e430618e4ce82fee143f4446d468863ba153ea897bdff2298"
 
 def istioapi_repositories(bind = True):
     BUILD = """

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -86,6 +86,9 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(
     decoder_callbacks_->streamInfo().setDynamicMetadata(
         Utils::IstioFilterName::kAuthentication, data);
     ENVOY_LOG(debug, "Saved Dynamic Metadata:\n{}", data.DebugString());
+    // Clear the route cache after saving the dynamic metadata for routing
+    // based on JWT claims.
+    decoder_callbacks_->clearRouteCache();
   }
   state_ = State::COMPLETE;
   return FilterHeadersStatus::Continue;

--- a/src/envoy/http/authn/http_filter.cc
+++ b/src/envoy/http/authn/http_filter.cc
@@ -86,9 +86,12 @@ FilterHeadersStatus AuthenticationFilter::decodeHeaders(
     decoder_callbacks_->streamInfo().setDynamicMetadata(
         Utils::IstioFilterName::kAuthentication, data);
     ENVOY_LOG(debug, "Saved Dynamic Metadata:\n{}", data.DebugString());
-    // Clear the route cache after saving the dynamic metadata for routing
-    // based on JWT claims.
-    decoder_callbacks_->clearRouteCache();
+    if (!filter_config_.disable_clear_route_cache()) {
+      // Clear the route cache after saving the dynamic metadata for routing
+      // based on JWT claims.
+      decoder_callbacks_->clearRouteCache();
+      ENVOY_LOG(debug, "Istio authn filter cleared route cache.");
+    }
   }
   state_ = State::COMPLETE;
   return FilterHeadersStatus::Continue;


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed for the JWT claim based routing.

The validated JWT claims are stored in the dynamic metadata and later used for routing, we need to clear the route cache after the JWT validation as it may change the route result.

Tested manually and will add full e2e test in Istio repo.

Approved design doc: https://docs.google.com/document/d/1s8Lykf8-KUZTLiG4YMSCHvxBDwZzHlrrHyZ7cJymc_8/edit#


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
