### PR TITLE
deflake: combine split metric point values during comparison

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -21,7 +21,7 @@ BAZEL_TARGETS ?= //...
 # Don't build Debian packages and Docker images in tests.
 BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS}
 E2E_TEST_TARGETS ?= $$(go list ./...)
-E2E_TEST_FLAGS ?=
+E2E_TEST_FLAGS ?= -p=1 -parallel=1
 HUB ?=
 TAG ?=
 repo_dir := .
@@ -127,12 +127,10 @@ test:
 	fi
 
 test_asan: BAZEL_CONFIG_CURRENT = $(BAZEL_CONFIG_ASAN)
-test_asan: E2E_TEST_FLAGS = -p=1 -parallel=1
 test_asan: E2E_TEST_ENVS = ASAN=true
 test_asan: test
 
 test_tsan: BAZEL_CONFIG_CURRENT = $(BAZEL_CONFIG_TSAN)
-test_tsan: E2E_TEST_FLAGS = -p=1 -parallel=1
 test_tsan: E2E_TEST_ENVS = TSAN=true
 test_tsan: test
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -21,7 +21,7 @@ BAZEL_TARGETS ?= //...
 # Don't build Debian packages and Docker images in tests.
 BAZEL_TEST_TARGETS ?= ${BAZEL_TARGETS}
 E2E_TEST_TARGETS ?= $$(go list ./...)
-E2E_TEST_FLAGS ?= -p=1 -parallel=1
+E2E_TEST_FLAGS := -p=1 -parallel=1
 HUB ?=
 TAG ?=
 repo_dir := .

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -67,6 +67,7 @@ BAZEL_CONFIG_CURRENT ?= $(BAZEL_CONFIG_DEV)
 BAZEL_BIN_PATH ?= $(shell bazel info $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) bazel-bin)
 TEST_ENVOY_PATH ?= $(BAZEL_BIN_PATH)/src/envoy/envoy
 TEST_ENVOY_TARGET ?= //src/envoy:envoy
+TEST_ENVOY_DEBUG ?= trace
 
 CENTOS_BUILD_ARGS ?= --cxxopt -D_GLIBCXX_USE_CXX11_ABI=1 --cxxopt -DENVOY_IGNORE_GLIBCXX_USE_CXX11_ABI_ERROR=1
 # WASM is not build on CentOS, skip it
@@ -123,7 +124,7 @@ test:
 	  export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) $(BAZEL_TEST_ARGS) -- $(BAZEL_TEST_TARGETS); \
 	fi
 	if [ -n "$(E2E_TEST_TARGETS)" ]; then \
-	  env ENVOY_DEBUG=trace ENVOY_PATH=$(TEST_ENVOY_PATH) $(E2E_TEST_ENVS) GO111MODULE=on go test -timeout 30m $(E2E_TEST_FLAGS) $(E2E_TEST_TARGETS); \
+	  env ENVOY_DEBUG=$(TEST_ENVOY_DEBUG) ENVOY_PATH=$(TEST_ENVOY_PATH) $(E2E_TEST_ENVS) GO111MODULE=on go test -timeout 30m $(E2E_TEST_FLAGS) $(E2E_TEST_TARGETS); \
 	fi
 
 test_asan: BAZEL_CONFIG_CURRENT = $(BAZEL_CONFIG_ASAN)
@@ -132,6 +133,7 @@ test_asan: test
 
 test_tsan: BAZEL_CONFIG_CURRENT = $(BAZEL_CONFIG_TSAN)
 test_tsan: E2E_TEST_ENVS = TSAN=true
+test_tsan: TEST_ENVOY_DEBUG = debug # tsan is too slow for trace
 test_tsan: test
 
 test_centos: BAZEL_BUILD_ARGS := $(CENTOS_BUILD_ARGS) $(BAZEL_BUILD_ARGS)

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -122,6 +122,7 @@ test:
 	if [ -n "$(BAZEL_TEST_TARGETS)" ]; then \
 	  export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) $(BAZEL_TEST_ARGS) -- $(BAZEL_TEST_TARGETS); \
 	fi
