### PR TITLE
bazel: add --stamp

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -37,7 +37,7 @@ PATH := /usr/lib/llvm-10/bin:$(PATH)
 VERBOSE ?=
 ifeq "$(VERBOSE)" "1"
 BAZEL_STARTUP_ARGS := --client_debug $(BAZEL_STARTUP_ARGS)
-BAZEL_BUILD_ARGS := -s --sandbox_debug --verbose_failures $(BAZEL_BUILD_ARGS)
+BAZEL_BUILD_ARGS := -s --sandbox_debug --verbose_failures --stamp $(BAZEL_BUILD_ARGS)
 endif
 
 ifeq "$(origin WITH_LIBCXX)" "undefined"


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Docker rules require stamp explicitly.