### PR TITLE
connect: support passthrough path

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -42,9 +42,10 @@ envoy_cc_binary(
         "//extensions/stats:stats_plugin",
         "//source/extensions/filters/http/alpn:config_lib",
         "//source/extensions/filters/http/authn:filter_lib",
-        "//source/extensions/filters/http/connect_baggage",
+        "//source/extensions/filters/http/connect_authority",  # Experimental: ambient
+        "//source/extensions/filters/http/connect_baggage",  # Experimental: ambient
         "//source/extensions/filters/http/istio_stats",
-        "//source/extensions/filters/listener/set_internal_dst_address:filter_lib",
+        "//source/extensions/filters/listener/set_internal_dst_address:filter_lib",  # Experimental: ambient
         "//source/extensions/filters/network/forward_downstream_sni:config_lib",
         "//source/extensions/filters/network/istio_authn:config_lib",
         "//source/extensions/filters/network/metadata_exchange:config_lib",

--- a/source/extensions/filters/http/connect_authority/BUILD
+++ b/source/extensions/filters/http/connect_authority/BUILD
@@ -1,4 +1,4 @@
-# Copyright Istio Authors. All Rights Reserved.
+# Copyright 2018 Istio Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,33 +13,29 @@
 # limitations under the License.
 #
 ################################################################################
+#
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_extension",
-    "envoy_cc_library",
-    "envoy_cc_test",
     "envoy_extension_package",
     "envoy_proto_library",
 )
 
-licenses(["notice"])  # Apache 2
-
 envoy_extension_package()
 
