### PR TITLE
contrib: enable all contrib extensions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,6 +78,10 @@ load("@envoy//bazel:repositories_extra.bzl", "envoy_dependencies_extra")
 
 envoy_dependencies_extra()
 
+load("@base_pip3//:requirements.bzl", "install_deps")
+
+install_deps()
+
 load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 
 envoy_dependency_imports()

--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -350,8 +350,18 @@ ISTIO_DISABLED_EXTENSIONS = [
     "envoy.transport_sockets.tcp_stats",
 ]
 
+# on istio 1.12 we enable all contrib extension for 0 migration pain.
 ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
+    "envoy.filters.http.squash",
+    "envoy.filters.http.sxg",
+    "envoy.filters.network.kafka_broker",
+    "envoy.filters.network.kafka_mesh",
     "envoy.filters.network.mysql_proxy",
+    "envoy.filters.network.postgres_proxy",
+    "envoy.filters.network.rocketmq_proxy",
+    "envoy.filters.network.sip_proxy",
+    "envoy.filters.sip.router",
+    "envoy.tls.key_providers.cryptomb",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +


### PR DESCRIPTION
Starting from envoy 1.20 the contrib extensions are built via allow list.

In istio 1.12 we build all known contrib extensions as was in istio 1.11.

Signed-off-by: Yuchen Dai <silentdai@gmail.com>
