### PR TITLE
enable sip_proxy extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -372,6 +372,8 @@ ISTIO_DISABLED_EXTENSIONS = [
 
 ISTIO_ENABLED_CONTRIB_EXTENSIONS = [ 
     "envoy.filters.network.mysql_proxy",
+    "envoy.filters.network.sip_proxy",
+    "envoy.filters.sip.router",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] + 


### PR DESCRIPTION
**What this PR does / why we need it**:
enable sip_proxy contrib extension

envoy sip_proxy contrib extension is an extension which brings service-mesh features to SIP protocol, it is under active developing in envoy under alpha stage now. and there are at least 2 companies who are interested with this extension.

currently, it can be  activated via **EnvoyFilter** in istio service-mesh environment, the config looks like below:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:                                                                                                                                                                                                                                                         
  name: sip-outbound
spec:
  workloadSelector:
    labels:
      app: sips
  configPatches:
  - applyTo: NETWORK_FILTER
    match:
      context: SIDECAR_OUTBOUND
      listener:
        name: "10.96.0.60_5060"
        portNumber: 5060
        filterChain:
          filter:
            name: "envoy.filters.network.tcp_proxy"
    patch:
      operation: REMOVE
  - applyTo: NETWORK_FILTER
    match:
      context: SIDECAR_OUTBOUND
      listener:
        name: "0.0.0.0_5060"
        portNumber: 5060
    patch:
      operation: ADD
      value:
        name: envoy.filters.network.sip_proxy
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.sip_proxy.v3alpha.SipProxy
          stat_prefix: sip-stas-spfe-outbound
          route_config:
            routes:l
            - match:
                domain: sips.default.svc.cluster.local
                parameter: x-suri
              route:
                cluster: outbound|5060||sips.default.svc.cluster.local
            - match:
                domain: '*'
              route:
                cluster: outbound|5060||sip-dispatcher.default.svc.cluster.local
          settings:
            transaction_timeout: 32s
            local_services:
            - domain: sipc.default.svc.cluster.local
              parameter: "x-suri"
            tra_service_config:
              grpc_service:
                envoy_grpc:
                  authority: tra.default.svc.cluster.local
                  cluster_name: outbound|50053||tra.default.svc.cluster.local
              timeout: 2s
              transport_api_version: V3
---
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: sips-cluster
spec:
  configPatches:
  - applyTo: CLUSTER
    match:
      context: SIDECAR_OUTBOUND
      cluster:
        name: "outbound|5060||sips.default.svc.cluster.local"
    patch:
      operation: MERGE
      value:
        name: "outbound|5060||sips.default.svc.cluster.local"
        typed_extension_protocol_options:
          envoy.filters.network.sip_proxy:
            "@type": type.googleapis.com/envoy.extensions.filters.network.sip_proxy.v3alpha.SipProtocolOptions
            customized_affinity:
              entries:
              - key_name: ep
              - key_name: skey
                query: true
                subscribe: false
            registration_affinity: true
            session_affinity: true
```

In the future, we plan to contribute to istio to enable sip service-mesh in istio way.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
