### PR TITLE
Update go.mod go directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module istio.io/proxy
 
-go 1.15
+go 1.19
 
 require (
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4
 	github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263
 	github.com/envoyproxy/go-control-plane v0.10.3
-	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7
 	github.com/prometheus/client_model v0.2.0
@@ -16,4 +15,15 @@ require (
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v2 v2.4.0
 	sigs.k8s.io/yaml v1.3.0
+)
+
+require (
+	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.6.7 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
+	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,7 +50,6 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 h1:hzAQntlaYRkVSFEfj9OTWlVV1H155FMD8BTKktLv0QI=
@@ -77,8 +76,6 @@ github.com/envoyproxy/go-control-plane v0.10.3/go.mod h1:fJJn/j26vwOu972OllsvAgJ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.7 h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=
 github.com/envoyproxy/protoc-gen-validate v0.6.7/go.mod h1:dyJXwwfPK2VSqiB9Klm1J6romD608Ba7Hij42vrOBCo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -313,7 +310,6 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/test/envoye2e/driver/check.go
+++ b/test/envoye2e/driver/check.go
@@ -16,7 +16,7 @@ package driver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -93,7 +93,7 @@ func (g *HTTPCall) Run(_ *Params) error {
 		return fmt.Errorf("error code for :%d: %d", g.Port, code)
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return err

--- a/test/envoye2e/driver/envoy.go
+++ b/test/envoye2e/driver/envoy.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -88,7 +87,7 @@ func (e *Envoy) Run(p *Params) error {
 	}
 	log.Printf("admin port %d", e.adminPort)
 
-	tmp, err := ioutil.TempFile(os.TempDir(), "envoy-bootstrap-*.yaml")
+	tmp, err := os.CreateTemp(os.TempDir(), "envoy-bootstrap-*.yaml")
 	if err != nil {
 		return err
 	}
@@ -210,7 +209,7 @@ func downloadEnvoy(ver string) (string, error) {
 		return "", fmt.Errorf("cannot get envoy sha from %v: %v", proxyDepURL, err)
 	}
 	defer resp.Body.Close()
-	istioDeps, err := ioutil.ReadAll(resp.Body)
+	istioDeps, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("cannot read body of istio deps: %v", err)
 	}

--- a/test/envoye2e/driver/resource.go
+++ b/test/envoye2e/driver/resource.go
@@ -15,7 +15,7 @@
 package driver
 
 import (
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -44,7 +44,7 @@ func TestPath(testFileName string) string {
 
 // Loads a test file content
 func LoadTestData(testFileName string) string {
-	data, err := ioutil.ReadFile(TestPath(testFileName))
+	data, err := os.ReadFile(TestPath(testFileName))
 	if err != nil {
 		panic(err)
 	}

--- a/test/envoye2e/env/http_client.go
+++ b/test/envoye2e/env/http_client.go
@@ -18,11 +18,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -46,7 +47,7 @@ func HTTPGet(url string) (code int, respBody string, err error) {
 		return 0, "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println(err)
 		return 0, "", err
@@ -59,7 +60,7 @@ func HTTPGet(url string) (code int, respBody string, err error) {
 // HTTPGet send GET
 func HTTPTlsGet(url, rootdir string, port uint16) (code int, respBody string, err error) {
 	certPool := x509.NewCertPool()
-	bs, err := ioutil.ReadFile(filepath.Join(rootdir, "testdata/certs/cert-chain.pem"))
+	bs, err := os.ReadFile(filepath.Join(rootdir, "testdata/certs/cert-chain.pem"))
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to read client ca cert: %s", err)
 	}
@@ -90,7 +91,7 @@ func HTTPTlsGet(url, rootdir string, port uint16) (code int, respBody string, er
 		return 0, "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println(err)
 		return 0, "", err
@@ -110,7 +111,7 @@ func HTTPPost(url string, contentType string, reqBody string) (code int, respBod
 		return 0, "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println(err)
 		return 0, "", err
@@ -133,7 +134,7 @@ func ShortLiveHTTPPost(url string, contentType string, reqBody string) (code int
 		return 0, "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println(err)
 		return 0, "", err
@@ -167,7 +168,7 @@ func HTTPGetWithHeaders(l string, headers map[string]string) (code int, respBody
 		return 0, "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Println(err)
 		return 0, "", err

--- a/test/envoye2e/stackdriver_plugin/sts.go
+++ b/test/envoye2e/stackdriver_plugin/sts.go
@@ -17,7 +17,7 @@ package stackdriverplugin
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"time"
@@ -67,7 +67,7 @@ func (sts *SecureTokenService) ServeHTTP(resp http.ResponseWriter, req *http.Req
 		resp.WriteHeader(http.StatusOK)
 	case path == "/token" && req.Method == http.MethodPost:
 		resp.WriteHeader(http.StatusOK)
-		body, _ := ioutil.ReadAll(req.Body)
+		body, _ := io.ReadAll(req.Body)
 		if string(body) == ExpectedTokenRequest {
 			_, _ = resp.Write([]byte(ExpectedTokenResponse))
 		} else {

--- a/testdata/testdata.gen.go
+++ b/testdata/testdata.gen.go
@@ -13,7 +13,6 @@ package testdata
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -807,7 +806,7 @@ func RestoreAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(_filePath(dir, name), data, info.Mode())
+	err = io.WriteFile(_filePath(dir, name), data, info.Mode())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the go.mod go directive to match that in istio/istio.

Note that there really isn't a need to update this directive. We haven't added anything the needs Go 1.16+ functionality (and not even sure if we need 1.15). 

We do pick up lint errors when specifying a later Go version as there are library deprecations. Note that the changes to fix this lint would require a go 1.16 as the library functions were added in 1.16 (I suspect that leaving the go directive as 1.15 will cause compilation errors trying to access the 1.16 functions).