### PR TITLE
fix: qbone breakage

### DIFF
--- a/testdata/listener/terminate_connect.yaml.tmpl
+++ b/testdata/listener/terminate_connect.yaml.tmpl
@@ -76,7 +76,7 @@ filter_chains:
                 resource_api_version: V3
             validation_context:
               trusted_ca: { filename: "testdata/certs/root.cert" }
-          require_client_certificate: true # XXX: This setting is ignored ATM per @danzh.
+#         require_client_certificate: true # XXX: This setting is ignored ATM per @danzh.
 {{ else }}
     name: tls
     typed_config:


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Envoy denies instead of silently failing now when using mTLS with QUIC.