### PR TITLE
metadata_exchange: stop waiting for data when upstream closes

### DIFF
--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
@@ -107,7 +107,7 @@ Network::FilterStatus MetadataExchangeFilter::onData(Buffer::Instance& data, boo
         // Upstream has entered a half-closed state, and will be sending no more data.
         // Since this plugin would expect additional headers, but none is forthcoming,
         // do not block the tcp_proxy downstream of us from draining the buffer.
-        ENVOY_LOG(warn, "Upstream closed early, aborting istio-peer-exchange");
+        ENVOY_LOG(debug, "Upstream closed early, aborting istio-peer-exchange");
         conn_state_ = Invalid;
         return Network::FilterStatus::Continue;
       }

--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
@@ -69,7 +69,7 @@ MetadataExchangeConfig::MetadataExchangeConfig(const std::string& stat_prefix,
     : scope_(scope), stat_prefix_(stat_prefix), protocol_(protocol),
       filter_direction_(filter_direction), stats_(generateStats(stat_prefix, scope)) {}
 
-Network::FilterStatus MetadataExchangeFilter::onData(Buffer::Instance& data, bool) {
+Network::FilterStatus MetadataExchangeFilter::onData(Buffer::Instance& data, bool end_stream) {
   switch (conn_state_) {
   case Invalid:
     FALLTHRU;
@@ -103,6 +103,14 @@ Network::FilterStatus MetadataExchangeFilter::onData(Buffer::Instance& data, boo
   case NeedMoreDataInitialHeader: {
     tryReadInitialProxyHeader(data);
     if (conn_state_ == NeedMoreDataInitialHeader) {
+      if (end_stream) {
+        // Upstream has entered a half-closed state, and will be sending no more data.
+        // Since this plugin would expect additional headers, but none is forthcoming,
+        // do not block the tcp_proxy downstream of us from draining the buffer.
+        ENVOY_LOG(warn, "Upstream closed early, aborting istio-peer-exchange");
+        conn_state_ = Invalid;
+        return Network::FilterStatus::Continue;
+      }
       return Network::FilterStatus::StopIteration;
     }
     if (conn_state_ == Invalid) {

--- a/test/envoye2e/driver/tcp.go
+++ b/test/envoye2e/driver/tcp.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -131,3 +132,89 @@ func (t *TCPConnection) Run(p *Params) error {
 }
 
 func (t *TCPConnection) Cleanup() {}
+
+// TCPServerAcceptAndClose implements a TCP server
+// which accepts the data and then closes the connection
+// immediately without any response.
+//
+// The exception from this description is the "ping" data
+// which is handled differently for checking if the server
+// is already up.
+type TCPServerAcceptAndClose struct {
+	lis net.Listener
+}
+
+var _ Step = &TCPServerAcceptAndClose{}
+
+func (t *TCPServerAcceptAndClose) Run(p *Params) error {
+	var err error
+	t.lis, err = net.Listen("tcp", fmt.Sprintf(":%d", p.Ports.BackendPort))
+	if err != nil {
+		return fmt.Errorf("failed to listen on %v", err)
+	}
+	go t.serve()
+	if err = waitForTCPServer(p.Ports.BackendPort); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *TCPServerAcceptAndClose) Cleanup() {
+	t.lis.Close()
+}
+
+func (t *TCPServerAcceptAndClose) serve() {
+	for {
+		conn, err := t.lis.Accept()
+		if err != nil {
+			return
+		}
+
+		go t.handleConnection(conn)
+	}
+}
+
+func (t *TCPServerAcceptAndClose) handleConnection(conn net.Conn) {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	bytes, err := reader.ReadString('\n')
+	if err != nil {
+		if err != io.EOF {
+			log.Println("failed to read data, err:", err)
+		}
+		return
+	}
+	bytes = strings.TrimSpace(bytes)
+	if strings.HasSuffix(bytes, "ping") {
+		log.Println("pinged - the TCP Server is available")
+		_, _ = conn.Write([]byte("alive\n"))
+	}
+	log.Println("received data. Closing the connection")
+}
+
+// InterceptedTCPConnection is a connection which expects
+// the terminated connection (before the timeout occurs)
+type InterceptedTCPConnection struct {
+	ReadTimeout time.Duration
+}
+
+var _ Step = &InterceptedTCPConnection{}
+
+func (t *InterceptedTCPConnection) Run(p *Params) error {
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", p.Ports.ClientPort))
+	if err != nil {
+		return fmt.Errorf("failed to connect to tcp server: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "some data"+"\n")
+	conn.SetReadDeadline(time.Now().Add(t.ReadTimeout))
+
+	_, err = bufio.NewReader(conn).ReadString('\n')
+	if err != io.EOF {
+		return errors.New("the connection should be terminated")
+	}
+	return nil
+}
+
+func (t *InterceptedTCPConnection) Cleanup() {}

--- a/test/envoye2e/driver/tcp.go
+++ b/test/envoye2e/driver/tcp.go
@@ -208,7 +208,10 @@ func (t *InterceptedTCPConnection) Run(p *Params) error {
 	defer conn.Close()
 
 	fmt.Fprintf(conn, "some data"+"\n")
-	conn.SetReadDeadline(time.Now().Add(t.ReadTimeout))
+	err = conn.SetReadDeadline(time.Now().Add(t.ReadTimeout))
+	if err != nil {
+		return fmt.Errorf("failed to set read deadline: %v", err)
+	}
 
 	_, err = bufio.NewReader(conn).ReadString('\n')
 	if err != io.EOF {

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -89,6 +89,7 @@ func init() {
 			"TestStatsExpiry",
 			"TestTCPMetadataExchange",
 			"TestTCPMetadataExchangeNoAlpn",
+			"TestTCPMetadataExchangeWithConnectionTermination",
 			"TestOtelPayload",
 		},
 	}


### PR DESCRIPTION
This fixes a bug found in a test environment when the upstream TCP server is starting up and the server sidecar receives a connection too early (possible if there is no k8s startupProbe defined, for instance). In such a case, the server sidecar should reset the TLS connection (2) once the SNI is parsed. This should normally cause the client connection to close as well, but in some cases the connection (1) would hang instead.
client -(1)-> sidecar -(2)-> sidecar -> -(3)-> server

This was observed only with TLS1.3 connections. With TLS1.2, the upstream reset would abort filter processing during the handshake, whereas with TLS1.3 the metadata_exchange filter was allowed to send data into the upstream buffer and move its state machine forward.

The reproducer included in this PR uses a slightly different mechanism to reliably trigger the issue, since the real-world reproduction is timing/latency dependent.
