### PR TITLE
stackdriver(logging): add support for cel logging filters

### DIFF
--- a/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
+++ b/extensions/stackdriver/config/v1alpha1/stackdriver_plugin_config.proto
@@ -120,8 +120,14 @@ message PluginConfig {
   // Optional. Allows enabling log compression for stackdriver access logs.
   google.protobuf.BoolValue enable_log_compression = 9;
 
-  // Optional. Controls what type of logs to export..
+  // Optional. Controls what type of logs to export.
   AccessLogging access_logging = 10;
+
+  // CEL expression for filtering access logging. If the expression evaluates
+  // to true, an access log entry will be generated. Otherwise, no access log
+  // entry will be generated.
+  // NOTE: Audit logs ignore configured filters.
+  string access_logging_filter_expression = 17;
 
   // (Optional) Collection of tag names and tag expressions to include in the
   // logs. Conflicts are resolved by the tag name by overriding previously

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -368,6 +368,18 @@ bool StackdriverRootContext::onConfigure(size_t size) {
   return true;
 }
 
+bool StackdriverRootContext::initializeLogFilter() {
+  uint32_t token = 0;
+  if (createExpression(config_.access_logging_filter_expression(), &token) !=
+      WasmResult::Ok) {
+    LOG_TRACE(absl::StrCat("cannot create an filter expression: " +
+                           config_.access_logging_filter_expression()));
+    return false;
+  }
+  log_filter_token_ = token;
+  return true;
+}
+
 bool StackdriverRootContext::configure(size_t configuration_size) {
   // onStart is called prior to onConfigure
   int proxy_tick_ms = getProxyTickerIntervalMilliseconds();
@@ -434,6 +446,11 @@ bool StackdriverRootContext::configure(size_t configuration_size) {
   if (enableAccessLog()) {
     std::unordered_map<std::string, std::string> extra_labels;
     cleanupExpressions();
+    cleanupLogFilter();
+    if (!initializeLogFilter()) {
+      LOG_WARN("Could not build filter expression for logging.");
+    }
+
     if (config_.has_custom_log_config()) {
       for (const auto& dimension : config_.custom_log_config().dimensions()) {
         uint32_t token;
@@ -558,6 +575,8 @@ bool StackdriverRootContext::onDone() {
   }
   tcp_request_queue_.clear();
   cleanupExpressions();
+  cleanupMetricsExpressions();
+  cleanupLogFilter();
   return done;
 }
 
@@ -581,7 +600,7 @@ void StackdriverRootContext::record() {
        (enableAccessLogOnError() &&
         (request_info.response_code >= 400 ||
          request_info.response_flag != ::Wasm::Common::NONE))) &&
-      shouldLogThisRequest(request_info)) {
+      shouldLogThisRequest(request_info) && evaluateLogFilter()) {
     ::Wasm::Common::populateExtendedHTTPRequestInfo(&request_info);
     std::unordered_map<std::string, std::string> extra_labels;
     evaluateExpressions(extra_labels);
@@ -591,6 +610,8 @@ void StackdriverRootContext::record() {
                          outbound, false /* audit */);
   }
 
+  // TODO(dougreid): should Audits override log filters? I believe so. At this
+  // time, we won't apply logging filters to audit logs.
   if (enableAuditLog() && shouldAuditThisRequest()) {
     if (!extended_info_populated) {
       ::Wasm::Common::populateExtendedHTTPRequestInfo(&request_info);
@@ -642,7 +663,12 @@ bool StackdriverRootContext::recordTCP(uint32_t id) {
   bool extended_info_populated = false;
   // Add LogEntry to Logger. Log Entries are batched and sent on timer
   // to Stackdriver Logging Service.
-  if (enableAllAccessLog() || (enableAccessLogOnError() && !no_error)) {
+  if (!record_info.log_filter_evaluated) {
+    record_info.log_connection = evaluateLogFilter();
+    record_info.log_filter_evaluated = true;
+  }
+  if ((enableAllAccessLog() || (enableAccessLogOnError() && !no_error)) &&
+      record_info.log_connection) {
     ::Wasm::Common::populateExtendedRequestInfo(&request_info);
     extended_info_populated = true;
     if (!record_info.expressions_evaluated) {
@@ -669,6 +695,7 @@ bool StackdriverRootContext::recordTCP(uint32_t id) {
         getCurrentTimeNanoseconds(), outbound, false /* audit */);
   }
 
+  // TODO(dougreid): confirm that audit should override filtering.
   if (enableAuditLog() && shouldAuditThisRequest()) {
     if (!extended_info_populated) {
       ::Wasm::Common::populateExtendedRequestInfo(&request_info);
@@ -716,6 +743,19 @@ inline bool StackdriverRootContext::enableAllAccessLog() {
   return (!config_.disable_server_access_logging() && !isOutbound()) ||
          config_.access_logging() ==
              stackdriver::config::v1alpha1::PluginConfig::FULL;
+}
+
+inline bool StackdriverRootContext::evaluateLogFilter() {
+  if (config_.access_logging_filter_expression() == "") {
+    return true;
+  }
+  bool value;
+  if (!evaluateExpression(log_filter_token_, &value)) {
+    LOG_TRACE(absl::StrCat("Could not evaluate expression: ",
+                           config_.access_logging_filter_expression()));
+    return true;
+  }
+  return value;
 }
 
 inline bool StackdriverRootContext::enableAccessLogOnError() {
@@ -817,6 +857,11 @@ void StackdriverRootContext::cleanupMetricsExpressions() {
     exprDelete(expression.token);
   }
   metrics_expressions_.clear();
+}
+
+void StackdriverRootContext::cleanupLogFilter() {
+  exprDelete(log_filter_token_);
+  log_filter_token_ = 0;
 }
 
 // TODO(bianpengyuan) Add final export once root context supports onDone.

--- a/extensions/stackdriver/stackdriver.cc
+++ b/extensions/stackdriver/stackdriver.cc
@@ -370,6 +370,11 @@ bool StackdriverRootContext::onConfigure(size_t size) {
 
 bool StackdriverRootContext::initializeLogFilter() {
   uint32_t token = 0;
+  if (config_.access_logging_filter_expression() == "") {
+    log_filter_token_ = token;
+    return true;
+  }
+
   if (createExpression(config_.access_logging_filter_expression(), &token) !=
       WasmResult::Ok) {
     LOG_TRACE(absl::StrCat("cannot create an filter expression: " +

--- a/extensions/stackdriver/stackdriver.h
+++ b/extensions/stackdriver/stackdriver.h
@@ -97,6 +97,10 @@ class StackdriverRootContext : public RootContext {
     // This caches evaluated extra access log labels.
     std::unordered_map<std::string, std::string> extra_log_labels;
     bool expressions_evaluated;
+
+    // cache filter expression value
+    bool log_connection;
+    bool log_filter_evaluated;
   };
 
   // Indicates whether to export any kind of access log or not.
@@ -128,11 +132,21 @@ class StackdriverRootContext : public RootContext {
   void evaluateMetricsExpressions(
       ::Extensions::Stackdriver::Metric::override_map& overrides);
 
+  // Evaluates a logging filter. If the returned value is `false`, no log
+  // entry will be added for the request/connection.
+  bool evaluateLogFilter();
+
+  // Initializes a configured logging filter.
+  bool initializeLogFilter();
+
   // Cleanup expressions in expressions_ vector.
   void cleanupExpressions();
 
   // Cleanup expressions in metrics_expressions_ vector.
   void cleanupMetricsExpressions();
+
+  // Cleanup any access logging filter expression.
+  void cleanupLogFilter();
 
   // Config for Stackdriver plugin.
   stackdriver::config::v1alpha1::PluginConfig config_;
@@ -177,6 +191,10 @@ class StackdriverRootContext : public RootContext {
     std::string expression;
   };
   std::vector<struct metricsExpressionInfo> metrics_expressions_;
+
+  // Stores the reference token for a configured access logging filter
+  // expression.
+  uint32_t log_filter_token_;
 };
 
 // StackdriverContext is per stream context. It has the same lifetime as

--- a/testdata/filters/stackdriver_inbound_logs_filter.yaml.tmpl
+++ b/testdata/filters/stackdriver_inbound_logs_filter.yaml.tmpl
@@ -1,0 +1,20 @@
+- name: stackdriver_inbound
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.http.wasm.v3.Wasm
+    value:
+      config:
+        root_id: "stackdriver_inbound"
+        vm_config:
+          {{- if .Vars.ReloadVM }}
+          vm_id: "stackdriver_inbound_{{ .Vars.Version }}"
+          {{- else }}
+          vm_id: "stackdriver_inbound"
+          {{- end }}
+          runtime: "envoy.wasm.runtime.null"
+          code:
+            local: { inline_string: "envoy.wasm.null.stackdriver" }
+        configuration:
+          "@type": "type.googleapis.com/google.protobuf.StringValue"
+          value: |
+            {"access_logging_filter_expression": "request.headers['x-filter'] != 'filter'"}

--- a/testdata/filters/stackdriver_outbound_logs_filter.yaml.tmpl
+++ b/testdata/filters/stackdriver_outbound_logs_filter.yaml.tmpl
@@ -1,0 +1,20 @@
+- name: stackdriver_outbound
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: envoy.extensions.filters.http.wasm.v3.Wasm
+    value:
+      config:
+        root_id: "stackdriver_outbound"
+        vm_config:
+          {{- if .Vars.ReloadVM }}
+          vm_id: "stackdriver_outbound_{{ .Vars.Version }}"
+          {{- else }}
+          vm_id: "stackdriver_outbound"
+          {{- end }}
+          runtime: "envoy.wasm.runtime.null"
+          code:
+            local: { inline_string: "envoy.wasm.null.stackdriver" }
+        configuration:
+          "@type": "type.googleapis.com/google.protobuf.StringValue"
+          value: |
+            {"access_logging": "FULL", "access_logging_filter_expression": "request.headers['x-filter'] != 'filter'"}


### PR DESCRIPTION
This PR adds support to the Stackdriver extension for CEL filtering in order to support Telemetry API additions. In https://github.com/istio/api/pull/2110, the ability to filter access logs via a CEL expression was added to the Telemetry API. 
