### PR TITLE
build: fix RBE enablement

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -64,35 +64,21 @@ export BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-0}"
 BAZEL_BUILD_RBE_INSTANCE="${BAZEL_BUILD_RBE_INSTANCE-projects/istio-testing/instances/default_instance}"
 BAZEL_BUILD_RBE_CACHE="${BAZEL_BUILD_RBE_CACHE-grpcs://remotebuildexecution.googleapis.com}"
 
-METADATA_SERVER_URL="http://169.254.169.254/computeMetadata/v1/instance/service-accounts/"
-WORKLOAD_IDENTITY="${WORKLOAD_IDENTITY-istio-prow-test-job@istio-testing.iam.gserviceaccount.com}"
+CREDS="google_default_credentials"
 # Use GCP service account when available.
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-  echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
+  echo "Using legacy GOOGLE_APPLICATION_CREDENTIALS. Move to workload identity!" >&2
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+  CREDS="google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
 
-  # Use RBE when logged in.
-  BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-200}"
-  if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
-    if [[ "${BAZEL_BUILD_RBE_JOBS}" -gt 0 ]]; then
-      echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (execute)"
-      export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --google_credentials=${GOOGLE_APPLICATION_CREDENTIALS} --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
-    elif [[ -n "${BAZEL_BUILD_RBE_CACHE}" ]]; then
-      echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (cache)"
-      export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --google_credentials=${GOOGLE_APPLICATION_CREDENTIALS} --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --remote_cache=${BAZEL_BUILD_RBE_CACHE}"
-    fi
-  fi
-elif gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep "${WORKLOAD_IDENTITY}"; then
-  echo "Detected GKE workload identity" >&2
-
-  BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-200}"
-  if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
-    if [[ "${BAZEL_BUILD_RBE_JOBS}" -gt 0 ]]; then
-      echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (execute)"
-      export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --google_default_credentials --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
-    elif [[ -n "${BAZEL_BUILD_RBE_CACHE}" ]]; then
-      echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (cache)"
-      export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --google_default_credentials --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --remote_cache=${BAZEL_BUILD_RBE_CACHE}"
-    fi
+BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-200}"
+if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
+  if [[ "${BAZEL_BUILD_RBE_JOBS}" -gt 0 ]]; then
+    echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (execute)"
+    export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --${CREDS} --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
+  elif [[ -n "${BAZEL_BUILD_RBE_CACHE}" ]]; then
+    echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (cache)"
+    export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --${CREDS} --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --remote_cache=${BAZEL_BUILD_RBE_CACHE}"
   fi
 fi


### PR DESCRIPTION
The old logic was very fragile. It relied either on legacy/insecure SA
key, or a *specific* account being used with WI.

We switched which account we use for WI, causing it to disable WI.

I don't think we need this subtlety. We already allow opting out of RBE
by the `BAZEL_BUILD_RBE_INSTANCE` variable -- which we already set when
we want to opt out -- so this should be fine. Additionally, the places
we don't want RBE (our private infra) do not have access to RBE, so if
they somehow tried to use it they would fail.

This simplifies the logic, and should re-enable RBE again
