### PR TITLE
release: allow publishing without check

### DIFF
--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -62,7 +62,6 @@ function usage() {
     -d  The bucket name to store proxy binary (optional).
         If not provided, both envoy binary push and docker image push are skipped.
     -i  Skip Ubuntu Xenial check. DO NOT USE THIS FOR RELEASED BINARIES.
-        Cannot be used together with -d option.
     -c  Build for CentOS releases. This will disable the Ubuntu Xenial check.
     -p  Push envoy docker image and wasm oci image.
         Registry is hard coded to gcr.io and repository is controlled via DOCKER_REPOSITORY and WASM_REPOSITORY env var."

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -102,9 +102,6 @@ if [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 0 ]; then
 elif [ "${CHECK}" -eq 1 ] && [ "${BUILD_FOR_CENTOS}" -eq 1 ]; then
   # Make sure the release binaries are built on CentOS 7
   [[ $(</etc/centos-release tr -dc '0-9.'|cut -d \. -f1) == "7" ]] || { echo "Must run on CentOS 7, got $(cat /centos-release)"; exit 1; }
-elif [ -n "${DST}" ]; then
-  echo "The -i option is not allowed together with -d option."
-  exit 1
 fi
 
 # The proxy binary name.


### PR DESCRIPTION
This allows non-official Istio AMD64 CI to publish without this check.
IMO a flag that is "skip checks" means we know what we are doing, and
should be allowed to skip+publish if we explicitly specify it. This will
be needed for arm64 builds where we cannot use Xenial

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
