### PR TITLE
do not send mx headers for services out of mesh

### DIFF
--- a/source/extensions/filters/http/peer_metadata/config.proto
+++ b/source/extensions/filters/http/peer_metadata/config.proto
@@ -71,4 +71,7 @@ message Config {
 
   // True to enable sharing with the upstream.
   bool shared_with_upstream = 5;
+
+  // Strip x-envoy-peer-metadata and x-envoy-peer-metadata-id headers on HTTP requests to services outside the mesh
+  bool strip_headers = 6;
 }

--- a/source/extensions/filters/http/peer_metadata/config.proto
+++ b/source/extensions/filters/http/peer_metadata/config.proto
@@ -37,6 +37,9 @@ message Config {
 
   // This method uses Istio HTTP metadata exchange headers, e.g. `x-envoy-peer-metadata`. Removes these headers if found.
   message IstioHeaders {
+    // Strip x-envoy-peer-metadata and x-envoy-peer-metadata-id headers on HTTP requests to services outside the mesh.
+    // Detects upstream clusters with `istio` and `external` filter metadata fields
+    bool skip_external_clusters = 1;
   }
 
   // An exhaustive list of the derivation methods.
@@ -71,7 +74,4 @@ message Config {
 
   // True to enable sharing with the upstream.
   bool shared_with_upstream = 5;
-
-  // Strip x-envoy-peer-metadata and x-envoy-peer-metadata-id headers on HTTP requests to services outside the mesh
-  bool strip_headers = 6;
 }

--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -349,13 +349,8 @@ bool MXPropagationMethod::skipMXHeaders(const StreamInfo::StreamInfo& info) cons
     if (it != filter_metadata.end()) {
       const auto& skip_mx = it->second.fields().find("external");
       if (skip_mx != it->second.fields().end()) {
-        const auto skip_mx_value = skip_mx->second.bool_value();
-        if (skip_mx_value) {
-          return true;
-        }
+        return skip_mx->second.bool_value();
       }
-    } else {
-      return true;
     }
   }
   return false;

--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -354,6 +354,8 @@ bool MXPropagationMethod::skipMXHeaders(const StreamInfo::StreamInfo& info) cons
           return true;
         }
       }
+    } else {
+      return true;
     }
   }
   return false;

