### PR TITLE
Fix sha used in go-control-plane for release-1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cloud.google.com/go/trace v1.4.0
 	github.com/cncf/xds/go v0.0.0-20221128185840-c261a164b73d
 	github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263
-	github.com/envoyproxy/go-control-plane v0.11.1-0.20230414193417-178e253923d1
+	github.com/envoyproxy/go-control-plane v0.11.1-0.20230416233444-7f2a3030ef40
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/prometheus/client_model v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/d4l3k/messagediff v1.2.2-0.20180726183240-b9e99b2f9263/go.mod h1:Oozb
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.11.1-0.20230414193417-178e253923d1 h1:wxoobdPX0T8IQu8oDg5Ngly1PccEwd+O3Q0RsDWfx58=
-github.com/envoyproxy/go-control-plane v0.11.1-0.20230414193417-178e253923d1/go.mod h1:84cjSkVxFD9Pi/gvI5AOq5NPhGsmS8oPsJLtCON6eK8=
+github.com/envoyproxy/go-control-plane v0.11.1-0.20230416233444-7f2a3030ef40 h1:JnNQ7Wd0TQAqFM+VrrCldFMixZTsssnucjKWY1zt9Oc=
+github.com/envoyproxy/go-control-plane v0.11.1-0.20230416233444-7f2a3030ef40/go.mod h1:84cjSkVxFD9Pi/gvI5AOq5NPhGsmS8oPsJLtCON6eK8=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.9.1 h1:PS7VIOgmSVhWUEeZwTe7z7zouA22Cr590PzXKbZHOVY=
 github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0++PMirau2/yoOwVac3AbF2w=


### PR DESCRIPTION
Update sha to the last update before envoy 1.26 branched