### PR TITLE
istio_stats: cleanup fallback

### DIFF
--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1016,19 +1016,6 @@ private:
       auto principals = NetworkFilters::IstioAuthn::getPrincipals(info.filterState());
       peer_san = principals.peer;
       local_san = principals.local;
-
-      // This fallback should be deleted once istio_authn is globally enabled.
-      if (peer_san.empty() && local_san.empty()) {
-        const Ssl::ConnectionInfoConstSharedPtr ssl_info =
-            info.downstreamAddressProvider().sslConnection();
-        if (ssl_info && !ssl_info->uriSanPeerCertificate().empty()) {
-          peer_san = ssl_info->uriSanPeerCertificate()[0];
-        }
-        if (ssl_info && !ssl_info->uriSanLocalCertificate().empty()) {
-          local_san = ssl_info->uriSanLocalCertificate()[0];
-        }
-      }
-
       // Save the connection security policy for a tag added later.
       mutual_tls_ = !peer_san.empty() && !local_san.empty();
       break;

--- a/test/envoye2e/tcp_metadata_exchange/tcp_metadata_exchange_test.go
+++ b/test/envoye2e/tcp_metadata_exchange/tcp_metadata_exchange_test.go
@@ -30,7 +30,8 @@ func TestTCPMetadataExchange(t *testing.T) {
 	}, envoye2e.ProxyE2ETests)
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_mx_network_filter.yaml.tmpl") + "\n" +
+	params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_authn_network_filter.yaml.tmpl") + "\n" +
+		params.LoadTestData("testdata/filters/server_mx_network_filter.yaml.tmpl") + "\n" +
 		params.LoadTestData("testdata/filters/server_stats_network_filter.yaml.tmpl")
 	params.Vars["ClientUpstreamFilters"] = params.LoadTestData("testdata/filters/client_mx_network_filter.yaml.tmpl")
 	params.Vars["ClientNetworkFilters"] = params.LoadTestData("testdata/filters/client_stats_network_filter.yaml.tmpl")
@@ -88,7 +89,8 @@ func TestTCPMetadataExchangeNoAlpn(t *testing.T) {
 	}, envoye2e.ProxyE2ETests)
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_mx_network_filter.yaml.tmpl") + "\n" +
+	params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_authn_network_filter.yaml.tmpl") + "\n" +
+		params.LoadTestData("testdata/filters/server_mx_network_filter.yaml.tmpl") + "\n" +
 		params.LoadTestData("testdata/filters/server_stats_network_filter.yaml.tmpl")
 	params.Vars["ClientUpstreamFilters"] = params.LoadTestData("testdata/filters/client_mx_network_filter.yaml.tmpl")
 	params.Vars["ClientNetworkFilters"] = params.LoadTestData("testdata/filters/client_stats_network_filter.yaml.tmpl")
@@ -136,7 +138,8 @@ func TestTCPMetadataExchangeWithConnectionTermination(t *testing.T) {
 	}, envoye2e.ProxyE2ETests)
 	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
 	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_node_metadata.json.tmpl")
-	params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_stats_network_filter.yaml.tmpl")
+	params.Vars["ServerNetworkFilters"] = params.LoadTestData("testdata/filters/server_authn_network_filter.yaml.tmpl") + "\n" +
+		params.LoadTestData("testdata/filters/server_stats_network_filter.yaml.tmpl")
 	params.Vars["ClientUpstreamFilters"] = params.LoadTestData("testdata/filters/client_mx_network_filter.yaml.tmpl")
 	params.Vars["ClientNetworkFilters"] = params.LoadTestData("testdata/filters/server_mx_network_filter.yaml.tmpl") + "\n" +
 		params.LoadTestData("testdata/filters/client_stats_network_filter.yaml.tmpl")

--- a/testdata/filters/server_authn_network_filter.yaml.tmpl
+++ b/testdata/filters/server_authn_network_filter.yaml.tmpl
@@ -1,0 +1,4 @@
+- name: authn
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: type.googleapis.com/io.istio.network.authn.Config


### PR DESCRIPTION
istio_authn has been enabled since 1.17, cleaning up the fallback.