### PR TITLE
Include missing headers

### DIFF
--- a/extensions/attributegen/plugin.h
+++ b/extensions/attributegen/plugin.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "absl/strings/str_join.h"
 #include "extensions/attributegen/config.pb.h"
 #include "google/protobuf/util/json_util.h"

--- a/extensions/common/wasm/json_util.h
+++ b/extensions/common/wasm/json_util.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "extensions/common/wasm/nlohmann_json.hpp"
 
 /**

--- a/extensions/stats/plugin.h
+++ b/extensions/stats/plugin.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include <optional>
 #include <unordered_map>
 
 #include "absl/strings/str_join.h"


### PR DESCRIPTION
Some combinations of compiler/c++ libraries don't include <optional>
header by default, making the build fail with

```
./extensions/common/wasm/json_util.h:36:6: error: no template named 'optional' in namespace 'std'
```