### PR TITLE
Pass shellcheck 0.8 linter

### DIFF
--- a/prow/proxy-postsubmit-centos.sh
+++ b/prow/proxy-postsubmit-centos.sh
@@ -24,7 +24,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 # Do not use RBE execution with Ubuntu toolchain, but still use RBE cache.
 export BAZEL_BUILD_RBE_JOBS=0
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 if [[ $(command -v gcloud) ]]; then

--- a/prow/proxy-postsubmit.sh
+++ b/prow/proxy-postsubmit.sh
@@ -20,7 +20,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 ########################################
 # Postsubmit script triggered by Prow. #
 ########################################
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 if [[ $(command -v gcloud) ]]; then

--- a/prow/proxy-presubmit-asan.sh
+++ b/prow/proxy-presubmit-asan.sh
@@ -20,7 +20,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 echo 'Bazel Tests'

--- a/prow/proxy-presubmit-centos-release.sh
+++ b/prow/proxy-presubmit-centos-release.sh
@@ -24,7 +24,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 # Do not use RBE execution with Ubuntu toolchain, but still use RBE cache.
 export BAZEL_BUILD_RBE_JOBS=0
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 echo "$(uname -s)-$(uname -m)"

--- a/prow/proxy-presubmit-release.sh
+++ b/prow/proxy-presubmit-release.sh
@@ -20,7 +20,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 echo 'Test building release artifacts'

--- a/prow/proxy-presubmit-tsan.sh
+++ b/prow/proxy-presubmit-tsan.sh
@@ -20,7 +20,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 echo 'Bazel Tests'

--- a/prow/proxy-presubmit-wasm.sh
+++ b/prow/proxy-presubmit-wasm.sh
@@ -20,7 +20,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 echo 'Generate Wasm module files and run Wasm related test'

--- a/prow/proxy-presubmit.sh
+++ b/prow/proxy-presubmit.sh
@@ -20,7 +20,7 @@ WD=$(cd "$WD" || exit 1 ; pwd)
 #######################################
 # Presubmit script triggered by Prow. #
 #######################################
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 source "${WD}/proxy-common.inc"
 
 echo 'Code Check'

--- a/scripts/push-debian.sh
+++ b/scripts/push-debian.sh
@@ -23,7 +23,6 @@
 #   -p gs://istio-release/release/0.2.1/deb
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS}"
 BAZEL_TARGET='//tools/deb:istio-proxy'
 BAZEL_BINARY="${ROOT}/bazel-bin/tools/deb/istio-proxy"
 ISTIO_VERSION=''


### PR DESCRIPTION
**What this PR does / why we need it**:

The latest build image uses shellcheck 0.8. Various scripts do not pass its linting.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
