### PR TITLE
Remove extraneous release-binary option

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -183,8 +183,6 @@ endif
 test_release_centos:
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS) $(CENTOS_BUILD_ARGS)" BUILD_ENVOY_BINARY_ONLY=1 BASE_BINARY_NAME=envoy-centos && ./scripts/release-binary.sh -c
 
-PUSH_RELEASE_FLAGS ?= -p
-
 push_release:
 ifeq "$(shell uname -m)" "x86_64"
 	export PATH=$(PATH) CC=$(CC) CXX=$(CXX) BAZEL_BUILD_ARGS="$(BAZEL_BUILD_ARGS)" && ./scripts/release-binary.sh -d "$(RELEASE_GCS_PATH)" ${PUSH_RELEASE_FLAGS}

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -66,7 +66,7 @@ function usage() {
   exit 1
 }
 
-while getopts d:ipc arg ; do
+while getopts d:ic arg ; do
   case "${arg}" in
     d) DST="${OPTARG}";;
     i) CHECK=0;;


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `release_proxy_postsubmit` and `release-arm64_proxy_postsubmit`job failures.
```
+ getopts d:ipc arg
+ case "${arg}" in
+ usage
+ echo './scripts/release-binary.sh
    -d  The bucket name to store proxy binary (optional).
        If not provided, both envoy binary push and docker image push are skipped.
    -i  Skip Ubuntu Xenial check. DO NOT USE THIS FOR RELEASED BINARIES.
    -c  Build for CentOS releases. This will disable the Ubuntu Xenial check.'
./scripts/release-binary.sh
    -d  The bucket name to store proxy binary (optional).
        If not provided, both envoy binary push and docker image push are skipped.
    -i  Skip Ubuntu Xenial check. DO NOT USE THIS FOR RELEASED BINARIES.
    -c  Build for CentOS releases. This will disable the Ubuntu Xenial check.
+ exit 1
```

PR #4748 removed the -p pushing option from the release-binary.sh script. The -p option was not removed in the Makefile.core.mk. This PR removes setting that option which causes the failure.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