--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -346,8 +346,8 @@ bool MXPropagationMethod::skipMXHeaders(StreamInfo::StreamInfo& info) const {
     if (it != filter_metadata.end()) {
       const auto& skip_mx = it->second.fields().find("external");
       if (skip_mx != it->second.fields().end()) {
-        const auto skip_mx_value = skip_mx->second.string_value();
-        if (skip_mx_value == "true") {
+        const auto skip_mx_value = skip_mx->second.bool_value();
+        if (skip_mx_value) {
           return true;
         }
       }

--- a/source/extensions/filters/http/peer_metadata/filter.h
+++ b/source/extensions/filters/http/peer_metadata/filter.h
@@ -74,7 +74,7 @@ private:
 class PropagationMethod {
 public:
   virtual ~PropagationMethod() = default;
-  virtual void inject(StreamInfo::StreamInfo&, Http::HeaderMap&) const PURE;
+  virtual void inject(const StreamInfo::StreamInfo&, Http::HeaderMap&) const PURE;
 };
 
 using PropagationMethodPtr = std::unique_ptr<PropagationMethod>;
@@ -82,15 +82,15 @@ using PropagationMethodPtr = std::unique_ptr<PropagationMethod>;
 class MXPropagationMethod : public PropagationMethod {
 public:
   MXPropagationMethod(Server::Configuration::ServerFactoryContext& factory_context,
-                      io::istio::http::peer_metadata::Config_IstioHeaders);
-  void inject(StreamInfo::StreamInfo&, Http::HeaderMap&) const override;
+                      const io::istio::http::peer_metadata::Config_IstioHeaders&);
+  void inject(const StreamInfo::StreamInfo&, Http::HeaderMap&) const override;
 
 private:
   std::string computeValue(Server::Configuration::ServerFactoryContext&) const;
   const std::string id_;
   const std::string value_;
-  bool skip_external_clusters_;
-  bool skipMXHeaders(StreamInfo::StreamInfo&) const;
+  const bool skip_external_clusters_;
+  bool skipMXHeaders(const StreamInfo::StreamInfo&) const;
 };
 
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {
@@ -99,8 +99,8 @@ public:
                Server::Configuration::FactoryContext&);
   void discoverDownstream(StreamInfo::StreamInfo&, Http::RequestHeaderMap&) const;
   void discoverUpstream(StreamInfo::StreamInfo&, Http::ResponseHeaderMap&) const;
-  void injectDownstream(StreamInfo::StreamInfo&, Http::ResponseHeaderMap&) const;
-  void injectUpstream(StreamInfo::StreamInfo&, Http::RequestHeaderMap&) const;
+  void injectDownstream(const StreamInfo::StreamInfo&, Http::ResponseHeaderMap&) const;
+  void injectUpstream(const StreamInfo::StreamInfo&, Http::RequestHeaderMap&) const;
 
 private:
   std::vector<DiscoveryMethodPtr> buildDiscoveryMethods(

--- a/source/extensions/filters/http/peer_metadata/filter.h
+++ b/source/extensions/filters/http/peer_metadata/filter.h
@@ -74,20 +74,23 @@ private:
 class PropagationMethod {
 public:
   virtual ~PropagationMethod() = default;
-  virtual void inject(Http::HeaderMap&) const PURE;
+  virtual void inject(StreamInfo::StreamInfo&, Http::HeaderMap&) const PURE;
 };
 
 using PropagationMethodPtr = std::unique_ptr<PropagationMethod>;
 
 class MXPropagationMethod : public PropagationMethod {
 public:
-  MXPropagationMethod(Server::Configuration::ServerFactoryContext& factory_context);
-  void inject(Http::HeaderMap&) const override;
+  MXPropagationMethod(Server::Configuration::ServerFactoryContext& factory_context,
+                      io::istio::http::peer_metadata::Config_IstioHeaders);
+  void inject(StreamInfo::StreamInfo&, Http::HeaderMap&) const override;
 
 private:
   std::string computeValue(Server::Configuration::ServerFactoryContext&) const;
   const std::string id_;
   const std::string value_;
+  bool skip_external_clusters_;
+  bool skipMXHeaders(StreamInfo::StreamInfo&) const;
 };
 
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {
@@ -96,9 +99,8 @@ public:
                Server::Configuration::FactoryContext&);
   void discoverDownstream(StreamInfo::StreamInfo&, Http::RequestHeaderMap&) const;
   void discoverUpstream(StreamInfo::StreamInfo&, Http::ResponseHeaderMap&) const;
-  void injectDownstream(Http::ResponseHeaderMap&) const;
-  void injectUpstream(Http::RequestHeaderMap&) const;
-  bool strip_headers_;
+  void injectDownstream(StreamInfo::StreamInfo&, Http::ResponseHeaderMap&) const;
+  void injectUpstream(StreamInfo::StreamInfo&, Http::RequestHeaderMap&) const;
 
 private:
   std::vector<DiscoveryMethodPtr> buildDiscoveryMethods(
@@ -131,7 +133,6 @@ public:
 
 private:
   FilterConfigSharedPtr config_;
-  bool skipMXHeaders(StreamInfo::StreamInfo&) const;
 };
 
 class FilterConfigFactory : public Common::FactoryBase<io::istio::http::peer_metadata::Config> {

--- a/source/extensions/filters/http/peer_metadata/filter.h
+++ b/source/extensions/filters/http/peer_metadata/filter.h
@@ -98,6 +98,7 @@ public:
   void discoverUpstream(StreamInfo::StreamInfo&, Http::ResponseHeaderMap&) const;
   void injectDownstream(Http::ResponseHeaderMap&) const;
   void injectUpstream(Http::RequestHeaderMap&) const;
+  bool strip_headers_;
 
 private:
   std::vector<DiscoveryMethodPtr> buildDiscoveryMethods(
@@ -130,6 +131,7 @@ public:
 
 private:
   FilterConfigSharedPtr config_;
+  bool skipMXHeaders(StreamInfo::StreamInfo&) const;
 };
 
 class FilterConfigFactory : public Common::FactoryBase<io::istio::http::peer_metadata::Config> {

--- a/source/extensions/filters/http/peer_metadata/filter_test.cc
+++ b/source/extensions/filters/http/peer_metadata/filter_test.cc
@@ -477,6 +477,22 @@ TEST_F(PeerMetadataTest, UpstreamMXPropagationSkip) {
   checkNoPeer(false);
 }
 
+TEST_F(PeerMetadataTest, UpstreamMXPropagationSkipPassthrough) {
+  std::shared_ptr<Upstream::MockClusterInfo> cluster_info_{
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
+  cluster_info_->name_ = "PassthroughCluster";
+  ON_CALL(stream_info_, upstreamClusterInfo()).WillByDefault(testing::Return(cluster_info_));
+  initialize(R"EOF(
+    upstream_propagation:
+      - istio_headers:
+          skip_external_clusters: true
+  )EOF");
+  EXPECT_EQ(0, request_headers_.size());
+  EXPECT_EQ(0, response_headers_.size());
+  checkNoPeer(true);
+  checkNoPeer(false);
+}
+
 } // namespace
 } // namespace PeerMetadata
 } // namespace HttpFilters

--- a/source/extensions/filters/http/peer_metadata/filter_test.cc
+++ b/source/extensions/filters/http/peer_metadata/filter_test.cc
@@ -435,9 +435,43 @@ TEST_F(PeerMetadataTest, DownstreamMXPropagation) {
 TEST_F(PeerMetadataTest, UpstreamMXPropagation) {
   initialize(R"EOF(
     upstream_propagation:
-      - istio_headers: {}
+      - istio_headers:
+          skip_external_clusters: false
   )EOF");
   EXPECT_EQ(2, request_headers_.size());
+  EXPECT_EQ(0, response_headers_.size());
+  checkNoPeer(true);
+  checkNoPeer(false);
+}
+
+TEST_F(PeerMetadataTest, UpstreamMXPropagationSkipNoMatch) {
+  initialize(R"EOF(
+    upstream_propagation:
+      - istio_headers:
+          skip_external_clusters: true
+  )EOF");
+  EXPECT_EQ(2, request_headers_.size());
+  EXPECT_EQ(0, response_headers_.size());
+  checkNoPeer(true);
+  checkNoPeer(false);
+}
+
+TEST_F(PeerMetadataTest, UpstreamMXPropagationSkip) {
+  std::shared_ptr<Upstream::MockClusterInfo> cluster_info_{
+      std::make_shared<NiceMock<Upstream::MockClusterInfo>>()};
+  auto metadata = TestUtility::parseYaml<envoy::config::core::v3::Metadata>(R"EOF(
+      filter_metadata:
+        istio:
+          external: true
+    )EOF");
+  ON_CALL(stream_info_, upstreamClusterInfo()).WillByDefault(testing::Return(cluster_info_));
+  ON_CALL(*cluster_info_, metadata()).WillByDefault(ReturnRef(metadata));
+  initialize(R"EOF(
+    upstream_propagation:
+      - istio_headers:
+          skip_external_clusters: true
+  )EOF");
+  EXPECT_EQ(0, request_headers_.size());
   EXPECT_EQ(0, response_headers_.size());
   checkNoPeer(true);
   checkNoPeer(false);


### PR DESCRIPTION
**What this PR does / why we need it**:

add logic in proxy to strip `x-envoy-peer-metadata` and `x-envoy-peer-metadata-id` headers for request to services outside of the mesh.  These headers contain values such as IP's and istio version which block some users from adopting istio due to security audits

 - outside of the mesh is detected on best effort basis
 - behavior is opt-in to prevent any breaking changes
 - affects HTTP traffic + traffic directed to PassthroughCluster or non-eds clusters

detection logic is limited to settings exposed in Envoy XDS cluster API
