### PR TITLE
stackdriver logging: better classify severity levels

### DIFF
--- a/test/envoye2e/stackdriver_plugin/stackdriver_test.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver_test.go
@@ -467,7 +467,7 @@ func TestStackdriverAccessLog(t *testing.T) {
 		destinationUnknown     string
 	}{
 		{"StackdriverAndAccessLogPlugin", "15s", 0, "200", 1, "", true, "", ""},
-		{"RequestGetsLoggedAgain", "1s", 1 * time.Second, "201", 2, "", true, "", ""},
+		{"RequestGetsLoggedAgain", "1s", 1 * time.Second, "200", 2, "", true, "", ""},
 		{"AllErrorRequestsGetsLogged", "1s", 0, "403", 10, "", true, "", ""},
 		{"AllClientErrorRequestsGetsLoggedOnNoMxAndError", "1s", 0, "403", 10, "true", false, "true", "true"},
 		{"NoClientRequestsGetsLoggedOnErrorConfigAndAllSuccessRequests", "15s", 0, "200", 1, "true", false, "true", "true"},

--- a/testdata/stackdriver/client_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/client_access_log_entry.yaml.tmpl
@@ -49,4 +49,8 @@ labels:
   upstream_cluster: "server-outbound-cluster"
   route_name: client_route
   response_details: "via_upstream"
+{{- if eq .Vars.SDLogStatusCode "200" }}
 severity: INFO
+{{- else }}
+severity: ERROR
+{{- end }}

--- a/testdata/stackdriver/server_access_log_entry.yaml.tmpl
+++ b/testdata/stackdriver/server_access_log_entry.yaml.tmpl
@@ -57,4 +57,8 @@ labels:
   dry_run_policy_name: "foo.httpbin-dryrun-allow"
   dry_run_policy_rule: "0"
   {{- end }}
+{{- if eq .Vars.SDLogStatusCode "200" }}
 severity: INFO
+{{- else }}
+severity: ERROR
+{{- end }}


### PR DESCRIPTION
The generated Stackdriver access logs do not properly reflect severity levels. This PR attempts to use the same logic in the "log on error" code to bear on severity levels -- as it stands to reason that if you detect an error to log, the level should be `ERROR`.