### PR TITLE
Fix lint errors with updated hadolint version

### DIFF
--- a/tools/extensionserver/Dockerfile
+++ b/tools/extensionserver/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:buster
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
-ADD extensionserver /extensionserver
+COPY extensionserver /extensionserver
 RUN chmod a+x /extensionserver
 EXPOSE 8080
 CMD ["/extensionserver", "-c", "/etc/extensionserver/config"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix lint errors reported by newer hadolint. I do note that `make lint` in the proxy repo didn't report the lint errors, so not sure the repo actually lints Dockerfiles. Errors were found running the updated hadolint across most of the repos.
- Use COPY instead of ADD. There is't any tar file extraction required
- Delete the apt-get lists after installing something 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
