### PR TITLE
make: use bazel info bin path for exportcache

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -203,9 +203,9 @@ push_release_centos:
 # Used by build container to export the build output from the docker volume cache
 exportcache:
 	@mkdir -p /work/out/$(TARGET_OS)_$(TARGET_ARCH)
-	@cp -a /work/bazel-bin/envoy /work/out/$(TARGET_OS)_$(TARGET_ARCH)
+	@cp -a $(BAZEL_BIN_PATH)/envoy /work/out/$(TARGET_OS)_$(TARGET_ARCH)
 	@chmod +w /work/out/$(TARGET_OS)_$(TARGET_ARCH)/envoy
-	@cp -a /work/bazel-bin/**/*wasm /work/out/$(TARGET_OS)_$(TARGET_ARCH) &> /dev/null || true
+	@cp -a $(BAZEL_BIN_PATH)/**/*wasm /work/out/$(TARGET_OS)_$(TARGET_ARCH) &> /dev/null || true
 
 .PHONY: build clean test check extensions-proto
 


### PR DESCRIPTION
Avoid making assumptions about bazel-bin path and honor the source of truth from bazel info commaand.

**What this PR does / why we need it**:

`/work/bazel-bin` doesn't always exist inside the container (e.g. when $XDG_CACHE_HOME is set to leverage external cache)

```
BUILD_WITH_CONTAINER=1 DOCKER_RUN_OPTIONS="-v ${XDG_CACHE_HOME}:${XDG_CACHE_HOME}" make shell
```

This small change tries to avoid making assumptions and takess bazel info result (that already exists in Makefile) as source of truth.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

N/A