-envoy_cc_library(
-    name = "filter_lib",
+envoy_cc_extension(
+    name = "connect_authority",
     srcs = ["filter.cc"],
     hdrs = ["filter.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":config_cc_proto",
-        "@envoy//envoy/network:filter_interface",
+        "//source/extensions/filters/listener/set_internal_dst_address:filter_lib",
         "@envoy//envoy/registry",
-        "@envoy//envoy/server:filter_config_interface",
-        "@envoy//source/common/network:filter_state_dst_address_lib",
-        "@envoy//source/common/network:utility_lib",
+        "@envoy//source/common/http:utility_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )
 

--- a/source/extensions/filters/http/connect_authority/config.proto
+++ b/source/extensions/filters/http/connect_authority/config.proto
@@ -1,0 +1,24 @@
+/* Copyright Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package io.istio.http.connect_authority;
+
+// Capture :authority and pass it to the set_original_dst filter state.
+message Config {
+  // To support per-route overrides.
+  bool enabled = 1;
+}

--- a/source/extensions/filters/http/connect_authority/filter.cc
+++ b/source/extensions/filters/http/connect_authority/filter.cc
@@ -16,8 +16,8 @@
 
 #include "envoy/registry/registry.h"
 #include "envoy/server/factory_context.h"
-#include "source/extensions/filters/listener/set_internal_dst_address/filter.h"
 #include "source/common/http/utility.h"
+#include "source/extensions/filters/listener/set_internal_dst_address/filter.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -27,11 +27,13 @@ namespace ConnectAuthority {
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
                                                 bool) {
   const FilterConfig* per_route_settings =
-          Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(decoder_callbacks_);
+      Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(
+          decoder_callbacks_);
   if (per_route_settings && per_route_settings->enabled()) {
     decoder_callbacks_->streamInfo().filterState()->setData(
-        Istio::SetInternalDstAddress::FilterStateKey, 
-        std::make_shared<Istio::SetInternalDstAddress::Authority>(headers.authority()),
+        Istio::SetInternalDstAddress::FilterStateKey,
+        std::make_shared<Istio::SetInternalDstAddress::Authority>(
+            headers.authority()),
         StreamInfo::FilterState::StateType::Mutable,
         StreamInfo::FilterState::LifeSpan::FilterChain,
         StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);

--- a/source/extensions/filters/http/connect_authority/filter.cc
+++ b/source/extensions/filters/http/connect_authority/filter.cc
@@ -1,0 +1,48 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "source/extensions/filters/http/connect_authority/filter.h"
+
+#include "envoy/registry/registry.h"
+#include "envoy/server/factory_context.h"
+#include "source/extensions/filters/listener/set_internal_dst_address/filter.h"
+#include "source/common/http/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace ConnectAuthority {
+
+Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
+                                                bool) {
+  const FilterConfig* per_route_settings =
+          Http::Utility::resolveMostSpecificPerFilterConfig<FilterConfig>(decoder_callbacks_);
+  if (per_route_settings && per_route_settings->enabled()) {
+    decoder_callbacks_->streamInfo().filterState()->setData(
+        Istio::SetInternalDstAddress::FilterStateKey, 
+        std::make_shared<Istio::SetInternalDstAddress::Authority>(headers.authority()),
+        StreamInfo::FilterState::StateType::Mutable,
+        StreamInfo::FilterState::LifeSpan::FilterChain,
+        StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
+  }
+  return Http::FilterHeadersStatus::Continue;
+}
+
+REGISTER_FACTORY(FilterConfigFactory,
+                 Server::Configuration::NamedHttpFilterConfigFactory);
+
+}  // namespace ConnectAuthority
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/connect_authority/filter.h
+++ b/source/extensions/filters/http/connect_authority/filter.h
@@ -1,0 +1,66 @@
+// Copyright Istio Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "source/extensions/filters/http/common/factory_base.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+#include "source/extensions/filters/http/connect_authority/config.pb.h"
+#include "source/extensions/filters/http/connect_authority/config.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace ConnectAuthority {
+
+class FilterConfig : public Router::RouteSpecificFilterConfig {
+public:
+  FilterConfig(const io::istio::http::connect_authority::Config& config) : enabled_(config.enabled()) {}
+  bool enabled() const { return enabled_; }
+private:
+  const bool enabled_;
+};
+
+class Filter : public Http::PassThroughFilter {
+ public:
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&,
+                                          bool) override;
+};
+
+class FilterConfigFactory
+    : public Common::FactoryBase<io::istio::http::connect_authority::Config> {
+ public:
+  FilterConfigFactory() : FactoryBase("envoy.filters.http.connect_authority") {}
+
+ private:
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const io::istio::http::connect_authority::Config& , const std::string&,
+      Server::Configuration::FactoryContext&) override {
+    return [](Http::FilterChainFactoryCallbacks& callbacks) {
+      auto filter = std::make_shared<Filter>();
+      callbacks.addStreamFilter(filter);
+    };
+  }
+  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+      const io::istio::http::connect_authority::Config& config,
+      Envoy::Server::Configuration::ServerFactoryContext& ,
+      ProtobufMessage::ValidationVisitor&) override {
+    return std::make_shared<FilterConfig>(config);
+  }
+};
+
+}  // namespace ConnectAuthority
+}  // namespace HttpFilters
+}  // namespace Extensions
+}  // namespace Envoy

--- a/source/extensions/filters/http/connect_authority/filter.h
+++ b/source/extensions/filters/http/connect_authority/filter.h
@@ -25,10 +25,12 @@ namespace HttpFilters {
 namespace ConnectAuthority {
 
 class FilterConfig : public Router::RouteSpecificFilterConfig {
-public:
-  FilterConfig(const io::istio::http::connect_authority::Config& config) : enabled_(config.enabled()) {}
+ public:
+  FilterConfig(const io::istio::http::connect_authority::Config& config)
+      : enabled_(config.enabled()) {}
   bool enabled() const { return enabled_; }
-private:
+
+ private:
   const bool enabled_;
 };
 
@@ -45,16 +47,17 @@ class FilterConfigFactory
 
  private:
   Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
-      const io::istio::http::connect_authority::Config& , const std::string&,
+      const io::istio::http::connect_authority::Config&, const std::string&,
       Server::Configuration::FactoryContext&) override {
     return [](Http::FilterChainFactoryCallbacks& callbacks) {
       auto filter = std::make_shared<Filter>();
       callbacks.addStreamFilter(filter);
     };
   }
-  Router::RouteSpecificFilterConfigConstSharedPtr createRouteSpecificFilterConfigTyped(
+  Router::RouteSpecificFilterConfigConstSharedPtr
+  createRouteSpecificFilterConfigTyped(
       const io::istio::http::connect_authority::Config& config,
-      Envoy::Server::Configuration::ServerFactoryContext& ,
+      Envoy::Server::Configuration::ServerFactoryContext&,
       ProtobufMessage::ValidationVisitor&) override {
     return std::make_shared<FilterConfig>(config);
   }

--- a/source/extensions/filters/listener/set_internal_dst_address/config.proto
+++ b/source/extensions/filters/listener/set_internal_dst_address/config.proto
@@ -16,4 +16,5 @@ syntax = "proto3";
 
 package istio.set_internal_dst_address.v1;
 
+// Set local address from the filter state or the dynamic metadata.
 message Config {};

--- a/source/extensions/filters/listener/set_internal_dst_address/filter.h
+++ b/source/extensions/filters/listener/set_internal_dst_address/filter.h
@@ -15,9 +15,20 @@
 #pragma once
 
 #include "envoy/network/filter.h"
+#include "envoy/stream_info/filter_state.h"
 
 namespace Istio {
 namespace SetInternalDstAddress {
+
+const absl::string_view FilterStateKey = "istio.set_internal_dst_address";
+
+struct Authority : public Envoy::StreamInfo::FilterState::Object {
+  Authority(absl::string_view value) : value_(value) {}
+  absl::optional<std::string> serializeAsString() const override {
+    return value_;
+  }
+  const std::string value_;
+};
 
 class Filter : public Envoy::Network::ListenerFilter,
                public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {

--- a/test/envoye2e/driver/check.go
+++ b/test/envoye2e/driver/check.go
@@ -33,6 +33,8 @@ const (
 type HTTPCall struct {
 	// Method
 	Method string
+	// Authority override
+	Authority string
 	// URL path
 	Path string
 	// Port specifies the port in 127.0.0.1:PORT
@@ -51,7 +53,7 @@ type HTTPCall struct {
 	DisableRedirect bool
 }
 
-func Get(port uint16, body string) Step {
+func Get(port uint16, body string) *HTTPCall {
 	return &HTTPCall{
 		Method: http.MethodGet,
 		Port:   port,
@@ -70,6 +72,9 @@ func (g *HTTPCall) Run(_ *Params) error {
 	}
 	for key, val := range g.RequestHeaders {
 		req.Header.Add(key, val)
+	}
+	if len(g.Authority) > 0 {
+		req.Host = g.Authority
 	}
 	dump, _ := httputil.DumpRequest(req, false)
 	log.Printf("HTTP request:\n%s", string(dump))

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -33,6 +33,8 @@ func init() {
 			"TestBasicTCPFlow",
 			"TestBasicCONNECT/quic",
 			"TestBasicCONNECT/h2",
+			"TestPassthroughCONNECT/quic",
+			"TestPassthroughCONNECT/h2",
 			"TestHTTPExchange",
 			"TestHTTPLocalRatelimit",
 			"TestStackdriverAccessLog/AllClientErrorRequestsGetsLoggedOnNoMxAndError",

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -702,6 +702,7 @@ func TestStatsServerWaypointProxyCONNECT(t *testing.T) {
 	params.Vars["ServerInternalAddress"] = "internal_inbound"
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_waypoint_proxy_node_metadata.json.tmpl")
 	params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
+	params.Vars["EnableTunnelEndpointMetadata"] = "true"
 
 	if err := (&driver.Scenario{
 		Steps: []driver.Step{

--- a/testdata/cluster/internal_outbound.yaml.tmpl
+++ b/testdata/cluster/internal_outbound.yaml.tmpl
@@ -7,11 +7,12 @@ load_assignment:
         address:
           envoy_internal_address:
             server_listener_name: internal_outbound
+{{- if eq .Vars.EnableTunnelEndpointMetadata "true" }}
       metadata:
         filter_metadata:
           tunnel:
-            address: 127.0.0.1:{{ .Ports.ServerTunnelPort }}
             destination: 127.0.0.1:{{ .Ports.ServerPort }}
+{{- end }}
 transport_socket:
   name: envoy.transport_sockets.internal_upstream
   typed_config:

--- a/testdata/cluster/original_dst.yaml.tmpl
+++ b/testdata/cluster/original_dst.yaml.tmpl
@@ -2,6 +2,8 @@ name: original_dst
 type: ORIGINAL_DST
 cleanup_interval: 1s
 lb_policy: CLUSTER_PROVIDED
+original_dst_lb_config:
+  upstream_port_override: {{ .Ports.ServerTunnelPort }}
 typed_extension_protocol_options:
   envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
     '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions

--- a/testdata/listener/client_passthrough.yaml.tmpl
+++ b/testdata/listener/client_passthrough.yaml.tmpl
@@ -1,0 +1,38 @@
+name: client
+traffic_direction: OUTBOUND
+address:
+  socket_address:
+    address: 127.0.0.1
+    port_value: {{ .Ports.ClientPort }}
+filter_chains:
+- filters:
+  - name: http
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+      codec_type: AUTO
+      stat_prefix: client
+      http_filters:
+      - name: connect_authority
+        typed_config:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/io.istio.http.connect_authority.Config
+      - name: envoy.filters.http.router
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      route_config:
+        name: client
+        virtual_hosts:
+        - name: client
+          domains: ["*"]
+          routes:
+          - name: client_route
+            match: { prefix: / }
+            typed_per_filter_config:
+              connect_authority:
+                "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                type_url: type.googleapis.com/io.istio.http.connect_authority.Config
+                value:
+                  enabled: true
+            route:
+              cluster: internal_outbound
+              timeout: 0s

--- a/testdata/listener/internal_outbound.yaml.tmpl
+++ b/testdata/listener/internal_outbound.yaml.tmpl
@@ -12,7 +12,7 @@ filter_chains:
       "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
       cluster: original_dst
       tunneling_config:
-        hostname: host.com:443
+        hostname: "%DOWNSTREAM_LOCAL_ADDRESS%"
         headers_to_add:
         - header:
             key: baggage


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Allow a passthrough HTTP CONNECT path: 
```
(terminate CONNECT with IP:PORT authority) -> (initiate CONNECT with the same IP:PORT in authority to IP:TUNNEL_PORT)
```

This is needed to have a generic path for pods behind a waypoint.