### PR TITLE
workload-env-default

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -54,7 +54,7 @@ BAZEL_BUILD_RBE_INSTANCE="${BAZEL_BUILD_RBE_INSTANCE-projects/istio-testing/inst
 BAZEL_BUILD_RBE_CACHE="${BAZEL_BUILD_RBE_CACHE-grpcs://remotebuildexecution.googleapis.com}"
 
 METADATA_SERVER_URL="http://169.254.169.254/computeMetadata/v1/instance/service-accounts/"
-WORKLOAD_IDENTITY="istio-prow-test-job@istio-testing.iam.gserviceaccount.com"
+WORKLOAD_IDENTITY="${WORKLOAD_IDENTITY-istio-prow-test-job@istio-testing.iam.gserviceaccount.com}"
 # Use GCP service account when available.
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2


### PR DESCRIPTION
**What this PR does / why we need it**:
Ability to customize the WORKLOAD_IDENTITY ENV variable 
This will make using RBE easier for building proxy on a different google cloud project

