### PR TITLE
telemetry: propagate downstream peer from baggage

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,6 +42,7 @@ envoy_cc_binary(
         "//extensions/stats:stats_plugin",
         "//source/extensions/filters/http/alpn:config_lib",
         "//source/extensions/filters/http/authn:filter_lib",
+        "//source/extensions/filters/http/connect_baggage",
         "//source/extensions/filters/http/istio_stats",
         "//source/extensions/filters/listener/set_internal_dst_address:filter_lib",
         "//source/extensions/filters/network/forward_downstream_sni:config_lib",

--- a/source/extensions/filters/http/connect_baggage/BUILD
+++ b/source/extensions/filters/http/connect_baggage/BUILD
@@ -1,0 +1,47 @@
+# Copyright 2018 Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_extension_package",
+    "envoy_proto_library",
+)
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "connect_baggage",
+    srcs = ["filter.cc"],
+    hdrs = ["filter.h"],
+    repository = "@envoy",
+    deps = [
+        ":config_cc_proto",
+        "//extensions/common:context",
+        "//extensions/common:metadata_object_lib",
+        "@envoy//envoy/registry",
+        "@envoy//source/common/http:header_utility_lib",
+        "@envoy//source/extensions/filters/common/expr:cel_state_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "config",
+    srcs = ["config.proto"],
+)

--- a/source/extensions/filters/http/connect_baggage/config.proto
+++ b/source/extensions/filters/http/connect_baggage/config.proto
@@ -1,0 +1,21 @@
+/* Copyright Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package io.istio.http.connect_baggage;
+
+// Computes and stores the downstream peer metadata from the "baggage" header.
+message Config {}

--- a/source/extensions/filters/http/connect_baggage/filter.cc
+++ b/source/extensions/filters/http/connect_baggage/filter.cc
@@ -1,0 +1,84 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/extensions/filters/http/connect_baggage/filter.h"
+
+#include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
+#include "extensions/common/context.h"
+#include "extensions/common/metadata_object.h"
+#include "source/common/http/header_utility.h"
+#include "source/extensions/filters/common/expr/cel_state.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace ConnectBaggage {
+
+Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
+                                                bool) {
+  const auto header_string = Http::HeaderUtility::getAllOfHeaderAsString(
+      headers, Http::LowerCaseString("baggage"));
+  const auto result = header_string.result();
+  if (result) {
+    const auto metadata_object =
+        Istio::Common::WorkloadMetadataObject::fromBaggage(*result);
+    const auto fb =
+        Istio::Common::convertWorkloadMetadataToFlatNode(metadata_object);
+    {
+      Filters::Common::Expr::CelStatePrototype prototype(
+          true, Filters::Common::Expr::CelStateType::FlatBuffers,
+          toAbslStringView(Wasm::Common::nodeInfoSchema()),
+          StreamInfo::FilterState::LifeSpan::FilterChain);
+      auto state = std::make_unique<Filters::Common::Expr::CelState>(prototype);
+      state->setValue(absl::string_view(
+          reinterpret_cast<const char*>(fb.data()), fb.size()));
+      decoder_callbacks_->streamInfo().filterState()->setData(
+          "wasm.downstream_peer", std::move(state),
+          StreamInfo::FilterState::StateType::Mutable,
+          StreamInfo::FilterState::LifeSpan::FilterChain,
+          StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+    }
+    {
+      Filters::Common::Expr::CelStatePrototype prototype(
+          true, Filters::Common::Expr::CelStateType::String,
+          absl::string_view(), StreamInfo::FilterState::LifeSpan::FilterChain);
+      auto state = std::make_unique<Filters::Common::Expr::CelState>(prototype);
+      state->setValue("unknown");
+      decoder_callbacks_->streamInfo().filterState()->setData(
+          "wasm.downstream_peer_id", std::move(state),
+          StreamInfo::FilterState::StateType::Mutable,
+          StreamInfo::FilterState::LifeSpan::FilterChain,
+          StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+    }
+  }
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterFactoryCb FilterConfigFactory::createFilterFactoryFromProtoTyped(
+    const io::istio::http::connect_baggage::Config&, const std::string&,
+    Server::Configuration::FactoryContext&) {
+  return [](Http::FilterChainFactoryCallbacks& callbacks) {
+    auto filter = std::make_shared<Filter>();
+    callbacks.addStreamFilter(filter);
+  };
+}
+
+REGISTER_FACTORY(FilterConfigFactory,
+                 Server::Configuration::NamedHttpFilterConfigFactory);
+
+}  // namespace ConnectBaggage
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/connect_baggage/filter.h
+++ b/source/extensions/filters/http/connect_baggage/filter.h
@@ -1,0 +1,47 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "source/extensions/filters/http/common/factory_base.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+#include "source/extensions/filters/http/connect_baggage/config.pb.h"
+#include "source/extensions/filters/http/connect_baggage/config.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace ConnectBaggage {
+
+class Filter : public Http::PassThroughFilter {
+ public:
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&,
+                                          bool) override;
+};
+
+class FilterConfigFactory
+    : public Common::FactoryBase<io::istio::http::connect_baggage::Config> {
+ public:
+  FilterConfigFactory() : FactoryBase("envoy.filters.http.connect_baggage") {}
+
+ private:
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const io::istio::http::connect_baggage::Config&, const std::string&,
+      Server::Configuration::FactoryContext&) override;
+};
+
+}  // namespace ConnectBaggage
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/testdata/listener/internal_outbound.yaml.tmpl
+++ b/testdata/listener/internal_outbound.yaml.tmpl
@@ -13,4 +13,8 @@ filter_chains:
       cluster: original_dst
       tunneling_config:
         hostname: host.com:443
+        headers_to_add:
+        - header:
+            key: baggage
+            value: k8s.deployment.name=productpage-v1
       stat_prefix: outbound

--- a/testdata/listener/terminate_connect.yaml.tmpl
+++ b/testdata/listener/terminate_connect.yaml.tmpl
@@ -47,6 +47,10 @@ filter_chains:
                 connect_config:
                   {}
       http_filters:
+      - name: connect_baggage
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/io.istio.http.connect_baggage.Config
       - name: envoy.filters.http.router
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -7,7 +7,7 @@ metric:
   - name: reporter
     value: destination
   - name: source_workload
-    value: unknown
+    value: productpage-v1
   - name: source_canonical_service
     value: unknown
   - name: source_canonical_revision


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Add a filter to convert `baggage` to `wasm.downstream_peer` upstream-shared filter state used by telemetry.