### PR TITLE
Export the cache to correct arch location

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -211,10 +211,10 @@ push_release_centos:
 
 # Used by build container to export the build output from the docker volume cache
 exportcache:
-	@mkdir -p /work/out/linux_amd64
-	@cp -a /work/bazel-bin/src/envoy/envoy /work/out/linux_amd64
-	@chmod +w /work/out/linux_amd64/envoy
-	@cp -a /work/bazel-bin/**/*wasm /work/out/linux_amd64 &> /dev/null || true
+	@mkdir -p /work/out/$(TARGET_OS)_$(TARGET_ARCH)
+	@cp -a /work/bazel-bin/src/envoy/envoy /work/out/$(TARGET_OS)_$(TARGET_ARCH)
+	@chmod +w /work/out/$(TARGET_OS)_$(TARGET_ARCH)/envoy
+	@cp -a /work/bazel-bin/**/*wasm /work/out/$(TARGET_OS)_$(TARGET_ARCH) &> /dev/null || true
 
 .PHONY: build clean test check artifacts extensions-proto
 


### PR DESCRIPTION
Now the exportcache action in the Makefile
only supports x86_64(amd64), so we add other archs support,
e.g., arm64, ppc64le, by a common variable in setup_env.sh.

Signed-off-by: trevor.tao <trevor.tao@arm.com>

**What this PR does / why we need it**:
For the Multi-arch support

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Multi-arch support for various platforms.

**Special notes for your reviewer**:
