### PR TITLE
Update to fix lint-go when using new common-files updates

### DIFF
--- a/test/envoye2e/basic_flow/basic_test.go
+++ b/test/envoye2e/basic_flow/basic_test.go
@@ -54,12 +54,14 @@ func TestBasicTCPFlow(t *testing.T) {
 				AdminPort: params.Ports.ServerAdmin,
 				Matchers: map[string]driver.StatMatcher{
 					"envoy_tcp_downstream_cx_total": &driver.PartialStat{Metric: "testdata/metric/basic_flow_server_tcp_connection.yaml.tmpl"},
-				}},
+				},
+			},
 			&driver.Stats{
 				AdminPort: params.Ports.ClientAdmin,
 				Matchers: map[string]driver.StatMatcher{
 					"envoy_tcp_downstream_cx_total": &driver.PartialStat{Metric: "testdata/metric/basic_flow_client_tcp_connection.yaml.tmpl"},
-				}},
+				},
+			},
 		},
 	}).Run(params); err != nil {
 		t.Fatal(err)
@@ -108,7 +110,8 @@ func TestBasicHTTPGateway(t *testing.T) {
 	if err := (&driver.Scenario{
 		[]driver.Step{
 			&driver.XDS{},
-			&driver.Update{Node: "server", Version: "0",
+			&driver.Update{
+				Node: "server", Version: "0",
 				Clusters: []string{driver.LoadTestData("testdata/cluster/server.yaml.tmpl")},
 				Listeners: []string{
 					driver.LoadTestData("testdata/listener/client.yaml.tmpl"),

--- a/test/envoye2e/driver/envoy.go
+++ b/test/envoye2e/driver/envoy.go
@@ -98,8 +98,8 @@ func (e *Envoy) Run(p *Params) error {
 		debugLevel = "info"
 	}
 	concurrency := "1"
-	if(e.Concurrency > 1) {
-	    concurrency = fmt.Sprint(e.Concurrency)
+	if e.Concurrency > 1 {
+		concurrency = fmt.Sprint(e.Concurrency)
 	}
 	args := []string{
 		"-c", e.tmpFile,
@@ -190,10 +190,10 @@ func getAdminPort(bootstrap string) (uint32, error) {
 // downloads env based on the given branch name. Return location of downloaded envoy.
 func downloadEnvoy(ver string) (string, error) {
 	var proxyDepURL string
-	if regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`).Match([]byte(ver)) {
+	if regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`).MatchString(ver) {
 		// this is a patch version string
 		proxyDepURL = fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%v/istio.deps", ver)
-	} else if regexp.MustCompile(`[0-9]+\.[0-9]+`).Match([]byte(ver)) {
+	} else if regexp.MustCompile(`[0-9]+\.[0-9]+`).MatchString(ver) {
 		// this is a minor version string
 		proxyDepURL = fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/release-%v/istio.deps", ver)
 	} else if ver == "master" {
@@ -236,7 +236,7 @@ func downloadEnvoy(ver string) (string, error) {
 	_ = os.RemoveAll(dir)
 
 	// make temp directory to put downloaded envoy binary.
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
 

--- a/test/envoye2e/driver/xds.go
+++ b/test/envoye2e/driver/xds.go
@@ -71,15 +71,19 @@ func (x *XDS) Cleanup() {
 	log.Println("stopping XDS server")
 	x.grpc.GracefulStop()
 }
+
 func (x *XDS) Debugf(format string, args ...interface{}) {
 	log.Printf("xds debug: "+format, args...)
 }
+
 func (x *XDS) Infof(format string, args ...interface{}) {
 	log.Printf("xds: "+format, args...)
 }
+
 func (x *XDS) Errorf(format string, args ...interface{}) {
 	log.Printf("xds error: "+format, args...)
 }
+
 func (x *XDS) Warnf(format string, args ...interface{}) {
 	log.Printf("xds warn: "+format, args...)
 }

--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -110,12 +110,14 @@ func TestStackdriverPayloadGateway(t *testing.T) {
 			&driver.XDS{},
 			sd,
 			&SecureTokenService{Port: stsPort},
-			&driver.Update{Node: "server", Version: "0",
+			&driver.Update{
+				Node: "server", Version: "0",
 				Clusters: []string{driver.LoadTestData("testdata/cluster/server.yaml.tmpl")},
 				Listeners: []string{
 					driver.LoadTestData("testdata/listener/client.yaml.tmpl"),
 					driver.LoadTestData("testdata/listener/server.yaml.tmpl"),
-				}},
+				},
+			},
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
 			&driver.Sleep{1 * time.Second},
 			&driver.Repeat{N: 1, Step: driver.Get(params.Ports.ClientPort, "hello, world!")},
@@ -390,9 +392,11 @@ func TestStackdriverParallel(t *testing.T) {
 			sd,
 			&SecureTokenService{Port: stsPort},
 			&driver.Update{Node: "client", Version: "0", Listeners: []string{
-				driver.LoadTestData("testdata/listener/client.yaml.tmpl")}},
+				driver.LoadTestData("testdata/listener/client.yaml.tmpl"),
+			}},
 			&driver.Update{Node: "server", Version: "0", Listeners: []string{
-				driver.LoadTestData("testdata/listener/server.yaml.tmpl")}},
+				driver.LoadTestData("testdata/listener/server.yaml.tmpl"),
+			}},
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
 			&driver.Sleep{1 * time.Second},
@@ -451,7 +455,7 @@ func getSdLogEntries(noClientLogs bool, logEntryCount int) []SDLogEntry {
 
 func TestStackdriverAccessLog(t *testing.T) {
 	t.Parallel()
-	var TestCases = []struct {
+	TestCases := []struct {
 		name                   string
 		logWindowDuration      string
 		sleepDuration          time.Duration
@@ -546,7 +550,7 @@ func TestStackdriverAccessLog(t *testing.T) {
 
 func TestStackdriverTCPMetadataExchange(t *testing.T) {
 	t.Parallel()
-	var TestCases = []struct {
+	TestCases := []struct {
 		name               string
 		alpnProtocol       string
 		sourceUnknown      string
@@ -619,18 +623,23 @@ func TestStackdriverTCPMetadataExchange(t *testing.T) {
 							"testdata/stackdriver/client_tcp_connection_count.yaml.tmpl",
 							"testdata/stackdriver/client_tcp_received_bytes_count.yaml.tmpl",
 							"testdata/stackdriver/server_tcp_received_bytes_count.yaml.tmpl",
-							"testdata/stackdriver/server_tcp_connection_count.yaml.tmpl"},
+							"testdata/stackdriver/server_tcp_connection_count.yaml.tmpl",
+						},
 						[]SDLogEntry{
 							{
 								LogBaseFile: "testdata/stackdriver/server_access_log.yaml.tmpl",
-								LogEntryFile: []string{"testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl",
-									"testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl"},
+								LogEntryFile: []string{
+									"testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl",
+									"testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl",
+								},
 								LogEntryCount: 10,
 							},
 							{
 								LogBaseFile: "testdata/stackdriver/client_access_log.yaml.tmpl",
-								LogEntryFile: []string{"testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl",
-									"testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl"},
+								LogEntryFile: []string{
+									"testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl",
+									"testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl",
+								},
 								LogEntryCount: 10,
 							},
 						}, false,
@@ -799,7 +808,8 @@ func TestStackdriverCustomAccessLog(t *testing.T) {
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
 			&driver.Sleep{1 * time.Second},
-			&driver.Repeat{N: 10,
+			&driver.Repeat{
+				N: 10,
 				Step: &driver.HTTPCall{
 					Port:           params.Ports.ClientPort,
 					Body:           "hello, world!",
@@ -863,14 +873,16 @@ func TestStackdriverAccessLogFilter(t *testing.T) {
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
 			&driver.Sleep{1 * time.Second},
-			&driver.Repeat{N: 1,
+			&driver.Repeat{
+				N: 1,
 				Step: &driver.HTTPCall{
 					Port:           params.Ports.ClientPort,
 					Body:           "hello, world!",
 					RequestHeaders: map[string]string{"User-Agent": "chrome"},
 				},
 			},
-			&driver.Repeat{N: 1,
+			&driver.Repeat{
+				N: 1,
 				Step: &driver.HTTPCall{
 					Port:           params.Ports.ClientPort,
 					Body:           "hello, world!",
@@ -989,7 +1001,7 @@ func TestStackdriverRbacAccessDenied(t *testing.T) {
 
 func TestStackdriverRbacTCPDryRun(t *testing.T) {
 	t.Parallel()
-	var TestCases = []struct {
+	TestCases := []struct {
 		name               string
 		alpnProtocol       string
 		sourceUnknown      string
@@ -1064,18 +1076,23 @@ func TestStackdriverRbacTCPDryRun(t *testing.T) {
 							"testdata/stackdriver/client_tcp_connection_count.yaml.tmpl",
 							"testdata/stackdriver/client_tcp_received_bytes_count.yaml.tmpl",
 							"testdata/stackdriver/server_tcp_received_bytes_count.yaml.tmpl",
-							"testdata/stackdriver/server_tcp_connection_count.yaml.tmpl"},
+							"testdata/stackdriver/server_tcp_connection_count.yaml.tmpl",
+						},
 						[]SDLogEntry{
 							{
 								LogBaseFile: "testdata/stackdriver/server_access_log.yaml.tmpl",
-								LogEntryFile: []string{"testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl",
-									"testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl"},
+								LogEntryFile: []string{
+									"testdata/stackdriver/server_tcp_access_log_entry_on_open.yaml.tmpl",
+									"testdata/stackdriver/server_tcp_access_log_entry.yaml.tmpl",
+								},
 								LogEntryCount: 10,
 							},
 							{
 								LogBaseFile: "testdata/stackdriver/client_access_log.yaml.tmpl",
-								LogEntryFile: []string{"testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl",
-									"testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl"},
+								LogEntryFile: []string{
+									"testdata/stackdriver/client_tcp_access_log_entry_on_open.yaml.tmpl",
+									"testdata/stackdriver/client_tcp_access_log_entry.yaml.tmpl",
+								},
 								LogEntryCount: 10,
 							},
 						}, false,
@@ -1119,7 +1136,8 @@ func TestStackdriverMetricExpiry(t *testing.T) {
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
 			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
 			&driver.Sleep{Duration: 1 * time.Second},
-			&driver.Repeat{N: 10,
+			&driver.Repeat{
+				N: 10,
 				Step: &driver.HTTPCall{
 					Port: params.Ports.ClientPort,
 					Body: "hello, world!",
@@ -1133,7 +1151,8 @@ func TestStackdriverMetricExpiry(t *testing.T) {
 			&driver.Sleep{Duration: 10 * time.Second},
 			// Send request directly to server, which will create several new time series with unknown source.
 			// This will also trigger the metrics with known source to be purged.
-			&driver.Repeat{N: 10,
+			&driver.Repeat{
+				N: 10,
 				Step: &driver.HTTPCall{
 					Port: params.Ports.ServerPort,
 					Body: "hello, world!",

--- a/test/envoye2e/stackdriver_plugin/sts.go
+++ b/test/envoye2e/stackdriver_plugin/sts.go
@@ -39,14 +39,12 @@ const (
 		"scope=https://www.googleapis.com/auth/cloud-platform"
 )
 
-var (
-	ExpectedTokenResponse = fmt.Sprintf(`{
+var ExpectedTokenResponse = fmt.Sprintf(`{
  "access_token": "%s",
  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
  "token_type": "Bearer",
  "expires_in": 180
 }`, ExpectedBearer)
-)
 
 var _ driver.Step = &SecureTokenService{}
 

--- a/testdata/testdata.gen.go
+++ b/testdata/testdata.gen.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -624,16 +625,16 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"bootstrap": &bintree{nil, map[string]*bintree{
-		"client.yaml.tmpl": &bintree{bootstrapClientYamlTmpl, map[string]*bintree{}},
-		"server.yaml.tmpl": &bintree{bootstrapServerYamlTmpl, map[string]*bintree{}},
-		"stats.yaml.tmpl":  &bintree{bootstrapStatsYamlTmpl, map[string]*bintree{}},
+	"bootstrap": {nil, map[string]*bintree{
+		"client.yaml.tmpl": {bootstrapClientYamlTmpl, map[string]*bintree{}},
+		"server.yaml.tmpl": {bootstrapServerYamlTmpl, map[string]*bintree{}},
+		"stats.yaml.tmpl":  {bootstrapStatsYamlTmpl, map[string]*bintree{}},
 	}},
-	"listener": &bintree{nil, map[string]*bintree{
-		"client.yaml.tmpl":     &bintree{listenerClientYamlTmpl, map[string]*bintree{}},
-		"server.yaml.tmpl":     &bintree{listenerServerYamlTmpl, map[string]*bintree{}},
-		"tcp_client.yaml.tmpl": &bintree{listenerTcp_clientYamlTmpl, map[string]*bintree{}},
-		"tcp_server.yaml.tmpl": &bintree{listenerTcp_serverYamlTmpl, map[string]*bintree{}},
+	"listener": {nil, map[string]*bintree{
+		"client.yaml.tmpl":     {listenerClientYamlTmpl, map[string]*bintree{}},
+		"server.yaml.tmpl":     {listenerServerYamlTmpl, map[string]*bintree{}},
+		"tcp_client.yaml.tmpl": {listenerTcp_clientYamlTmpl, map[string]*bintree{}},
+		"tcp_server.yaml.tmpl": {listenerTcp_serverYamlTmpl, map[string]*bintree{}},
 	}},
 }}
 
@@ -647,7 +648,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0o755))
 	if err != nil {
 		return err
 	}

--- a/tools/extensionserver/server.go
+++ b/tools/extensionserver/server.go
@@ -50,16 +50,20 @@ func New(ctx context.Context) *ExtensionServer {
 func (es *ExtensionServer) StreamExtensionConfigs(stream extensionservice.ExtensionConfigDiscoveryService_StreamExtensionConfigsServer) error {
 	return es.Server.StreamHandler(stream, APIType)
 }
+
 func (es *ExtensionServer) DeltaExtensionConfigs(_ extensionservice.ExtensionConfigDiscoveryService_DeltaExtensionConfigsServer) error {
 	return status.Errorf(codes.Unimplemented, "not implemented")
 }
+
 func (es *ExtensionServer) FetchExtensionConfigs(ctx context.Context, req *discovery.DiscoveryRequest) (*discovery.DiscoveryResponse, error) {
 	req.TypeUrl = APIType
 	return es.Server.Fetch(ctx, req)
 }
+
 func (es *ExtensionServer) Update(config *core.TypedExtensionConfig) error {
 	return es.cache.UpdateResource(config.Name, config)
 }
+
 func (es *ExtensionServer) Delete(name string) error {
 	return es.cache.DeleteResource(name)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Ran gofumpt and then fixed remaining failures (change to MatchString).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
