### PR TITLE
Changes to filters to support ztunnel tcp metrics

### DIFF
--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -223,14 +223,13 @@ flatbuffers::DetachedBuffer extractEmptyNodeFlatBuffer();
 // address access.
 flatbuffers::DetachedBuffer extractLocalNodeFlatBuffer();
 
+// Extract peer metadata from workload labels.
+bool extractPeerMetadataFromWorkloadLabels(std::string workload_labels,
+                                           flatbuffers::FlatBufferBuilder& fbb);
+
 // Extract upstream peer metadata from upstream host metadata.
 // Returns true if the metadata is found in the upstream host metadata.
 bool extractPeerMetadataFromUpstreamHostMetadata(
-    flatbuffers::FlatBufferBuilder& fbb);
-
-// Extract upstream peer metadata from upstream cluster metadata.
-// Returns true if the metadata is found in the upstream cluster metadata.
-bool extractPeerMetadataFromUpstreamClusterMetadata(
     flatbuffers::FlatBufferBuilder& fbb);
 
 // Returns flatbuffer schema for node info.

--- a/src/envoy/metadata_to_peer_node/metadata_to_peer_node.cc
+++ b/src/envoy/metadata_to_peer_node/metadata_to_peer_node.cc
@@ -70,6 +70,11 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
           WorkloadMetadataObject::kSourceMetadataObjectKey);
 
   if (meta_obj == nullptr) {
+    meta_obj = filter_state.getDataReadOnly<WorkloadMetadataObject>(
+        WorkloadMetadataObject::kDestinationMetadataObjectKey);
+  }
+
+  if (meta_obj == nullptr) {
     ENVOY_LOG(trace, "metadata to peer: no metadata object found");
     return Network::FilterStatus::Continue;
   }

--- a/src/envoy/workload_metadata/workload_metadata.cc
+++ b/src/envoy/workload_metadata/workload_metadata.cc
@@ -80,6 +80,20 @@ Network::FilterStatus Filter::onAccept(Network::ListenerFilterCallbacks& cb) {
   ENVOY_LOG(debug, "workload metadata: new connection accepted");
 
   const Network::ConnectionSocket& socket = cb.socket();
+
+  if (socket.connectionInfoProvider().localAddress()->ip()) {
+    std::string dest_ip_addr =
+        socket.connectionInfoProvider().localAddress()->ip()->addressAsString();
+    auto dest_metadata = config_->metadata(dest_ip_addr);
+    if (dest_metadata != nullptr) {
+      cb.filterState().setData(
+          WorkloadMetadataObject::kDestinationMetadataObjectKey, dest_metadata,
+          StreamInfo::FilterState::StateType::ReadOnly,
+          StreamInfo::FilterState::LifeSpan::Request,
+          StreamInfo::FilterState::StreamSharing::None);
+    }
+  }
+
   auto remote_ip =
       socket.connectionInfoProvider().remoteAddress()->ip()->addressAsString();
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR has changes to some stats relates filters to support adding them to ztunnel inbound listener to enable TCP metrics.
The labels of the source workload are being set based on the baggage header received in the tunnel connection request.
The labels of the destination workload (local) are being taken from the workloads metadata mapping retrieved by the workload metadata filter through ECDS.

The changes are using the existing mechanisms.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NA

**Special notes for your reviewer**:

Please notice that I've kept the cluster/host metadata modes in the stats configuration because refactoring the names (to ztunnel/waypoint) will require a sync with a PR on the Istio repo as well.
Changes in this PR shouldn't break the waypoint L7 metrics support or current ambient branch on the Istio repo.