### PR TITLE
telemetry: fix handling of off-GCP generic node cases

### DIFF
--- a/extensions/stackdriver/common/utils.cc
+++ b/extensions/stackdriver/common/utils.cc
@@ -182,16 +182,18 @@ void getMonitoredResource(const std::string &monitored_resource_type,
 
   if (monitored_resource_type == kGenericNode) {
     // need location, namespace, node_id
-    auto location_label = platform_metadata->LookupByKey(kGCPLocationKey);
-    if (location_label) {
-      (*monitored_resource->mutable_labels())[kLocationLabel] =
-          flatbuffers::GetString(location_label->value());
-    }
-    (*monitored_resource->mutable_labels())[kNamespaceLabel] =
-        flatbuffers::GetString(local_node_info.namespace_());
+    if (platform_metadata) {
+      auto location_label = platform_metadata->LookupByKey(kGCPLocationKey);
+      if (location_label) {
+        (*monitored_resource->mutable_labels())[kLocationLabel] =
+            flatbuffers::GetString(location_label->value());
+      }
+      (*monitored_resource->mutable_labels())[kNamespaceLabel] =
+          flatbuffers::GetString(local_node_info.namespace_());
 
-    auto node_id = getNodeID(local_node_info.instance_ips());
-    (*monitored_resource->mutable_labels())[kNodeIDLabel] = node_id;
+      auto node_id = getNodeID(local_node_info.instance_ips());
+      (*monitored_resource->mutable_labels())[kNodeIDLabel] = node_id;
+    }
     return;
   }
 

--- a/extensions/stackdriver/metric/registry_test.cc
+++ b/extensions/stackdriver/metric/registry_test.cc
@@ -50,6 +50,19 @@ const ::Wasm::Common::FlatNode& nodeInfo(flatbuffers::FlatBufferBuilder& fbb) {
       fbb.GetBufferPointer());
 }
 
+const ::Wasm::Common::FlatNode& nodeInfoWithNoPlatform(
+    flatbuffers::FlatBufferBuilder& fbb) {
+  auto name = fbb.CreateString("test_pod");
+  auto namespace_ = fbb.CreateString("test_namespace");
+  ::Wasm::Common::FlatNodeBuilder node(fbb);
+  node.add_name(name);
+  node.add_namespace_(namespace_);
+  auto data = node.Finish();
+  fbb.Finish(data);
+  return *flatbuffers::GetRoot<::Wasm::Common::FlatNode>(
+      fbb.GetBufferPointer());
+}
+
 google::api::MonitoredResource serverMonitoredResource() {
   google::api::MonitoredResource monitored_resource;
   monitored_resource.set_type(Common::kContainerMonitoredResource);
@@ -88,6 +101,14 @@ TEST(RegistryTest, getStackdriverOptionsProjectID) {
   ::Extensions::Stackdriver::Common::StackdriverStubOption stub_option;
   auto options = getStackdriverOptions(node_info, stub_option);
   EXPECT_EQ(options.project_id, "test_project");
+}
+
+TEST(RegistryTest, getStackdriverOptionsNoProjectID) {
+  flatbuffers::FlatBufferBuilder fbb;
+  const auto& node_info = nodeInfoWithNoPlatform(fbb);
+  ::Extensions::Stackdriver::Common::StackdriverStubOption stub_option;
+  auto options = getStackdriverOptions(node_info, stub_option);
+  EXPECT_EQ(options.project_id, "");
 }
 
 TEST(RegistryTest, getStackdriverOptionsMonitoredResource) {


### PR DESCRIPTION
In certain off-GCP testing scenarios, the Stackdriver extension can be used with no platform metadata (no `GCP_METADATA`). This can lead to proxy crashes when trying to lookup platform metadata when building a Monitored Resource for reporting.

This PR adds a check to ensure platform metadata exists when building `generic_node` MRs.  A test is added to ensure no crashing.

Fixes istio/istio#40201