### PR TITLE
Fix missing preserve_casing extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -274,7 +274,7 @@ ENVOY_EXTENSIONS = {
     # HTTP header formatters
     #
 
-    "envoy.http.stateful_header_formatters.preserve_case":       "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
+    "envoy.http.stateful_header_formatters.preserve_case":       "//source/extensions/http/header_formatters/preserve_case:config",
 
     #
     # Original IP detection


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- All istio/istio upstream SHA's from this commit onwards -> https://github.com/istio/istio/commit/b74e118e09fa623ccc39080c6cbf5ea1710127d4 are missing `preserve_case` extension

- As part of that commit, it seems envoy SHA was upgraded -> https://github.com/istio/proxy/compare/d8d68716031420dd76cba89eee3eda7d29312c3e..44e4301ccecc331d1d0682fffc3f3462a45f0ea3

- When comparing the diff in envoy SHAs it seems there is a change in the preserve_case extension and there is a `config` target available in the bazel build file -> https://github.com/envoyproxy/envoy/compare/dba39baf054b9bc7a352c481a70b774e69b8b52d..168c3aea0f1817883faff00c8cccd264392a58c3#diff-4a31ee25ae1eac06e297bdd88debf787bbcd0aaa7b294b62532c955130b3d2f4R23

- I am not 100% certain but I think the missing extension might get fixed by this. Please forgive me if my understanding is incorrect with how extensions are configured  / tied with the envoy source repo.