### PR TITLE
Add envoy.resource_monitors.downstream_connections

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -192,6 +192,7 @@ ENVOY_EXTENSIONS = {
 
     "envoy.resource_monitors.fixed_heap":               "//source/extensions/resource_monitors/fixed_heap:config",
     "envoy.resource_monitors.injected_resource":        "//source/extensions/resource_monitors/injected_resource:config",
+    "envoy.resource_monitors.downstream_connections":   "//source/extensions/resource_monitors/downstream_connections:config",
 
     #
     # Stat sinks


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to use this resource monitor in Istio to replace a deprecated runtime flag.

**Which issue this PR fixes** 
https://github.com/istio/istio/pull/47474

