### PR TITLE
stats: change tcp_reporting_duration default to 5s

### DIFF
--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -480,7 +480,7 @@ struct Config : public Logger::Loggable<Logger::Id::filter> {
         disable_host_header_fallback_(
             proto_config.disable_host_header_fallback()),
         report_duration_(PROTOBUF_GET_MS_OR_DEFAULT(
-            proto_config, tcp_reporting_duration, /* 15s */ 15000)) {
+            proto_config, tcp_reporting_duration, /* 5s */ 5000)) {
     reporter_ = Reporter::ClientSidecar;
     switch (proto_config.reporter()) {
       case stats::Reporter::UNSPECIFIED:


### PR DESCRIPTION
Signed-off-by: hejianpeng <hejianpeng2@huawei.com>

follow up https://github.com/istio/istio/pull/41996#discussion_r1022925172

cc @kyessenov 