### PR TITLE
StatefulSession: include HeaderBasedSessionState extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -300,6 +300,7 @@ ENVOY_EXTENSIONS = {
     #
 
     "envoy.http.stateful_session.cookie":                "//source/extensions/http/stateful_session/cookie:config",
+    "envoy.http.stateful_session.header":                "//source/extensions/http/stateful_session/header:config",
 
     #
     # QUIC extensions


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR includes a newly added extension for stateful sessions `envoy.extensions.http.stateful_session.header.v3.HeaderBasedSessionState`

**Special notes for your reviewer**:
This is the envoy PR : https://github.com/envoyproxy/envoy/pull/23145/files