### PR TITLE
Disable CPU limit

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -31,7 +31,7 @@ GOPATH=/home/prow/go
 ROOT=/go/src
 
 # Configure available resources and disable IPv6 tests.
-export BAZEL_BUILD_ARGS="--local_ram_resources=12288 --local_cpu_resources=8 --verbose_failures --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
+export BAZEL_BUILD_ARGS="--verbose_failures --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
 
 # Override envoy.
 if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_PREFIX:-}" ]]; then


### PR DESCRIPTION
Currently we give each job limit=64 CPUs but then tell Bazel to limit to 8 cores. I think it will be much faster if we remove the limit..?