### PR TITLE
authn: network peer identity

### DIFF
--- a/source/extensions/filters/network/istio_authn/BUILD
+++ b/source/extensions/filters/network/istio_authn/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_extension_package",
+    "envoy_proto_library",
+)
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "config_lib",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":config_cc_proto",
+        "@envoy//envoy/common:hashable_interface",
+        "@envoy//envoy/network:filter_interface",
+        "@envoy//envoy/registry",
+        "@envoy//envoy/server:filter_config_interface",
+        "@envoy//envoy/stream_info:filter_state_interface",
+        "@envoy//source/common/common:hash_lib",
+        "@envoy//source/extensions/filters/network/common:factory_base_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "config",
+    srcs = ["config.proto"],
+)

--- a/source/extensions/filters/network/istio_authn/BUILD
+++ b/source/extensions/filters/network/istio_authn/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2018 Istio Authors. All Rights Reserved.
+# Copyright Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/source/extensions/filters/network/istio_authn/config.cc
+++ b/source/extensions/filters/network/istio_authn/config.cc
@@ -1,4 +1,4 @@
-/* Copyright 2018 Istio Authors. All Rights Reserved.
+/* Copyright Istio Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/source/extensions/filters/network/istio_authn/config.cc
+++ b/source/extensions/filters/network/istio_authn/config.cc
@@ -1,0 +1,83 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "source/extensions/filters/network/istio_authn/config.h"
+
+#include "envoy/network/filter.h"
+#include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
+
+#include "source/common/common/hash.h"
+#include "source/extensions/filters/network/istio_authn/config.pb.h"
+#include "source/extensions/filters/network/istio_authn/config.pb.validate.h"
+#include "source/extensions/filters/network/common/factory_base.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace IstioAuthn {
+
+absl::optional<uint64_t> PeerPrincipal::hash() const {
+  return Envoy::HashUtil::xxHash64(principal_);
+}
+
+class IstioAuthnFilter : public Network::ReadFilter {
+public:
+  // Network::ReadFilter
+  Network::FilterStatus onData(Buffer::Instance&, bool) override {
+    return Network::FilterStatus::Continue;
+  }
+  Network::FilterStatus onNewConnection() override {
+    return Network::FilterStatus::Continue;
+  }
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override {
+    Network::Connection& conn = callbacks.connection();
+    const auto ssl = conn.ssl();
+    if (ssl && ssl->peerCertificatePresented()) {
+      for (const std::string& san : ssl->uriSanPeerCertificate()) {
+        if (absl::StartsWith(san, SpiffePrefix)) {
+          conn.streamInfo().filterState()->setData(PeerPrincipalKey, std::make_shared<PeerPrincipal>(san),
+              StreamInfo::FilterState::StateType::ReadOnly,
+              StreamInfo::FilterState::LifeSpan::Connection,
+              StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+          break;
+        }
+      }
+    }
+  }
+};
+
+class IstioAuthnConfigFactory
+    : public Common::FactoryBase<io::istio::network::authn::Config> {
+public:
+  IstioAuthnConfigFactory() : FactoryBase("io.istio.network.authn") {}
+
+private:
+  Network::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const io::istio::network::authn::Config&,
+                                    Server::Configuration::FactoryContext&) override {
+    return [](Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(std::make_shared<IstioAuthnFilter>());
+    };
+  }
+};
+
+REGISTER_FACTORY(IstioAuthnConfigFactory,
+                 Server::Configuration::NamedNetworkFilterConfigFactory);
+
+}  // namespace IstioAuthn
+}  // namespace NetworkFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/network/istio_authn/config.cc
+++ b/source/extensions/filters/network/istio_authn/config.cc
@@ -30,6 +30,7 @@ namespace NetworkFilters {
 namespace IstioAuthn {
 
 absl::optional<uint64_t> PeerPrincipal::hash() const {
+  // XXX: This should really be a cryptographic hash to avoid SAN collision.
   return Envoy::HashUtil::xxHash64(principal_);
 }
 

--- a/source/extensions/filters/network/istio_authn/config.h
+++ b/source/extensions/filters/network/istio_authn/config.h
@@ -1,4 +1,4 @@
-/* Copyright 2018 Istio Authors. All Rights Reserved.
+/* Copyright Istio Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/source/extensions/filters/network/istio_authn/config.h
+++ b/source/extensions/filters/network/istio_authn/config.h
@@ -1,0 +1,43 @@
+/* Copyright 2018 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "envoy/common/hashable.h"
+#include "envoy/stream_info/filter_state.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace IstioAuthn {
+
+constexpr absl::string_view SpiffePrefix("spiffe://");
+constexpr absl::string_view PeerPrincipalKey = "io.istio.peer_principal";
+
+class PeerPrincipal : public StreamInfo::FilterState::Object,
+                      public Hashable {
+public:
+  PeerPrincipal(const std::string& principal) : principal_(principal) {}
+  absl::optional<std::string> serializeAsString() const override { return principal_; }
+  // Envoy::Hashable
+  absl::optional<uint64_t> hash() const override;
+private:
+  const std::string principal_;
+};
+
+}  // namespace IstioAuthn
+}  // namespace NetworkFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/network/istio_authn/config.h
+++ b/source/extensions/filters/network/istio_authn/config.h
@@ -26,14 +26,16 @@ namespace IstioAuthn {
 constexpr absl::string_view SpiffePrefix("spiffe://");
 constexpr absl::string_view PeerPrincipalKey = "io.istio.peer_principal";
 
-class PeerPrincipal : public StreamInfo::FilterState::Object,
-                      public Hashable {
-public:
+class PeerPrincipal : public StreamInfo::FilterState::Object, public Hashable {
+ public:
   PeerPrincipal(const std::string& principal) : principal_(principal) {}
-  absl::optional<std::string> serializeAsString() const override { return principal_; }
+  absl::optional<std::string> serializeAsString() const override {
+    return principal_;
+  }
   // Envoy::Hashable
   absl::optional<uint64_t> hash() const override;
-private:
+
+ private:
   const std::string principal_;
 };
 

--- a/source/extensions/filters/network/istio_authn/config.proto
+++ b/source/extensions/filters/network/istio_authn/config.proto
@@ -1,0 +1,23 @@
+/* Copyright 2020 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package io.istio.network.authn;
+
+// Computes and stores the peer principal as a filter state object
+// `io.istio.peer_principal`. The principal is the first element in the peer
+// certificate URI SAN list with "spiffe://" prefix.
+message Config {}

--- a/source/extensions/filters/network/istio_authn/config.proto
+++ b/source/extensions/filters/network/istio_authn/config.proto
@@ -1,4 +1,4 @@
-/* Copyright 2020 Istio Authors. All Rights Reserved.
+/* Copyright Istio Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/envoy/BUILD
+++ b/src/envoy/BUILD
@@ -34,6 +34,7 @@ envoy_cc_binary(
         "//source/extensions/filters/http/authn:filter_lib",
         "//source/extensions/filters/http/istio_stats",
         "//source/extensions/filters/network/forward_downstream_sni:config_lib",
+        "//source/extensions/filters/network/istio_authn:config_lib",
         "//source/extensions/filters/network/metadata_exchange:config_lib",
         "//source/extensions/filters/network/sni_verifier:config_lib",
         "//source/extensions/filters/network/tcp_cluster_rewrite:config_lib",


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Define a new filter state to carry the peer identity (SPIFFE URI SAN).

This will deprecate the "TLS capture" hack used in ambient, and generalize it for https://github.com/istio/istio/issues/41585.

Future PRs will transition points-of-use to this filter state:
* RBAC will refer to the filter state instead of direct "authenticated principal" from TLS. Ambient uses plaintext when applying RBAC policies, so this is needed. Ref: https://github.com/envoyproxy/envoy/pull/23828.
* Stats will refer to the filter state instead of re-computing the principal. This is needed to make sure policy&telemetry apply to the same principal.
