### PR TITLE
build: Run v8://build only when required

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -131,7 +131,7 @@ test:
 
 test_asan:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_DEV)) && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_ASAN)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) //src/envoy:envoy
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) -- $(BAZEL_TEST_TARGETS)
 	env ENVOY_PATH=$(BAZEL_ENVOY_PATH) ASAN=true GO111MODULE=on go test -timeout 30m ./...
@@ -145,7 +145,7 @@ test_tsan:
 
 test_centos:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	$(call prerun_v8_build_if_required,$(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_TSAN)) && \
+	$(call prerun_v8_build_if_required,$(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_DEV)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_DEV) //src/envoy:envoy
 	# TODO: re-enable IPv6 tests
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_DEV) --test_filter="-*IPv6*" -- $(CENTOS_BAZEL_TEST_TARGETS)

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -69,12 +69,11 @@ CENTOS_BUILD_ARGS ?= --cxxopt -D_GLIBCXX_USE_CXX11_ABI=1 --cxxopt -DENVOY_IGNORE
 # TODO can we do some sort of regex?
 CENTOS_BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS} -tools/deb/... -tools/docker/... -extensions:stats.wasm -extensions:metadata_exchange.wasm -extensions:attributegen.wasm
 
-# Prerun @com_googlesource_chromium_v8//:build if and only if BAZEL_TARGETS depends on v8.
 define prerun_v8_build
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) ${1} @com_googlesource_chromium_v8//:build
 endef
 
-# When @com_googlesource_chromium_v8 is found in BAZEL_TARGETS dependencies, run prerun_v8_build.
+# Prerun @com_googlesource_chromium_v8//:build if and only if BAZEL_TARGETS depends on v8.
 define prerun_v8_build_if_required
 	$(if $(findstring com_googlesource_chromium_v8,$(shell bazel query "deps($(BAZEL_TARGETS))")),$(call prerun_v8_build,${1}))
 endef

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -69,25 +69,34 @@ CENTOS_BUILD_ARGS ?= --cxxopt -D_GLIBCXX_USE_CXX11_ABI=1 --cxxopt -DENVOY_IGNORE
 # TODO can we do some sort of regex?
 CENTOS_BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS} -tools/deb/... -tools/docker/... -extensions:stats.wasm -extensions:metadata_exchange.wasm -extensions:attributegen.wasm
 
+# Prerun @com_googlesource_chromium_v8//:build if and only if BAZEL_TARGETS depends on v8.
+define prerun_v8_build
+	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) ${1} @com_googlesource_chromium_v8//:build
+endef
+
+# When @com_googlesource_chromium_v8 is found in BAZEL_TARGETS dependencies, run prerun_v8_build.
+define prerun_v8_build_if_required
+	$(if $(findstring com_googlesource_chromium_v8,$(shell bazel query "deps($(BAZEL_TARGETS))")),$(call prerun_v8_build,${1}))
+endef
+
 build:
-	#TODO(lambdai): Prerun v8//:build if and only if BAZEL_TARGETS depends on v8.
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_DEV)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) $(BAZEL_TARGETS)
 
 build_envoy:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_REL) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_REL)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_REL) //src/envoy:envoy
 
 build_envoy_tsan:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_TSAN)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) //src/envoy:envoy
 
 build_envoy_asan:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_ASAN)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) //src/envoy:envoy
 
 build_wasm:
@@ -115,28 +124,28 @@ gen-check:
 
 test:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_DEV)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) //src/envoy:envoy
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_DEV) -- $(BAZEL_TEST_TARGETS)
 	env ENVOY_PATH=$(BAZEL_ENVOY_PATH) GO111MODULE=on go test -timeout 30m ./...
 
 test_asan:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_DEV)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) //src/envoy:envoy
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_ASAN) -- $(BAZEL_TEST_TARGETS)
 	env ENVOY_PATH=$(BAZEL_ENVOY_PATH) ASAN=true GO111MODULE=on go test -timeout 30m ./...
 
 test_tsan:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(BAZEL_CONFIG_TSAN)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) //src/envoy:envoy
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_TSAN) -- $(BAZEL_TEST_TARGETS)
 	env ENVOY_PATH=$(BAZEL_ENVOY_PATH) TSAN=true GO111MODULE=on go test -timeout 30m ./...
 
 test_centos:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && \
-	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_DEV) @com_googlesource_chromium_v8//:build && \
+	$(call prerun_v8_build_if_required,$(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_TSAN)) && \
 	bazel $(BAZEL_STARTUP_ARGS) build $(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_DEV) //src/envoy:envoy
 	# TODO: re-enable IPv6 tests
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS) $(BAZEL_CONFIG_DEV) --test_filter="-*IPv6*" -- $(CENTOS_BAZEL_TEST_TARGETS)


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the `prerun_v8_build_if_required` function to the Makefile for running `@com_googlesource_chromium_v8//:build` if and only if `BAZEL_TARGETS` has dependency to `com_googlesource_chromium_v8`.

**Which issue this PR fixes**: 

This fixes @lambdai's TODO here: https://github.com/istio/proxy/blob/7da4055593032e1ff7ea1b34ea5fc8003a0f2de1/Makefile.core.mk#L73

**Special notes for your reviewer**:

Not sure how to test this on CI. I tested it manually.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>