### PR TITLE
Enable Hyperscan input matcher and regex engine extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -418,6 +418,18 @@ ENVOY_CONTRIB_EXTENSIONS = {
     #
 
     "envoy.network.connection_balance.dlb":                     "//contrib/network/connection_balance/dlb/source:connection_balancer",
+
+    #
+    # Input matchers
+    #
+
+    "envoy.matching.input_matchers.hyperscan":                  "//contrib/hyperscan/matching/input_matchers/source:config",
+
+    #
+    # Regex engines
+    #
+
+    "envoy.regex_engines.hyperscan":                            "//contrib/hyperscan/regex_engines/source:config",
 }
 
 
@@ -435,6 +447,8 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.tls.key_providers.cryptomb",
     "envoy.tls.key_providers.qat",
     "envoy.network.connection_balance.dlb",
+    "envoy.matching.input_matchers.hyperscan",
+    "envoy.regex_engines.hyperscan",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up of #4495. Current version of Hyperscan is compatible to both Clang 14 (Envoy CI) and Clang 12 (Istio CI).

Enable Hyperscan input matcher and regex engine extension.

Hyperscan support in Envoy is merged and available from envoyproxy/envoy#21973

[Hyperscan](https://github.com/intel/hyperscan) is a high-performance multiple regex matching library, using hybrid automata techniques to allow simultaneous matching of large numbers of regular expressions across streams of data, which can be used in situations with large quantities of regex including router and WAF.

**Special notes for your reviewer:**

Hyperscan regex engine can be enabled with custom bootstrap config.
