### PR TITLE
enable DLB connection balance extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -395,6 +395,12 @@ ENVOY_CONTRIB_EXTENSIONS = {
     #
 
     "envoy.bootstrap.vcl":                                      "//contrib/vcl/source:config",
+
+    #
+    # Connection Balance extensions
+    #
+
+    "envoy.network.connection_balance.dlb":                     "//contrib/network/connection_balance/dlb/source:connection_balancer",
 }
 
 
@@ -409,6 +415,7 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.sip.router",
     "envoy.tls.key_providers.cryptomb",
     "envoy.tls.key_providers.qat",
+    "envoy.network.connection_balance.dlb",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

**What this PR does / why we need it**:

It is to enable DLB connection balance extension.

DLB support in Envoy is merged and available from https://github.com/envoyproxy/envoy/pull/20268

Intel® Dynamic Load Balancer (Intel® DLB) is a hardware managed system of queues and arbiters connecting producers and consumers. It is a PCI device envisaged to live in the server CPU uncore and can interact with software running on cores, and potentially with other devices. More details please refer to https://www.intel.com/content/www/us/en/download/686372/intel-dynamic-load-balancer.html.



**Special notes for your reviewer**:

With EnvoyFilter, this feature can work, no more extra integration work in Istio side.