### PR TITLE
stats: fix crash on invalid json

### DIFF
--- a/extensions/stats/plugin.cc
+++ b/extensions/stats/plugin.cc
@@ -590,6 +590,11 @@ void PluginRootContext::onTick() {
 
 void PluginRootContext::report(::Wasm::Common::RequestInfo& request_info,
                                bool end_stream) {
+  if (!initialized_) {
+    LOG_TRACE("stats plugin not initialized properly (wrong json config?)");
+    return;
+  }
+
   // HTTP peer metadata should be done by the time report is called for a
   // request info. TCP metadata might still be awaiting.
   // Upstream host should be selected for metadata fallback.


### PR DESCRIPTION
Signed-off-by: Tianpeng Wang <tpwang@alauda.io>

**What this PR does / why we need it**:

When the stats plugin starts with wrong JSON config (ill-formatted for example), it will crash on any request (healthcheck for example) which makes pod crash repeatedly (or fail to start if healthcheck configured).
