### PR TITLE
istio_authn: share multiple times

### DIFF
--- a/source/extensions/filters/network/istio_authn/config.cc
+++ b/source/extensions/filters/network/istio_authn/config.cc
@@ -63,7 +63,7 @@ void IstioAuthnFilter::populate() const {
             PeerPrincipalKey, std::make_shared<Principal>(san),
             StreamInfo::FilterState::StateType::ReadOnly,
             StreamInfo::FilterState::LifeSpan::Connection,
-            StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnectionOnce);
+            StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
         break;
       }
     }
@@ -73,7 +73,7 @@ void IstioAuthnFilter::populate() const {
             LocalPrincipalKey, std::make_shared<Principal>(san),
             StreamInfo::FilterState::StateType::ReadOnly,
             StreamInfo::FilterState::LifeSpan::Connection,
-            StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnectionOnce);
+            StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnection);
         break;
       }
     }


### PR DESCRIPTION
This is needed to sync ambient branch with master. While there is another PR doing this its also changing a bunch of other things, so to just have a minimal "sync to master" this is needed because we need to pass through multiple listener hops.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
