### PR TITLE
metadata_exchange: fix layered TCP/HTTP write conflict

### DIFF
--- a/extensions/common/context.cc
+++ b/extensions/common/context.cc
@@ -347,7 +347,7 @@ PeerNodeInfo::PeerNodeInfo(const std::string_view peer_metadata_id_key,
                            const std::string_view peer_metadata_key) {
   // Attempt to read from filter_state first.
   found_ = getValue({peer_metadata_id_key}, &peer_id_);
-  if (found_ && peer_id_ != kMetadataNotFoundValue) {
+  if (found_) {
     if (getValue({peer_metadata_key}, &peer_node_)) {
       return;
     }
@@ -355,6 +355,9 @@ PeerNodeInfo::PeerNodeInfo(const std::string_view peer_metadata_id_key,
 
   // Sentinel value is preserved as ID to implement maybeWaiting.
   found_ = false;
+  if (getValue({kMetadataNotFoundValue}, &peer_id_)) {
+    peer_id_ = kMetadataNotFoundValue;
+  }
 
   // Downstream peer metadata will never be in localhost endpoint. Skip
   // looking for it.

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -32,8 +32,8 @@ constexpr std::string_view kUpstreamMetadataKey = "upstream_peer";
 constexpr std::string_view kDownstreamMetadataIdKey = "downstream_peer_id";
 constexpr std::string_view kDownstreamMetadataKey = "downstream_peer";
 
-// Sentinel value assigned to peer metadata ID key, indicating that the peer
-// metadata is absent. This is different from a missing peer metadata ID key
+// Sentinel key in the filter state, indicating that the peer metadata is
+// decidedly absent. This is different from a missing peer metadata ID key
 // which could indicate that the metadata is not received yet.
 const std::string kMetadataNotFoundValue = "envoy.wasm.metadata_exchange.peer_unknown";
 

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -93,10 +93,8 @@ bool peerInfoRead(Reporter reporter, const StreamInfo::FilterState& filter_state
       reporter == Reporter::ServerSidecar || reporter == Reporter::ServerGateway
           ? "wasm.downstream_peer_id"
           : "wasm.upstream_peer_id";
-  const auto* object =
-      filter_state.getDataReadOnly<Envoy::Extensions::Filters::Common::Expr::CelState>(
-          filter_state_key);
-  return object != nullptr;
+  return filter_state.hasDataWithName(filter_state_key) ||
+         filter_state.hasDataWithName("envoy.wasm.metadata_exchange.peer_unknown");
 }
 
 const Wasm::Common::FlatNode* peerInfo(Reporter reporter,

--- a/source/extensions/filters/http/peer_metadata/filter.h
+++ b/source/extensions/filters/http/peer_metadata/filter.h
@@ -90,7 +90,7 @@ private:
   const std::string value_;
 };
 
-class FilterConfig {
+class FilterConfig : public Logger::Loggable<Logger::Id::filter> {
 public:
   FilterConfig(const io::istio::http::peer_metadata::Config&,
                Server::Configuration::FactoryContext&);

--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
@@ -311,10 +311,7 @@ void MetadataExchangeFilter::getMetadata(google::protobuf::Struct* metadata) {
 std::string MetadataExchangeFilter::getMetadataId() { return local_info_.node().id(); }
 
 void MetadataExchangeFilter::setMetadataNotFoundFilterState() {
-  auto key = config_->filter_direction_ == FilterDirection::Downstream
-                 ? ::Wasm::Common::kDownstreamMetadataIdKey
-                 : ::Wasm::Common::kUpstreamMetadataIdKey;
-  updatePeerId(toAbslStringView(key), ::Wasm::Common::kMetadataNotFoundValue);
+  updatePeerId(::Wasm::Common::kMetadataNotFoundValue, ::Wasm::Common::kMetadataNotFoundValue);
 }
 
 } // namespace MetadataExchange

--- a/testdata/metric/envoy_bug_failures.yaml
+++ b/testdata/metric/envoy_bug_failures.yaml
@@ -1,0 +1,5 @@
+name: envoy_server_envoy_bug_failures
+type: COUNTER
+metric:
+- counter:
+    value: 0


### PR DESCRIPTION
It appears Istio enables both HTTP and TCP MX filters at the same time in some cases (e.g. for dry run RBAC Stackdriver test). When that happens, there's a data write conflict:
- TCP MX writes "peer not found" at the connection life span, because ALPN is not set;
- HTTP MX writes actual peer ID at the request life span for the same key.

Because they use the same key, the second write fails in the native implementation of HTTP MX. On the other hand, Wasm HTTP MX uses a controversial trick where it overwrites the TCP MX value with HTTP MX value that makes this problem hidden. That trick causes different issues because now requests are accidentally sharing their filter state (it's per connection, not per request anymore).

The fix is to prevent sharing in this case by 1) making TCP MX write a different "peer not found" key, 2) gracefully accepting TCP MX over HTTP MX when they are truly duplicate (it's not clear if that ever happens), since transport level metadata is likely more trusted.

