### PR TITLE
connect_authority: always hash shared state

### DIFF
--- a/source/extensions/filters/http/connect_authority/BUILD
+++ b/source/extensions/filters/http/connect_authority/BUILD
@@ -36,6 +36,7 @@ envoy_cc_extension(
         "@envoy//source/common/http:utility_lib",
         "@envoy//source/extensions/filters/http/common:factory_base_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@envoy//source/extensions/filters/network/common:factory_base_lib",
     ],
 )
 

--- a/source/extensions/filters/http/connect_authority/config.proto
+++ b/source/extensions/filters/http/connect_authority/config.proto
@@ -22,5 +22,6 @@ message Config {
   // To support per-route overrides.
   bool enabled = 1;
   // Tunnel port for the override.
+  // Default value 0 implies the port is obtained from the authority.
   uint32 port = 2;
 }

--- a/source/extensions/filters/listener/set_internal_dst_address/BUILD
+++ b/source/extensions/filters/listener/set_internal_dst_address/BUILD
@@ -35,9 +35,11 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         ":config_cc_proto",
+        "@envoy//envoy/common:hashable_interface",
         "@envoy//envoy/network:filter_interface",
         "@envoy//envoy/registry",
         "@envoy//envoy/server:filter_config_interface",
+        "@envoy//source/common/common:hash_lib",
         "@envoy//source/common/network:filter_state_dst_address_lib",
         "@envoy//source/common/network:utility_lib",
     ],

--- a/source/extensions/filters/listener/set_internal_dst_address/filter.h
+++ b/source/extensions/filters/listener/set_internal_dst_address/filter.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "envoy/common/hashable.h"
 #include "envoy/network/filter.h"
 #include "envoy/stream_info/filter_state.h"
 
@@ -22,10 +23,13 @@ namespace SetInternalDstAddress {
 
 const absl::string_view FilterStateKey = "istio.set_internal_dst_address";
 
-struct Authority : public Envoy::StreamInfo::FilterState::Object {
+struct Authority : public Envoy::StreamInfo::FilterState::Object, public Envoy::Hashable {
   Authority(absl::string_view value, uint32_t port) : value_(value), port_(port) {}
   absl::optional<std::string> serializeAsString() const override { return value_; }
+  absl::optional<uint64_t> hash() const override;
+
   const std::string value_;
+  // Default value 0 implies no port is overriden from the authority.
   const uint32_t port_;
 };
 

--- a/source/extensions/filters/network/istio_authn/config.cc
+++ b/source/extensions/filters/network/istio_authn/config.cc
@@ -28,7 +28,7 @@ namespace IstioAuthn {
 
 absl::optional<uint64_t> Principal::hash() const {
   // XXX: This should really be a cryptographic hash to avoid SAN collision.
-  return Envoy::HashUtil::xxHash64(principal_);
+  return HashUtil::xxHash64(principal_);
 }
 
 PrincipalInfo getPrincipals(const StreamInfo::FilterState& filter_state) {

--- a/test/envoye2e/basic_flow/basic_test.go
+++ b/test/envoye2e/basic_flow/basic_test.go
@@ -219,11 +219,13 @@ func TestPassthroughCONNECT(t *testing.T) {
 			updateClient := &driver.Update{
 				Node: "client", Version: "{{ .N }}",
 				Clusters: []string{
+					driver.LoadTestData("testdata/cluster/tcp_passthrough.yaml.tmpl"),
 					driver.LoadTestData("testdata/cluster/internal_outbound.yaml.tmpl"),
 					driver.LoadTestData("testdata/cluster/original_dst.yaml.tmpl"),
 				},
 				Listeners: []string{
 					driver.LoadTestData("testdata/listener/client_passthrough.yaml.tmpl"),
+					driver.LoadTestData("testdata/listener/tcp_passthrough.yaml.tmpl"),
 					driver.LoadTestData("testdata/listener/internal_outbound.yaml.tmpl"),
 				},
 				Secrets: []string{

--- a/testdata/cluster/tcp_passthrough.yaml.tmpl
+++ b/testdata/cluster/tcp_passthrough.yaml.tmpl
@@ -1,0 +1,17 @@
+name: tcp_passthrough
+load_assignment:
+  cluster_name: tcp_passthrough
+  endpoints:
+  - lb_endpoints:
+    - endpoint:
+        address:
+          envoy_internal_address:
+            server_listener_name: tcp_passthrough
+transport_socket:
+  name: envoy.transport_sockets.internal_upstream
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.transport_sockets.internal_upstream.v3.InternalUpstreamTransport
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer

--- a/testdata/listener/client_passthrough.yaml.tmpl
+++ b/testdata/listener/client_passthrough.yaml.tmpl
@@ -35,5 +35,5 @@ filter_chains:
                   enabled: true
                   port: {{ .Ports.ServerTunnelPort }}
             route:
-              cluster: internal_outbound
+              cluster: tcp_passthrough
               timeout: 0s

--- a/testdata/listener/tcp_passthrough.yaml.tmpl
+++ b/testdata/listener/tcp_passthrough.yaml.tmpl
@@ -1,0 +1,18 @@
+name: tcp_passthrough
+internal_listener: {}
+listener_filters:
+- name: set_dst_address
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: type.googleapis.com/istio.set_internal_dst_address.v1.Config
+filter_chains:
+- filters:
+  - name: connect_authority
+    typed_config:
+      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+      type_url: type.googleapis.com/io.istio.http.connect_authority.Config
+  - name: tcp_proxy
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+      cluster: internal_outbound
+      stat_prefix: tcp_passthrough


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

Fixes https://github.com/istio/istio/issues/43238.

* Share once and re-share explicitly to better control pooling.
* Add default value for port to mean preserve authority port.