### PR TITLE
[release-1.16] Add stamp

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -37,7 +37,7 @@ PATH := /usr/lib/llvm-10/bin:$(PATH)
 VERBOSE ?=
 ifeq "$(VERBOSE)" "1"
 BAZEL_STARTUP_ARGS := --client_debug $(BAZEL_STARTUP_ARGS)
-BAZEL_BUILD_ARGS := -s --sandbox_debug --verbose_failures $(BAZEL_BUILD_ARGS)
+BAZEL_BUILD_ARGS := -s --sandbox_debug --verbose_failures --stamp $(BAZEL_BUILD_ARGS)
 endif
 
 ifeq "$(origin WITH_LIBCXX)" "undefined"

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -37,7 +37,7 @@ PATH := /usr/lib/llvm-10/bin:$(PATH)
 VERBOSE ?=
 ifeq "$(VERBOSE)" "1"
 BAZEL_STARTUP_ARGS := --client_debug $(BAZEL_STARTUP_ARGS)
-BAZEL_BUILD_ARGS := -s --sandbox_debug --verbose_failures --stamp $(BAZEL_BUILD_ARGS)
+BAZEL_BUILD_ARGS := -s --sandbox_debug --verbose_failures $(BAZEL_BUILD_ARGS)
 endif
 
 ifeq "$(origin WITH_LIBCXX)" "undefined"

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -33,6 +33,9 @@ if [[ "$(uname)" != "Darwin" && "${BAZEL_BUILD_ARGS}" != *"--config=libc++"* ]];
   BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --config=libc++"
 fi
 
+# Expliticly stamp.
+BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --stamp"
+
 if [[ "$(uname)" == "Darwin" ]]; then
   BAZEL_CONFIG_ASAN="--config=macos-asan"
 else


### PR DESCRIPTION
Manually backport #4176 / #4177 to 1.16.
We need stamps with the newer rules_docker. Reference: https://github.com/bazelbuild/rules_docker/blob/48ad6d6df43d1e4b9feeec961995aef01dd72080/README.md?plain=1#L290

This fixes the postsubmit release job failure: https://prow.istio.io/view/gs/istio-prow/logs/release_proxy_release-1.16_postsubmit/1610750069819052032