### PR TITLE
[release-1.13] Use release/v1.21 from github.com/envoyproxy/envoy and not main

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,10 +38,10 @@ bind(
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
 # Note: this is needed by release builder to resolve envoy dep sha to tag.
-# Commit date: 2022-01-19
-ENVOY_SHA = "a86612d050e25a0e85e9b72fe7a39f6cbe0d793e"
+# Commit date: 2022-01-12
+ENVOY_SHA = "a9d72603c68da3a10a1c0d021d01c7877e6f2a30"
 
-ENVOY_SHA256 = "e854ef80e50cc0d7fcd2f8b720b95d8c175c76d0546ca5201be5fc7965aa2980"
+ENVOY_SHA256 = "a5141988689826df54667a401edf4ca49efed3dded22189dd0e7ebd688955782"
 
 ENVOY_ORG = "envoyproxy"
 

--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -26,7 +26,6 @@ common --experimental_allow_tags_propagation
 # Enable position independent code (this is the default on macOS and Windows)
 # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
 build:linux --copt=-fPIC
-build:linux --copt=-Wno-deprecated-declarations
 build:linux --cxxopt=-std=c++17
 build:linux --conlyopt=-fexceptions
 build:linux --fission=dbg,opt


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the latest sha from github.com/envoyproxy/envoy for the release/v1.21 branch and not from the main branch

`UPDATE_BRANCH=release/v1.21 scripts/update_envoy.sh`