### PR TITLE
istio_authn: only share for tunneling

### DIFF
--- a/source/extensions/filters/network/istio_authn/config.h
+++ b/source/extensions/filters/network/istio_authn/config.h
@@ -58,6 +58,9 @@ PrincipalInfo getPrincipals(const StreamInfo::FilterState& filter_state);
 // socket option at the moment.
 class IstioAuthnFilter : public Network::ReadFilter, public Network::ConnectionCallbacks {
 public:
+  IstioAuthnFilter(bool shared)
+      : shared_(shared ? StreamInfo::FilterState::StreamSharing::SharedWithUpstreamConnectionOnce
+                       : StreamInfo::FilterState::StreamSharing::None) {}
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
   void onAboveWriteBufferHighWatermark() override {}
@@ -72,6 +75,7 @@ public:
 
 private:
   void populate() const;
+  const StreamInfo::FilterState::StreamSharing shared_;
   Network::ReadFilterCallbacks* read_callbacks_{nullptr};
 };
 

--- a/source/extensions/filters/network/istio_authn/config.proto
+++ b/source/extensions/filters/network/istio_authn/config.proto
@@ -23,4 +23,7 @@ package io.istio.network.authn;
 // list with the "spiffe://" prefix. The principals are populated downstream
 // only if the peer certificate is presented.
 message Config {
+  // Share the filter state with the upstream connections. This is meant to be
+  // used in the tunnel listeners.
+  bool shared = 1;
 }

--- a/testdata/listener/terminate_connect.yaml.tmpl
+++ b/testdata/listener/terminate_connect.yaml.tmpl
@@ -22,6 +22,8 @@ filter_chains:
     typed_config:
       "@type": type.googleapis.com/udpa.type.v1.TypedStruct
       type_url: type.googleapis.com/io.istio.network.authn.Config
+      value:
+        shared: true
 {{ end }}
   - name: envoy.filters.network.http_connection_manager
     typed_config:


### PR DESCRIPTION
After https://github.com/istio/istio/pull/42031, this filter is enabled for sidecar inbound.

Shared state with the upstream connections causes extra connection pools created per downstream identity. This hurts efficiency since sidecars cannot re-use pools and adds latency to create new connections.

This change restricts sharing only to the tunneling listeners.