### PR TITLE
Add support for configurability of stackdriver metrics

### DIFF
--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -28,7 +28,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 
 // Custom instance configuration overrides.
-// Provides a way to customize metrics/logs.
+// Provides a way to customize logs.
 message CustomConfig {
   // (Optional) Collection of tag names and tag expressions to include in the
   // instance. Conflicts are resolved by the tag name by overriding previously
@@ -41,7 +41,7 @@ message CustomConfig {
   repeated string tags_to_remove = 2;
 }
 
-// next id: 15
+// next id: 17
 message PluginConfig {
   // Types of Access logs to export. Does not affect audit logging.
   enum AccessLogging {
@@ -113,7 +113,8 @@ message PluginConfig {
   // Optional. Allows disabling of reporting of the request and response size
   // metrics for HTTP traffic. Defaults to false (request and response size
   // metrics are enabled).
-  bool disable_http_size_metrics = 8;
+  // Deprecated -- use drop_metrics instead.
+  bool disable_http_size_metrics = 8 [deprecated = true];
 
   // Optional. Allows enabling log compression for stackdriver access logs.
   google.protobuf.BoolValue enable_log_compression = 9;
@@ -135,4 +136,21 @@ message PluginConfig {
   // series will never be expired. This option is useful to avoid unbounded
   // metric label explodes proxy memory.
   google.protobuf.Duration metric_expiry_duration = 15;
+
+  // Optional. Allows altering metrics behavior.
+  // Metric names for specifying overloads drop the `istio.io/service` prefix.
+  // Examples: `server/request_count`, `client/roundtrip_latencies`
+  map<string, MetricsOverride> metrics_overrides = 16;
+}
+
+// Provides behavior modifications for Cloud Monitoring metrics.
+message MetricsOverride {
+  // Optional. If true, no data for the associated metric will be collected or
+  // exported.
+  bool drop = 1;
+
+  // Optional. Maps tag names to value expressions that will be used at
+  // reporting time. If the tag name does not match a well-known tag for the
+  // istio Cloud Monitoring metrics, the configuration will have no effect.
+  map<string, string> tag_overrides = 2;
 }

--- a/extensions/stackdriver/metric/record.h
+++ b/extensions/stackdriver/metric/record.h
@@ -27,14 +27,18 @@ namespace Metric {
 void record(bool is_outbound, const ::Wasm::Common::FlatNode& local_node_info,
             const ::Wasm::Common::FlatNode& peer_node_info,
             const ::Wasm::Common::RequestInfo& request_info,
-            bool record_http_size_metrics);
+            bool record_http_size_metrics,
+            std::unordered_map<
+                std::string, std::vector<std::pair<std::string, std::string>>>);
 
 // Record TCP metrics based on local node info and request info.
 // Reporter kind deceides the type of metrics to record.
-void recordTCP(bool is_outbound,
-               const ::Wasm::Common::FlatNode& local_node_info,
-               const ::Wasm::Common::FlatNode& peer_node_info,
-               const ::Wasm::Common::RequestInfo& request_info);
+void recordTCP(
+    bool is_outbound, const ::Wasm::Common::FlatNode& local_node_info,
+    const ::Wasm::Common::FlatNode& peer_node_info,
+    const ::Wasm::Common::RequestInfo& request_info,
+    std::unordered_map<std::string,
+                       std::vector<std::pair<std::string, std::string>>>);
 
 }  // namespace Metric
 }  // namespace Stackdriver

--- a/extensions/stackdriver/metric/registry.cc
+++ b/extensions/stackdriver/metric/registry.cc
@@ -201,66 +201,86 @@ StackdriverOptions getStackdriverOptions(
 /*
  *  view function macros
  */
-#define REGISTER_COUNT_VIEW(_v)                              \
-  void register##_v##View(absl::Duration expiry_duration) {  \
-    const ViewDescriptor view_descriptor =                   \
-        ViewDescriptor()                                     \
-            .set_name(k##_v##View)                           \
-            .set_measure(k##_v##Measure)                     \
-            .set_expiry_duration(expiry_duration)            \
-            .set_aggregation(Aggregation::Count()) ADD_TAGS; \
-    View view(view_descriptor);                              \
-    view_descriptor.RegisterForExport();                     \
+#define REGISTER_COUNT_VIEW(_v)                                            \
+  void register##_v##View(absl::Duration expiry_duration,                  \
+                          std::vector<std::string_view> dropped_metrics) { \
+    auto iter = std::find(dropped_metrics.begin(), dropped_metrics.end(),  \
+                          k##_v##View);                                    \
+    if (iter != dropped_metrics.end()) return;                             \
+    const ViewDescriptor view_descriptor =                                 \
+        ViewDescriptor()                                                   \
+            .set_name(k##_v##View)                                         \
+            .set_measure(k##_v##Measure)                                   \
+            .set_expiry_duration(expiry_duration)                          \
+            .set_aggregation(Aggregation::Count()) ADD_TAGS;               \
+    View view(view_descriptor);                                            \
+    view_descriptor.RegisterForExport();                                   \
   }
 
-#define REGISTER_TCP_COUNT_VIEW(_v)                                 \
-  void register##_v##View(absl::Duration expiry_duration) {         \
-    const ViewDescriptor view_descriptor =                          \
-        ViewDescriptor()                                            \
-            .set_name(k##_v##View)                                  \
-            .set_measure(k##_v##Measure)                            \
-            .set_expiry_duration(expiry_duration)                   \
-            .set_aggregation(Aggregation::Count()) ADD_COMMON_TAGS; \
-    View view(view_descriptor);                                     \
-    view_descriptor.RegisterForExport();                            \
+#define REGISTER_TCP_COUNT_VIEW(_v)                                        \
+  void register##_v##View(absl::Duration expiry_duration,                  \
+                          std::vector<std::string_view> dropped_metrics) { \
+    auto iter = std::find(dropped_metrics.begin(), dropped_metrics.end(),  \
+                          k##_v##View);                                    \
+    if (iter != dropped_metrics.end()) return;                             \
+    const ViewDescriptor view_descriptor =                                 \
+        ViewDescriptor()                                                   \
+            .set_name(k##_v##View)                                         \
+            .set_measure(k##_v##Measure)                                   \
+            .set_expiry_duration(expiry_duration)                          \
+            .set_aggregation(Aggregation::Count()) ADD_COMMON_TAGS;        \
+    View view(view_descriptor);                                            \
+    view_descriptor.RegisterForExport();                                   \
   }
 
-#define REGISTER_TCP_SUM_VIEW(_v)                                 \
-  void register##_v##View(absl::Duration expiry_duration) {       \
-    const ViewDescriptor view_descriptor =                        \
-        ViewDescriptor()                                          \
-            .set_name(k##_v##View)                                \
-            .set_measure(k##_v##Measure)                          \
-            .set_expiry_duration(expiry_duration)                 \
-            .set_aggregation(Aggregation::Sum()) ADD_COMMON_TAGS; \
-    View view(view_descriptor);                                   \
-    view_descriptor.RegisterForExport();                          \
+#define REGISTER_TCP_SUM_VIEW(_v)                                          \
+  void register##_v##View(absl::Duration expiry_duration,                  \
+                          std::vector<std::string_view> dropped_metrics) { \
+    auto iter = std::find(dropped_metrics.begin(), dropped_metrics.end(),  \
+                          k##_v##View);                                    \
+    if (iter != dropped_metrics.end()) return;                             \
+    const ViewDescriptor view_descriptor =                                 \
+        ViewDescriptor()                                                   \
+            .set_name(k##_v##View)                                         \
+            .set_measure(k##_v##Measure)                                   \
+            .set_expiry_duration(expiry_duration)                          \
+            .set_aggregation(Aggregation::Sum()) ADD_COMMON_TAGS;          \
+    View view(view_descriptor);                                            \
+    view_descriptor.RegisterForExport();                                   \
   }
 
-#define REGISTER_DISTRIBUTION_VIEW(_v)                              \
-  void register##_v##View(absl::Duration expiry_duration) {         \
-    const ViewDescriptor view_descriptor =                          \
-        ViewDescriptor()                                            \
-            .set_name(k##_v##View)                                  \
-            .set_measure(k##_v##Measure)                            \
-            .set_expiry_duration(expiry_duration)                   \
-            .set_aggregation(Aggregation::Distribution(             \
-                BucketBoundaries::Exponential(20, 1, 2))) ADD_TAGS; \
-    View view(view_descriptor);                                     \
-    view_descriptor.RegisterForExport();                            \
+#define REGISTER_DISTRIBUTION_VIEW(_v)                                     \
+  void register##_v##View(absl::Duration expiry_duration,                  \
+                          std::vector<std::string_view> dropped_metrics) { \
+    auto iter = std::find(dropped_metrics.begin(), dropped_metrics.end(),  \
+                          k##_v##View);                                    \
+    if (iter != dropped_metrics.end()) return;                             \
+    const ViewDescriptor view_descriptor =                                 \
+        ViewDescriptor()                                                   \
+            .set_name(k##_v##View)                                         \
+            .set_measure(k##_v##Measure)                                   \
+            .set_expiry_duration(expiry_duration)                          \
+            .set_aggregation(Aggregation::Distribution(                    \
+                BucketBoundaries::Exponential(20, 1, 2))) ADD_TAGS;        \
+    View view(view_descriptor);                                            \
+    view_descriptor.RegisterForExport();                                   \
   }
 
-#define REGISTER_BYTES_DISTRIBUTION_VIEW(_v)                        \
-  void register##_v##View(absl::Duration expiry_duration) {         \
-    const ViewDescriptor view_descriptor =                          \
-        ViewDescriptor()                                            \
-            .set_name(k##_v##View)                                  \
-            .set_measure(k##_v##Measure)                            \
-            .set_expiry_duration(expiry_duration)                   \
-            .set_aggregation(Aggregation::Distribution(             \
-                BucketBoundaries::Exponential(7, 1, 10))) ADD_TAGS; \
-    View view(view_descriptor);                                     \
-    view_descriptor.RegisterForExport();                            \
+#define REGISTER_BYTES_DISTRIBUTION_VIEW(_v)                               \
+  void register##_v##View(absl::Duration expiry_duration,                  \
+                          std::vector<std::string_view> dropped_metrics) { \
+    auto iter = std::find(dropped_metrics.begin(), dropped_metrics.end(),  \
+                          k##_v##View);                                    \
+    if (iter != dropped_metrics.end()) return;                             \
+    const ViewDescriptor view_descriptor =                                 \
+        ViewDescriptor()                                                   \
+            .set_name(k##_v##View)                                         \
+            .set_measure(k##_v##Measure)                                   \
+            .set_expiry_duration(expiry_duration)                          \
+            .set_aggregation(Aggregation::Distribution(                    \
+                BucketBoundaries::Exponential(7, 1, 10))) ADD_TAGS;        \
+    View view(view_descriptor);                                            \
+    view_descriptor.RegisterForExport();                                   \
   }
 
 #define ADD_TAGS ADD_COMMON_TAGS ADD_HTTP_GRPC_TAGS
@@ -336,7 +356,8 @@ MEASURE_FUNC(clientConnectionsCloseCount, ClientConnectionsCloseCount, 1, Int64)
 MEASURE_FUNC(clientReceivedBytesCount, ClientReceivedBytesCount, By, Int64)
 MEASURE_FUNC(clientSentBytesCount, ClientSentBytesCount, By, Int64)
 
-void registerViews(absl::Duration expiry_duration) {
+void registerViews(absl::Duration expiry_duration,
+                   std::vector<std::string_view> dropped_metrics) {
   // Register measure first, which views depend on.
   serverRequestCountMeasure();
   serverRequestBytesMeasure();
@@ -356,22 +377,22 @@ void registerViews(absl::Duration expiry_duration) {
   clientSentBytesCountMeasure();
 
   // Register views to export;
-  registerServerRequestCountView(expiry_duration);
-  registerServerRequestBytesView(expiry_duration);
-  registerServerResponseBytesView(expiry_duration);
-  registerServerResponseLatenciesView(expiry_duration);
-  registerClientRequestCountView(expiry_duration);
-  registerClientRequestBytesView(expiry_duration);
-  registerClientResponseBytesView(expiry_duration);
-  registerClientRoundtripLatenciesView(expiry_duration);
-  registerServerConnectionsOpenCountView(expiry_duration);
-  registerServerConnectionsCloseCountView(expiry_duration);
-  registerServerReceivedBytesCountView(expiry_duration);
-  registerServerSentBytesCountView(expiry_duration);
-  registerClientConnectionsOpenCountView(expiry_duration);
-  registerClientConnectionsCloseCountView(expiry_duration);
-  registerClientReceivedBytesCountView(expiry_duration);
-  registerClientSentBytesCountView(expiry_duration);
+  registerServerRequestCountView(expiry_duration, dropped_metrics);
+  registerServerRequestBytesView(expiry_duration, dropped_metrics);
+  registerServerResponseBytesView(expiry_duration, dropped_metrics);
+  registerServerResponseLatenciesView(expiry_duration, dropped_metrics);
+  registerClientRequestCountView(expiry_duration, dropped_metrics);
+  registerClientRequestBytesView(expiry_duration, dropped_metrics);
+  registerClientResponseBytesView(expiry_duration, dropped_metrics);
+  registerClientRoundtripLatenciesView(expiry_duration, dropped_metrics);
+  registerServerConnectionsOpenCountView(expiry_duration, dropped_metrics);
+  registerServerConnectionsCloseCountView(expiry_duration, dropped_metrics);
+  registerServerReceivedBytesCountView(expiry_duration, dropped_metrics);
+  registerServerSentBytesCountView(expiry_duration, dropped_metrics);
+  registerClientConnectionsOpenCountView(expiry_duration, dropped_metrics);
+  registerClientConnectionsCloseCountView(expiry_duration, dropped_metrics);
+  registerClientReceivedBytesCountView(expiry_duration, dropped_metrics);
+  registerClientSentBytesCountView(expiry_duration, dropped_metrics);
 }
 
 /*

--- a/extensions/stackdriver/metric/registry.h
+++ b/extensions/stackdriver/metric/registry.h
@@ -39,7 +39,7 @@ opencensus::exporters::stats::StackdriverOptions getStackdriverOptions(
         stub_option);
 
 // registers Opencensus views
-void registerViews(absl::Duration);
+void registerViews(absl::Duration, std::vector<std::string_view>);
 
 // Opencensus tag key functions.
 opencensus::tags::TagKey requestOperationKey();

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -124,8 +124,18 @@ class StackdriverRootContext : public RootContext {
   void evaluateExpressions(
       std::unordered_map<std::string, std::string>& extra_labels);
 
+  // Evaluate Expressions in metrics_expressions_ vector, storing in
+  // tag_overrides.
+  void evaluateMetricsExpressions(
+      std::unordered_map<std::string,
+                         std::vector<std::pair<std::string, std::string>>>&
+          tag_overrides);
+
   // Cleanup expressions in expressions_ vector.
   void cleanupExpressions();
+
+  // Cleanup expressions in metrics_expressions_ vector.
+  void cleanupMetricsExpressions();
 
   // Config for Stackdriver plugin.
   stackdriver::config::v1alpha1::PluginConfig config_;
@@ -161,6 +171,15 @@ class StackdriverRootContext : public RootContext {
     std::string expression;
   };
   std::vector<struct expressionInfo> expressions_;
+
+  // Stores expressions for evaluation for metrics.
+  struct metricsExpressionInfo {
+    uint32_t token;
+    std::string metric;
+    std::string tag;
+    std::string expression;
+  };
+  std::vector<struct metricsExpressionInfo> metrics_expressions_;
 };
 
 // StackdriverContext is per stream context. It has the same lifetime as

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -71,6 +71,7 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 				for _, ts := range req.TimeSeries {
 					if strings.HasSuffix(ts.Metric.Type, "request_count") ||
 						strings.HasSuffix(ts.Metric.Type, "connection_open_count") ||
+						strings.HasSuffix(ts.Metric.Type, "request_bytes") ||
 						strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
 						ts.Points[0].Interval = nil

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -217,6 +217,10 @@ func TestStackdriverReload(t *testing.T) {
 	params.Vars["STSPort"] = strconv.Itoa(int(stsPort))
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
+	params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/access_log_policy.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stackdriver_inbound.yaml.tmpl")
+	params.Vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/access_log_policy.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stackdriver_outbound.yaml.tmpl")
 	enableStackDriver(t, params.Vars)
 
 	sd := &Stackdriver{Port: sdPort}

--- a/testdata/filters/stackdriver_inbound.yaml.tmpl
+++ b/testdata/filters/stackdriver_inbound.yaml.tmpl
@@ -17,4 +17,4 @@
         configuration:
           "@type": "type.googleapis.com/google.protobuf.StringValue"
           value: |
-            {"enable_audit_log": true, "metric_expiry_duration": "10s"}
+            {"enable_audit_log": true, "metric_expiry_duration": "10s", "metrics_overrides": {"server/request_bytes":{"drop": true}, "server/connection_open_count":{"tag_overrides":{"mesh_uid":"'override'"}}}}

--- a/testdata/filters/stackdriver_network_inbound.yaml.tmpl
+++ b/testdata/filters/stackdriver_network_inbound.yaml.tmpl
@@ -17,4 +17,4 @@
         configuration:
           "@type": "type.googleapis.com/google.protobuf.StringValue"
           value: |
-            {}
+            {"metrics_overrides": {"server/request_bytes":{"drop": true}, "server/connection_open_count":{"tag_overrides":{"mesh_uid":"'override'"}}}}

--- a/testdata/filters/stackdriver_network_outbound.yaml.tmpl
+++ b/testdata/filters/stackdriver_network_outbound.yaml.tmpl
@@ -17,4 +17,4 @@
         configuration:
           "@type": "type.googleapis.com/google.protobuf.StringValue"
           value: |
-            {"access_logging": "FULL"}
+            {"access_logging": "FULL", "metrics_overrides": {"client/request_bytes":{"drop": true}, "client/request_count":{"tag_overrides":{"request_operation":"'override'"}}}}

--- a/testdata/filters/stackdriver_outbound.yaml.tmpl
+++ b/testdata/filters/stackdriver_outbound.yaml.tmpl
@@ -18,9 +18,9 @@
           "@type": "type.googleapis.com/google.protobuf.StringValue"
           value: |
             {{- if .Vars.JustSendErrorClientLog }}
-            {"access_logging": "ERRORS_ONLY", "enable_audit_log": true}
+            {"access_logging": "ERRORS_ONLY", "enable_audit_log": true, "metrics_overrides": {"client/request_bytes":{"drop": true}, "client/request_count":{"tag_overrides":{"request_operation":"'override'"}}}}
             {{- else if .Vars.StackdriverFilterCustomClientConfig }}
             {{ .Vars.StackdriverFilterCustomClientConfig | fill }}
             {{- else }}
-            {"access_logging": "FULL", "enable_audit_log": true}
+            {"access_logging": "FULL", "enable_audit_log": true, "metrics_overrides": {"client/request_bytes":{"drop": true}, "client/request_count":{"tag_overrides":{"request_operation":"'override'"}}}}
             {{- end }}

--- a/testdata/stackdriver/client_request_count.yaml.tmpl
+++ b/testdata/stackdriver/client_request_count.yaml.tmpl
@@ -15,7 +15,7 @@ metric:
     destination_workload_name: ratings-v1
     destination_workload_namespace: default
     mesh_uid: proj-123
-    request_operation: GET
+    request_operation: override
     request_protocol: http
     response_code: "200"
     service_authentication_policy: unknown # TODO: upstream TLS indicator is not reported

--- a/testdata/stackdriver/gce_client_request_count.yaml.tmpl
+++ b/testdata/stackdriver/gce_client_request_count.yaml.tmpl
@@ -15,7 +15,7 @@ metric:
     destination_workload_name: ratings-v1
     destination_workload_namespace: default
     mesh_uid: proj-123
-    request_operation: GET
+    request_operation: override
     request_protocol: http
     response_code: "200"
     service_authentication_policy: unknown # TODO: upstream TLS indicator is not reported

--- a/testdata/stackdriver/server_tcp_connection_count.yaml.tmpl
+++ b/testdata/stackdriver/server_tcp_connection_count.yaml.tmpl
@@ -14,7 +14,7 @@ metric:
     destination_service_namespace: default
     destination_workload_name: ratings-v1
     destination_workload_namespace: default
-    mesh_uid: proj-123
+    mesh_uid: override
     request_protocol: tcp
     service_authentication_policy: {{ .Vars.ServiceAuthenticationPolicy }}
     {{- if .Vars.SourceUnknown }}


### PR DESCRIPTION
This PR is an attempt to bring some configurability to the existing Stackdriver extension for monitoring. It is intended to bring Stackdriver to _near_ (ex: Stackdriver does not support adding new tags) feature-parity with the Telemetry API.

This adds two basic capabilities:
1. Dropping metrics
2. Overriding tag expressions

---
Work still left:

- [ ] Validate tags exist and are well-known before handling
- [ ] Clean-up comments, etc.