### PR TITLE
enable network golang filter extension

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -411,6 +411,7 @@ ENVOY_CONTRIB_EXTENSIONS = {
     #
 
     "envoy.filters.network.client_ssl_auth":                    "//contrib/client_ssl_auth/filters/network/source:config",
+    "envoy.filters.network.golang":                             "//contrib/golang/filters/network/source:config",
     "envoy.filters.network.kafka_broker":                       "//contrib/kafka/filters/network/source:kafka_broker_config_lib",
     "envoy.filters.network.kafka_mesh":                         "//contrib/kafka/filters/network/source/mesh:config_lib",
     "envoy.filters.network.mysql_proxy":                        "//contrib/mysql_proxy/filters/network/source:config",
@@ -452,6 +453,7 @@ ISTIO_DISABLED_EXTENSIONS = [
 
 ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.http.golang",
+    "envoy.filters.network.golang",
     "envoy.filters.network.mysql_proxy",
     "envoy.filters.network.postgres_proxy",
     "envoy.filters.network.sip_proxy",


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable network golang filter from contrib image

This allows to easily write custom golang network filters and extend the functionality of proxy at L4. A similar filter for L7 is already included in istio/proxy image (#4463 )