### PR TITLE
connect: share authority twice

### DIFF
--- a/source/extensions/filters/http/connect_authority/filter.cc
+++ b/source/extensions/filters/http/connect_authority/filter.cc
@@ -33,7 +33,7 @@ Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers,
         std::make_shared<Istio::SetInternalDstAddress::Authority>(headers.getHostValue(),
                                                                   per_route_settings->port()),
         StreamInfo::FilterState::StateType::Mutable, StreamInfo::FilterState::LifeSpan::FilterChain,
-        StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnectionOnce);
+        StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
   }
   return Http::FilterHeadersStatus::Continue;
 }


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Make authority propagate through another "passthrough pod" internal listener for HTTP policy&telemetry.