### PR TITLE
Allow skipping reporting of individual prometheus metrics

### DIFF
--- a/extensions/stats/config.proto
+++ b/extensions/stats/config.proto
@@ -46,9 +46,9 @@ message MetricConfig {
   // NOT IMPLEMENTED. (Optional) Conditional enabling the override.
   string match = 4;
 
-  // (Optional) If this is set to true, the metric(s) selected by this configuration
-  // will not be generated or reported.
-  bool skip_reporting = 5;
+  // (Optional) If this is set to true, the metric(s) selected by this
+  // configuration will not be generated or reported.
+  bool drop = 5;
 }
 
 enum MetricType {

--- a/extensions/stats/config.proto
+++ b/extensions/stats/config.proto
@@ -45,6 +45,10 @@ message MetricConfig {
 
   // NOT IMPLEMENTED. (Optional) Conditional enabling the override.
   string match = 4;
+
+  // (Optional) If this is set to true, the metric(s) selected by this configuration
+  // will not be generated or reported.
+  bool skip_reporting = 5;
 }
 
 enum MetricType {

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -356,7 +356,6 @@ bool PluginRootContext::initializeDimensions(const json& j) {
         std::sort(tags.begin(), tags.end());
 
         auto name = JsonGetField<std::string>(metric, "name").value_or("");
-        // for (const auto& factory_it : factories) {
         for (auto factory_it = factories.begin();
              factory_it != factories.end();) { /*do not advance iterator here*/
           if (!name.empty() && name != factory_it->first) {

--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -358,6 +358,14 @@ bool PluginRootContext::initializeDimensions(const json& j) {
           if (!name.empty() && name != factory_it.first) {
             continue;
           }
+
+          bool skip_reporting =
+              JsonGetField<bool>(metric, "skip_reporting").value_or(false);
+          if (skip_reporting) {
+            factories.erase(factory_it.first);
+            continue;
+          }
+
           auto& indexes = metric_indexes[factory_it.first];
 
           // Process tag deletions.

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -69,7 +69,9 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 				sd.Lock()
 				sd.tsReq = append(sd.tsReq, req)
 				for _, ts := range req.TimeSeries {
-					if strings.HasSuffix(ts.Metric.Type, "request_count") || strings.HasSuffix(ts.Metric.Type, "connection_open_count") || strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
+					if strings.HasSuffix(ts.Metric.Type, "request_count") ||
+						strings.HasSuffix(ts.Metric.Type, "connection_open_count") ||
+						strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
 						ts.Points[0].Interval = nil
 						sd.ts[proto.MarshalTextString(ts)] = struct{}{}

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -69,9 +69,7 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 				sd.Lock()
 				sd.tsReq = append(sd.tsReq, req)
 				for _, ts := range req.TimeSeries {
-					if strings.HasSuffix(ts.Metric.Type, "request_count") ||
-						strings.HasSuffix(ts.Metric.Type, "connection_open_count") ||
-						strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
+					if strings.HasSuffix(ts.Metric.Type, "request_count") || strings.HasSuffix(ts.Metric.Type, "connection_open_count") || strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
 						ts.Points[0].Interval = nil
 						sd.ts[proto.MarshalTextString(ts)] = struct{}{}

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -94,8 +94,9 @@ var TestCases = []struct {
 		ClientConfig: "testdata/stats/client_config_customized.yaml.tmpl",
 		ServerConfig: "testdata/stats/server_config.yaml",
 		ClientStats: map[string]driver.StatMatcher{
-			"istio_custom":         &driver.ExactStat{"testdata/metric/client_custom_metric.yaml.tmpl"},
-			"istio_requests_total": &driver.ExactStat{"testdata/metric/client_request_total_customized.yaml.tmpl"},
+			"istio_custom":                        &driver.ExactStat{"testdata/metric/client_custom_metric.yaml.tmpl"},
+			"istio_requests_total":                &driver.ExactStat{"testdata/metric/client_request_total_customized.yaml.tmpl"},
+			"istio_request_duration_milliseconds": &driver.MissingStat{"istio_request_duration_milliseconds"},
 		},
 		ServerStats: map[string]driver.StatMatcher{
 			"istio_requests_total": &driver.ExactStat{"testdata/metric/server_request_total.yaml.tmpl"},

--- a/testdata/stats/client_config_customized.yaml.tmpl
+++ b/testdata/stats/client_config_customized.yaml.tmpl
@@ -3,9 +3,6 @@ definitions:
 - name: requests_total
   value: "10"
   type: COUNTER
-- name: request_duration_milliseconds
-  value: "100"
-  type: COUNTER
 - name: custom
   value: "1"
   type: COUNTER

--- a/testdata/stats/client_config_customized.yaml.tmpl
+++ b/testdata/stats/client_config_customized.yaml.tmpl
@@ -3,10 +3,15 @@ definitions:
 - name: requests_total
   value: "10"
   type: COUNTER
+- name: request_duration_milliseconds
+  value: "100"
+  type: COUNTER
 - name: custom
   value: "1"
   type: COUNTER
 metrics:
+  - name: request_duration_milliseconds
+    skip_reporting: true
   - name: custom
     dimensions:
       reporter: "'proxy'"

--- a/testdata/stats/client_config_customized.yaml.tmpl
+++ b/testdata/stats/client_config_customized.yaml.tmpl
@@ -8,7 +8,7 @@ definitions:
   type: COUNTER
 metrics:
   - name: request_duration_milliseconds
-    skip_reporting: true
+    drop: true
   - name: custom
     dimensions:
       reporter: "'proxy'"


### PR DESCRIPTION
Adds the ability to remove reporting of an individual stat in the `stats` filter configuration.

This PR is meant to allow `stats` filter configuration to match the full capabilities exposed in the experimental Telemetry API. In particular, it allows matching of `Telemetry.metrics.overrides.disabled`.

It assumes the `MetricsConfig` will include a `name` field, as disabling all metrics can be achieved in the control plane by simply not sending any filter config.
