### PR TITLE
[release-1.13] Update scripts/verify-last-flag-matches-upstream.sh to Envoy 1.21

### DIFF
--- a/scripts/verify-last-flag-matches-upstream.sh
+++ b/scripts/verify-last-flag-matches-upstream.sh
@@ -16,7 +16,7 @@
 #
 ################################################################################
 
-# This script verifies the LastFlag response flag in istio/proxy matches the one in envoyproxy/envoy 
+# This script verifies the LastFlag response flag in istio/proxy matches the one in envoyproxy/envoy
 # and fails with a non-zero exit code if they differ.
 
 set -x
@@ -29,7 +29,7 @@ ENVOY_PATH_LASTFLAG_SPEC="envoy/stream_info/stream_info.h"
 
 ENVOY_ORG="$(grep -Pom1 "^ENVOY_ORG = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
 ENVOY_REPO="$(grep -Pom1 "^ENVOY_REPO = \"\K[a-zA-Z-]+" "${WORKSPACE}")"
-ENVOY_LATEST_SHA="$(git ls-remote https://github.com/"${ENVOY_ORG}"/"${ENVOY_REPO}" "main" | awk '{ print $1}')"
+ENVOY_LATEST_SHA="$(git ls-remote https://github.com/"${ENVOY_ORG}"/"${ENVOY_REPO}" "release/v1.21" | awk '{ print $1}')"
 
 trap 'rm -rf ${PATH_LASTFLAG_SPEC_UPSTREAM}' EXIT
 curl -sSL "https://raw.githubusercontent.com/${ENVOY_ORG}/${ENVOY_REPO}/${ENVOY_LATEST_SHA}/${ENVOY_PATH_LASTFLAG_SPEC}" > "${PATH_LASTFLAG_SPEC_UPSTREAM}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Test test-proxy test is failing because of an update in the Envoy "main" stream. The test should be checking the appropriate Envoy branch. For example see https://github.com/istio/proxy/pull/3670.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
