### PR TITLE
Added option to configure envoy concurrency when running tests.

### DIFF
--- a/test/envoye2e/driver/envoy.go
+++ b/test/envoye2e/driver/envoy.go
@@ -58,6 +58,9 @@ type Envoy struct {
 	// standard out for the Envoy process (defaults to os.Stdout).
 	Stdout io.Writer
 
+	// Value used to set the --concurrency flag when starting envoy.
+	Concurrency uint32
+
 	tmpFile   string
 	cmd       *exec.Cmd
 	adminPort uint32
@@ -94,10 +97,14 @@ func (e *Envoy) Run(p *Params) error {
 	if !ok {
 		debugLevel = "info"
 	}
+	concurrency := "1"
+	if(e.Concurrency > 1) {
+	    concurrency = fmt.Sprint(e.Concurrency)
+	}
 	args := []string{
 		"-c", e.tmpFile,
 		"-l", debugLevel,
-		"--concurrency", "1",
+		"--concurrency", concurrency,
 		"--disable-hot-restart",
 		"--drain-time-s", "4", // this affects how long draining listenrs are kept alive
 	}


### PR DESCRIPTION
What this PR does / why we need it:
It adds to driver.Envoy the option to configure the "--concurrency" flag when running the envoy executable.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #36601

Special notes for your reviewer: