### PR TITLE
Enable QAT PrivateKeyProvider extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -361,6 +361,7 @@ ENVOY_CONTRIB_EXTENSIONS = {
     #
 
     "envoy.tls.key_providers.cryptomb":                         "//contrib/cryptomb/private_key_providers/source:config",
+    "envoy.tls.key_providers.qat":                              "//contrib/qat/private_key_providers/source:config",
 
     #
     # Socket interface extensions
@@ -380,6 +381,7 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.network.sip_proxy",
     "envoy.filters.sip.router",
     "envoy.tls.key_providers.cryptomb",
+    "envoy.tls.key_providers.qat",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +


### PR DESCRIPTION
**What this PR does / why we need it**:
An addition to CryptoMB private key provider extension https://github.com/istio/proxy/pull/3752. 

QAT support in Envoy is merged and available from https://github.com/envoyproxy/envoy/pull/21984. 

Next generation Intel® QAT support with Intel® Xeon® Scalable processors will feature an Intel® QAT cryptography and compression acceleration engine.

QAT private key provider extension will use qatlib library (https://github.com/intel/qatlib) to accelerate RSA operations in handshakes. The extension will look a bit like the existing cryptomb private key provider. The use case is to move the expensive cryptographic operations away from the CPU to the accelerator device, leaving CPU cycles for other use.

Additional Description:
Support for Intel® QAT is already present in the mainline Linux kernel and in Kubernetes device plugins (to expose the device files to containers). There are previous generations of Intel QAT® hardware devices, but they are not supported by this extension.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
