### PR TITLE
Add gen compilation database tool like envoy

### DIFF
--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+
+# This method is equivalent to https://github.com/grailbio/bazel-compilation-database/blob/master/generate.sh
+def generate_compilation_database(args):
+    # We need to download all remote outputs for generated source code. This option lives here to override those
+    # specified in bazelrc.
+    bazel_options = shlex.split(os.environ.get("BAZEL_BUILD_OPTIONS", "")) + [
+        "--config=compdb",
+        "--remote_download_outputs=all",
+    ]
+
+    subprocess.check_call(["bazel", "build"] + bazel_options + [
+        "--aspects=@bazel_compdb//:aspects.bzl%compilation_database_aspect",
+        "--output_groups=compdb_files,header_files"
+    ] + args.bazel_targets)
+
+    execroot = subprocess.check_output(["bazel", "info", "execution_root"]
+                                       + bazel_options).decode().strip()
+
+    compdb = []
+    for compdb_file in Path(execroot).glob("**/*.compile_commands.json"):
+        compdb.extend(
+            json.loads("[" + compdb_file.read_text().replace("__EXEC_ROOT__", execroot) + "]"))
+    return compdb
+
+
+def is_header(filename):
+    for ext in (".h", ".hh", ".hpp", ".hxx"):
+        if filename.endswith(ext):
+            return True
+    return False
+
+
+def is_compile_target(target, args):
+    filename = target["file"]
+    if not args.include_headers and is_header(filename):
+        return False
+
+    if not args.include_genfiles:
+        if filename.startswith("bazel-out/"):
+            return False
+
+    if not args.include_external:
+        if filename.startswith("external/"):
+            return False
+
+    return True
+
+
+def modify_compile_command(target, args):
+    cc, options = target["command"].split(" ", 1)
+
+    # Workaround for bazel added C++11 options, those doesn't affect build itself but
+    # clang-tidy will misinterpret them.
+    options = options.replace("-std=c++0x ", "")
+    options = options.replace("-std=c++11 ", "")
+
+    if args.vscode:
+        # Visual Studio Code doesn't seem to like "-iquote". Replace it with
+        # old-style "-I".
+        options = options.replace("-iquote ", "-I ")
+
+    if is_header(target["file"]):
+        options += " -Wno-pragma-once-outside-header -Wno-unused-const-variable"
+        options += " -Wno-unused-function"
+        # By treating external/envoy* as C++ files we are able to use this script from subrepos that
+        # depend on Envoy targets.
+        if not target["file"].startswith("external/") or target["file"].startswith(
+                "external/envoy"):
+            # *.h file is treated as C header by default while our headers files are all C++17.
+            options = "-x c++ -std=c++17 -fexceptions " + options
+
+    target["command"] = " ".join([cc, options])
+    return target
+
+
+def fix_compilation_database(args, db):
+    db = [modify_compile_command(target, args) for target in db if is_compile_target(target, args)]
+
+    with open("compile_commands.json", "w") as db_file:
+        json.dump(db, db_file, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Generate JSON compilation database')
+    parser.add_argument('--include_external', action='store_true')
+    parser.add_argument('--include_genfiles', action='store_true')
+    parser.add_argument('--include_headers', action='store_true')
+    parser.add_argument('--vscode', action='store_true')
+    parser.add_argument(
+        'bazel_targets',
+        nargs='*',
+        default=[
+            "//src/...",
+            "//extensions/...",
+            "//test/...",
+        ])
+    args = parser.parse_args()
+    fix_compilation_database(args, generate_compilation_database(args))

--- a/tools/gen_compilation_database.py
+++ b/tools/gen_compilation_database.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import json
 import os


### PR DESCRIPTION
**What this PR does / why we need it**:
This tool was added to make it easier for us to generate a compilation database for the project and to improve the efficiency of reading the code, this tool comes from envoy: https://github.com/envoyproxy/envoy/blob/main/tools/gen_compilation_database.py

**Special notes for your reviewer**:
Run `tools/gen_compilation_database.py --vscode` in vscode can generate compilation database.