+	export ENVOY_DEBUG=trace
 	if [ -n "$(E2E_TEST_TARGETS)" ]; then \
 	  env ENVOY_PATH=$(TEST_ENVOY_PATH) $(E2E_TEST_ENVS) GO111MODULE=on go test -timeout 30m $(E2E_TEST_FLAGS) $(E2E_TEST_TARGETS); \
 	fi

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -122,9 +122,8 @@ test:
 	if [ -n "$(BAZEL_TEST_TARGETS)" ]; then \
 	  export PATH=$(PATH) CC=$(CC) CXX=$(CXX) && bazel $(BAZEL_STARTUP_ARGS) test $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) $(BAZEL_TEST_ARGS) -- $(BAZEL_TEST_TARGETS); \
 	fi
-	export ENVOY_DEBUG=trace
 	if [ -n "$(E2E_TEST_TARGETS)" ]; then \
-	  env ENVOY_PATH=$(TEST_ENVOY_PATH) $(E2E_TEST_ENVS) GO111MODULE=on go test -timeout 30m $(E2E_TEST_FLAGS) $(E2E_TEST_TARGETS); \
+	  env ENVOY_DEBUG=trace ENVOY_PATH=$(TEST_ENVOY_PATH) $(E2E_TEST_ENVS) GO111MODULE=on go test -timeout 30m $(E2E_TEST_FLAGS) $(E2E_TEST_TARGETS); \
 	fi
 
 test_asan: BAZEL_CONFIG_CURRENT = $(BAZEL_CONFIG_ASAN)

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -133,7 +133,7 @@ func (sd *Stackdriver) Check(p *driver.Params, tsFiles []string, lsFiles []SDLog
 		pb := &monitoring.TimeSeries{}
 		p.LoadTestProto(t, pb)
 		if len(pb.Points) != 1 || pb.Points[0].Value.GetInt64Value() == 0 {
-			panic("malformed metric golden")
+			log.Fatal("malformed metric golden")
 		}
 		point := pb.Points[0]
 		pb.Points = nil

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -83,7 +83,7 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 						})
 						for _, point := range ts.Points {
 							point.Interval = nil
-							sd.ts[key] = sd.ts[key] + point.Value.GetInt64Value()
+							sd.ts[key] += point.Value.GetInt64Value()
 						}
 					} else {
 						log.Printf("skipping metric type %q\n", ts.Metric.Type)

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -42,7 +42,7 @@ type Stackdriver struct {
 
 	done  chan error
 	tsReq []*monitoring.CreateTimeSeriesRequest
-	ts    map[string]struct{}
+	ts    map[string]int64
 	ls    map[string]struct{}
 }
 
@@ -57,7 +57,7 @@ var _ driver.Step = &Stackdriver{}
 func (sd *Stackdriver) Run(p *driver.Params) error {
 	sd.done = make(chan error, 1)
 	sd.ls = make(map[string]struct{})
-	sd.ts = make(map[string]struct{})
+	sd.ts = make(map[string]int64)
 	sd.tsReq = make([]*monitoring.CreateTimeSeriesRequest, 0, 20)
 	metrics, logging, _, _ := NewFakeStackdriver(sd.Port, sd.Delay, true, ExpectedBearer)
 
@@ -74,9 +74,12 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 						strings.HasSuffix(ts.Metric.Type, "request_bytes") ||
 						strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
-						ts.Points[0].Interval = nil
-
-						sd.ts[prototext.Format(ts)] = struct{}{}
+						var key monitoring.TimeSeries = *ts
+						key.Points = nil
+						for _, point := range ts.Points {
+							point.Interval = nil
+							sd.ts[prototext.Format(&key)] = sd.ts[prototext.Format(&key)] + point.Value.GetInt64Value()
+						}
 					} else {
 						log.Printf("skipping metric type %q\n", ts.Metric.Type)
 					}
@@ -120,11 +123,16 @@ func (sd *Stackdriver) Cleanup() {
 
 func (sd *Stackdriver) Check(p *driver.Params, tsFiles []string, lsFiles []SDLogEntry, verifyLatency bool) driver.Step {
 	// check as sets of strings by marshaling to proto
-	twant := make(map[string]struct{})
+	twant := make(map[string]int64)
 	for _, t := range tsFiles {
 		pb := &monitoring.TimeSeries{}
 		p.LoadTestProto(t, pb)
-		twant[prototext.Format(pb)] = struct{}{}
+		if len(pb.Points) != 1 || pb.Points[0].Value.GetInt64Value() == 0 {
+			panic("malformed metric golden")
+		}
+		point := pb.Points[0]
+		pb.Points = nil
+		twant[prototext.Format(pb)] = point.Value.GetInt64Value()
 	}
 	lwant := make(map[string]struct{})
 	for _, l := range lsFiles {
@@ -159,7 +167,7 @@ func (r *resetStackdriver) Run(p *driver.Params) error {
 	r.sd.Lock()
 	defer r.sd.Unlock()
 	r.sd.ls = make(map[string]struct{})
-	r.sd.ts = make(map[string]struct{})
+	r.sd.ts = make(map[string]int64)
 	r.sd.tsReq = make([]*monitoring.CreateTimeSeriesRequest, 0, 20)
 	return nil
 }
@@ -168,7 +176,7 @@ func (r *resetStackdriver) Cleanup() {}
 
 type checkStackdriver struct {
 	sd                    *Stackdriver
-	twant                 map[string]struct{}
+	twant                 map[string]int64
 	lwant                 map[string]struct{}
 	verifyResponseLatency bool
 }
@@ -206,20 +214,6 @@ func (s *checkStackdriver) Run(p *driver.Params) error {
 		} else {
 			foundAllMetrics = reflect.DeepEqual(s.sd.ts, s.twant)
 		}
-		if !foundAllMetrics {
-			log.Printf("got metrics %d, want %d\n", len(s.sd.ts), len(s.twant))
-			if len(s.sd.ts) >= len(s.twant) {
-				for got := range s.sd.ts {
-					log.Println(got)
-				}
-				log.Println("--- but want ---")
-				for want := range s.twant {
-					log.Println(want)
-				}
-				return fmt.Errorf("failed to receive expected metrics")
-			}
-		}
-
 		if !s.verifyResponseLatency {
 			verfiedLatency = true
 		} else {
@@ -242,6 +236,17 @@ func (s *checkStackdriver) Run(p *driver.Params) error {
 		log.Println("sleeping till next check")
 		time.Sleep(1 * time.Second)
 	}
+	if !foundAllMetrics {
+		log.Printf("got metrics %d, want %d\n", len(s.sd.ts), len(s.twant))
+		for got, value := range s.sd.ts {
+			log.Printf("%s=%d\n", got, value)
+		}
+		log.Println("--- but want ---")
+		for want, value := range s.twant {
+			log.Printf("%s=%d\n", want, value)
+		}
+	}
+
 	return fmt.Errorf("found all metrics %v, all logs %v, verified latency %v", foundAllMetrics, foundAllLogs, verfiedLatency)
 }
 

--- a/test/envoye2e/stackdriver_plugin/stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/stackdriver.go
@@ -74,11 +74,16 @@ func (sd *Stackdriver) Run(p *driver.Params) error {
 						strings.HasSuffix(ts.Metric.Type, "request_bytes") ||
 						strings.HasSuffix(ts.Metric.Type, "received_bytes_count") {
 						// clear the timestamps for comparison
-						var key monitoring.TimeSeries = *ts
-						key.Points = nil
+						var key = prototext.Format(&monitoring.TimeSeries{
+							Metric:     ts.Metric,
+							Resource:   ts.Resource,
+							Metadata:   ts.Metadata,
+							MetricKind: ts.MetricKind,
+							ValueType:  ts.ValueType,
+						})
 						for _, point := range ts.Points {
 							point.Interval = nil
-							sd.ts[prototext.Format(&key)] = sd.ts[prototext.Format(&key)] + point.Value.GetInt64Value()
+							sd.ts[key] = sd.ts[key] + point.Value.GetInt64Value()
 						}
 					} else {
 						log.Printf("skipping metric type %q\n", ts.Metric.Type)


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Sum up metrics that got split into separate points for whatever reason.