### PR TITLE
codeowners: switch default to policies and telemetry maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                   @istio/wg-networking-maintainers-data-plane
+*                                   @istio/wg-policies-and-telemetry-maintainers
 /extensions/                        @istio/wg-policies-and-telemetry-maintainers
 /src/envoy/tcp/metadata_exchange/   @istio/wg-policies-and-telemetry-maintainers
 /src/istio/                         @istio/wg-policies-and-telemetry-maintainers


### PR DESCRIPTION
The default owners group only has a single active member. This transfers ownership to a related group with more than a single member.