### PR TITLE
turn previously removed BAZEL_BIN_PATH in to target-specific variable to fix exportcache builds

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -49,6 +49,7 @@ BAZEL_CONFIG_TSAN = # no working config
 endif
 BAZEL_CONFIG_CURRENT ?= $(BAZEL_CONFIG_DEV)
 
+BAZEL_BIN_PATH ?= $(shell bazel info $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) bazel-bin)
 TEST_ENVOY_TARGET ?= //:envoy
 TEST_ENVOY_DEBUG ?= trace
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -49,7 +49,6 @@ BAZEL_CONFIG_TSAN = # no working config
 endif
 BAZEL_CONFIG_CURRENT ?= $(BAZEL_CONFIG_DEV)
 
-BAZEL_BIN_PATH ?= $(shell bazel info $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) bazel-bin)
 TEST_ENVOY_TARGET ?= //:envoy
 TEST_ENVOY_DEBUG ?= trace
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -151,6 +151,7 @@ else
 endif
 
 # Used by build container to export the build output from the docker volume cache
+exportcache: BAZEL_BIN_PATH ?= $(shell bazel info $(BAZEL_BUILD_ARGS) $(BAZEL_CONFIG_CURRENT) bazel-bin)
 exportcache:
 	@mkdir -p /work/out/$(TARGET_OS)_$(TARGET_ARCH)
 	@cp -a $(BAZEL_BIN_PATH)/envoy /work/out/$(TARGET_OS)_$(TARGET_ARCH)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds back an important definition that was removed between the 1.18 and 1.19 releases: https://github.com/istio/proxy/compare/release-1.18..release-1.19#diff-662262a00ad44baa70fb14405b688c43143c3b4635ff8766030dd34b328f8306L67

Without this definition, Istio fails to build locally. The `exportcache` target fails with a `/envoy: no such file or directory` error since `BAZEL_BIN_PATH` is still referenced in a couple places in that target.

Instead of defining the variable globally, this PR defines it as a target-specific one so that Bazel is only started when a target requiring it is run. This is to retain the optimizations in speed added by @howardjohn in PR https://github.com/istio/proxy/pull/4763.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: I can't see issue list so not sure if there is one for this already.

I notice this line was removed in the following commit, but I'm not an expert on Bazel nor the build process so I'm sure I'm not understanding everything here: https://github.com/istio/proxy/commit/b6a4cab8f74cf38a77b9d02626e326c2cee2524a

I'm not sure if the `TEST_ENVOY_PATH` was necessary too. It seems like the `exportcache` target is working again after only adding that one line back, but not sure why any of those lines were removed in the first place, so maybe someone could help explain to me that and which lines need to be there and which are ok to leave out.

**Special notes for your reviewer**:
Credit to @jeesmon for finding this to be the issue. More info in Istio slack thread in #test-and-release: https://istio.slack.com/archives/C6FCV6WN4/p1696463622534729