### PR TITLE
build: fix minor compilation and compliance issues

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -27,13 +27,11 @@ config_setting(
     values = {
         "cpu": "darwin",
     },
-    visibility = ["//visibility:public"],
 )
 
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "//extensions/access_log_policy:access_log_policy_lib",
         "//extensions/stackdriver:stackdriver_plugin",
@@ -54,5 +52,4 @@ pkg_tar(
     mode = "0755",
     package_dir = "/usr/local/bin/",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
 )

--- a/extensions/access_log_policy/BUILD
+++ b/extensions/access_log_policy/BUILD
@@ -1,12 +1,11 @@
-licenses(["notice"])  # Apache 2
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
-    "envoy_package",
 )
 
-envoy_package()
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "access_log_policy_lib",
@@ -18,7 +17,6 @@ envoy_cc_library(
         "plugin.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "//extensions/access_log_policy/config/v1alpha1:access_log_policy_config_cc_proto",
         "//extensions/common:context",

--- a/extensions/access_log_policy/config/v1alpha1/BUILD
+++ b/extensions/access_log_policy/config/v1alpha1/BUILD
@@ -15,11 +15,12 @@
 ################################################################################
 #
 
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
 cc_proto_library(
     name = "access_log_policy_config_cc_proto",
-    visibility = [
-        "//extensions/access_log_policy:__pkg__",
-    ],
     deps = ["access_log_policy_config_proto"],
 )
 

--- a/extensions/common/BUILD
+++ b/extensions/common/BUILD
@@ -15,14 +15,10 @@
 ################################################################################
 #
 
-licenses(["notice"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_cc_benchmark_binary",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_package",
 )
 load(
     "@com_github_google_flatbuffers//:build_defs.bzl",
@@ -35,7 +31,9 @@ load(
     "envoy_extension_cc_test",
 )
 
-envoy_package()
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "context",
@@ -47,7 +45,6 @@ envoy_cc_library(
         "istio_dimensions.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":node_info_fb_cc",
         ":util",
@@ -64,7 +61,6 @@ envoy_cc_library(
         "proto_util.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":node_info_fb_cc",
         ":util",
@@ -82,7 +78,6 @@ envoy_cc_library(
         "util.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "@proxy_wasm_cpp_host//:null_lib",
     ],
@@ -94,7 +89,6 @@ envoy_cc_library(
         "istio_dimensions.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
 )
 
 envoy_extension_cc_test(
@@ -180,7 +174,6 @@ envoy_cc_library(
         "//extensions/common/wasm:json_util.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "@com_github_nlohmann_json//:json",
         "@com_google_absl//absl/strings",
@@ -193,7 +186,6 @@ envoy_cc_library(
     srcs = ["metadata_object.cc"],
     hdrs = ["metadata_object.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":node_info_fb_cc",
         "@envoy//envoy/network:filter_interface",

--- a/extensions/common/wasm/json_util.cc
+++ b/extensions/common/wasm/json_util.cc
@@ -25,7 +25,7 @@ std::optional<JsonObject> JsonParse(std::string_view str) {
   if (result.is_discarded() || !result.is_object()) {
     return std::nullopt;
   }
-  return result;
+  return {result};
 }
 
 template <>

--- a/extensions/stackdriver/BUILD
+++ b/extensions/stackdriver/BUILD
@@ -15,12 +15,14 @@
 ################################################################################
 #
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
 )
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "stackdriver_plugin",

--- a/extensions/stackdriver/common/BUILD
+++ b/extensions/stackdriver/common/BUILD
@@ -15,10 +15,6 @@
 ################################################################################
 #
 
-licenses(["notice"])
-
-package(default_visibility = ["//extensions/stackdriver:__subpackages__"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
@@ -28,6 +24,10 @@ load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
 )
+
+package(default_visibility = ["//extensions/stackdriver:__subpackages__"])
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "constants",

--- a/extensions/stackdriver/config/v1alpha1/BUILD
+++ b/extensions/stackdriver/config/v1alpha1/BUILD
@@ -15,12 +15,12 @@
 ################################################################################
 #
 
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
 cc_proto_library(
     name = "stackdriver_plugin_config_cc_proto",
-    visibility = [
-        "//extensions/stackdriver:__pkg__",
-        "//extensions/stackdriver/metric:__pkg__",
-    ],
     deps = ["stackdriver_plugin_config_proto"],
 )
 

--- a/extensions/stackdriver/log/BUILD
+++ b/extensions/stackdriver/log/BUILD
@@ -15,7 +15,7 @@
 ################################################################################
 #
 
-licenses(["notice"])  # Apache 2
+package(default_visibility = ["//visibility:public"])
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
@@ -27,6 +27,8 @@ load(
     "envoy_extension_cc_test",
 )
 
+licenses(["notice"])
+
 envoy_cc_library(
     name = "logger",
     srcs = [
@@ -36,9 +38,6 @@ envoy_cc_library(
         "logger.h",
     ],
     repository = "@envoy",
-    visibility = [
-        "//extensions/stackdriver:__pkg__",
-    ],
     deps = [
         ":exporter",
         "//extensions/common:context",
@@ -57,9 +56,6 @@ envoy_cc_library(
     ],
     copts = ["-DPROXY_WASM_PROTOBUF=1"],
     repository = "@envoy",
-    visibility = [
-        "//extensions/stackdriver:__pkg__",
-    ],
     deps = [
         "//extensions/stackdriver/common:metrics",
         "//extensions/stackdriver/common:utils",

--- a/extensions/stackdriver/metric/BUILD
+++ b/extensions/stackdriver/metric/BUILD
@@ -15,8 +15,6 @@
 ################################################################################
 #
 
-licenses(["notice"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
@@ -26,6 +24,10 @@ load(
     "@envoy//test/extensions:extensions_build_system.bzl",
     "envoy_extension_cc_test",
 )
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "metric",
@@ -38,9 +40,6 @@ envoy_cc_library(
         "registry.h",
     ],
     repository = "@envoy",
-    visibility = [
-        "//extensions/stackdriver:__pkg__",
-    ],
     deps = [
         "//extensions/common:context",
         "//extensions/stackdriver/common:constants",

--- a/source/extensions/common/BUILD
+++ b/source/extensions/common/BUILD
@@ -21,6 +21,10 @@ load(
     "envoy_cc_test",
 )
 
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
 envoy_cc_library(
     name = "authn_lib",
     srcs = [
@@ -30,7 +34,6 @@ envoy_cc_library(
         "authn.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":filter_names_lib",
         ":utils_lib",
@@ -50,7 +53,6 @@ envoy_cc_library(
         "utils.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "@envoy//source/exe:envoy_common_lib",
     ],
@@ -62,7 +64,6 @@ envoy_cc_library(
         "filter_objects.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         "@envoy//envoy/registry",
         "@envoy//envoy/stream_info:filter_state_interface",
@@ -105,5 +106,4 @@ cc_library(
     hdrs = [
         "filter_names.h",
     ],
-    visibility = ["//visibility:public"],
 )

--- a/source/extensions/common/workload_discovery/BUILD
+++ b/source/extensions/common/workload_discovery/BUILD
@@ -15,15 +15,16 @@
 ################################################################################
 #
 
+package(default_visibility = ["//visibility:public"])
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_extension",
     "envoy_cc_test",
-    "envoy_extension_package",
     "envoy_proto_library",
 )
 
-envoy_extension_package()
+licenses(["notice"])
 
 envoy_cc_extension(
     name = "api_lib",

--- a/source/extensions/common/workload_discovery/BUILD
+++ b/source/extensions/common/workload_discovery/BUILD
@@ -15,14 +15,15 @@
 ################################################################################
 #
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_extension_package",
     "envoy_cc_extension",
     "envoy_cc_test",
     "envoy_proto_library",
 )
+
+envoy_extension_package()
 
 licenses(["notice"])
 

--- a/source/extensions/common/workload_discovery/BUILD
+++ b/source/extensions/common/workload_discovery/BUILD
@@ -17,9 +17,9 @@
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_extension_package",
     "envoy_cc_extension",
     "envoy_cc_test",
+    "envoy_extension_package",
     "envoy_proto_library",
 )
 

--- a/source/extensions/filters/http/alpn/BUILD
+++ b/source/extensions/filters/http/alpn/BUILD
@@ -15,13 +15,14 @@
 ################################################################################
 #
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_extension_package",
     "envoy_cc_library",
     "envoy_cc_test",
 )
+
+envoy_extension_package()
 
 licenses(["notice"])
 

--- a/source/extensions/filters/http/alpn/BUILD
+++ b/source/extensions/filters/http/alpn/BUILD
@@ -15,14 +15,15 @@
 ################################################################################
 #
 
+package(default_visibility = ["//visibility:public"])
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_package",
 )
 
-envoy_package()
+licenses(["notice"])
 
 envoy_cc_library(
     name = "alpn_filter",
@@ -42,7 +43,6 @@ envoy_cc_library(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":alpn_filter",
         "//source/extensions/common:filter_names_lib",

--- a/source/extensions/filters/http/alpn/BUILD
+++ b/source/extensions/filters/http/alpn/BUILD
@@ -17,9 +17,9 @@
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_extension_package",
     "envoy_cc_library",
     "envoy_cc_test",
+    "envoy_extension_package",
 )
 
 envoy_extension_package()

--- a/source/extensions/filters/http/authn/BUILD
+++ b/source/extensions/filters/http/authn/BUILD
@@ -17,10 +17,10 @@
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_extension_package",
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_cc_test_library",
+    "envoy_extension_package",
 )
 
 envoy_extension_package()

--- a/source/extensions/filters/http/authn/BUILD
+++ b/source/extensions/filters/http/authn/BUILD
@@ -15,14 +15,15 @@
 ################################################################################
 #
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_extension_package",
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_cc_test_library",
 )
+
+envoy_extension_package()
 
 licenses(["notice"])
 

--- a/source/extensions/filters/http/authn/BUILD
+++ b/source/extensions/filters/http/authn/BUILD
@@ -24,6 +24,8 @@ load(
     "envoy_cc_test_library",
 )
 
+licenses(["notice"])
+
 envoy_cc_library(
     name = "authenticator",
     srcs = [

--- a/source/extensions/filters/http/istio_stats/BUILD
+++ b/source/extensions/filters/http/istio_stats/BUILD
@@ -15,13 +15,14 @@
 ################################################################################
 #
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_extension_package",
     "envoy_cc_extension",
     "envoy_proto_library",
 )
+
+envoy_extension_package()
 
 licenses(["notice"])
 

--- a/source/extensions/filters/http/istio_stats/BUILD
+++ b/source/extensions/filters/http/istio_stats/BUILD
@@ -17,8 +17,8 @@
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_extension_package",
     "envoy_cc_extension",
+    "envoy_extension_package",
     "envoy_proto_library",
 )
 

--- a/source/extensions/filters/http/istio_stats/BUILD
+++ b/source/extensions/filters/http/istio_stats/BUILD
@@ -15,14 +15,15 @@
 ################################################################################
 #
 
+package(default_visibility = ["//visibility:public"])
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_extension",
-    "envoy_extension_package",
     "envoy_proto_library",
 )
 
-envoy_extension_package()
+licenses(["notice"])
 
 envoy_cc_extension(
     name = "istio_stats",

--- a/source/extensions/filters/http/peer_metadata/BUILD
+++ b/source/extensions/filters/http/peer_metadata/BUILD
@@ -15,14 +15,15 @@
 ################################################################################
 #
 
-package(default_visibility = ["//visibility:public"])
-
 load(
     "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_extension_package",
     "envoy_cc_extension",
     "envoy_cc_test",
     "envoy_proto_library",
 )
+
+envoy_extension_package()
 
 licenses(["notice"])
 

--- a/source/extensions/filters/http/peer_metadata/BUILD
+++ b/source/extensions/filters/http/peer_metadata/BUILD
@@ -15,15 +15,16 @@
 ################################################################################
 #
 
+package(default_visibility = ["//visibility:public"])
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_extension",
     "envoy_cc_test",
-    "envoy_extension_package",
     "envoy_proto_library",
 )
 
-envoy_extension_package()
+licenses(["notice"])
 
 envoy_cc_extension(
     name = "filter_lib",

--- a/source/extensions/filters/http/peer_metadata/BUILD
+++ b/source/extensions/filters/http/peer_metadata/BUILD
@@ -17,9 +17,9 @@
 
 load(
     "@envoy//bazel:envoy_build_system.bzl",
-    "envoy_extension_package",
     "envoy_cc_extension",
     "envoy_cc_test",
+    "envoy_extension_package",
     "envoy_proto_library",
 )
 

--- a/source/extensions/filters/network/metadata_exchange/BUILD
+++ b/source/extensions/filters/network/metadata_exchange/BUILD
@@ -21,10 +21,11 @@ load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_cc_test",
-    "envoy_package",
 )
 
-envoy_package()
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "metadata_exchange",
@@ -65,7 +66,6 @@ envoy_cc_library(
     srcs = ["config.cc"],
     hdrs = ["config.h"],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
     deps = [
         ":metadata_exchange",
         "//source/extensions/filters/network/metadata_exchange/config:metadata_exchange_cc_proto",

--- a/source/extensions/filters/network/metadata_exchange/config/BUILD
+++ b/source/extensions/filters/network/metadata_exchange/config/BUILD
@@ -14,6 +14,9 @@
 #
 ################################################################################
 #
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
 
 proto_library(
     name = "metadata_exchange_proto",
@@ -22,6 +25,5 @@ proto_library(
 
 cc_proto_library(
     name = "metadata_exchange_cc_proto",
-    visibility = ["//visibility:public"],
     deps = ["metadata_exchange_proto"],
 )

--- a/src/istio/authn/BUILD
+++ b/src/istio/authn/BUILD
@@ -17,6 +17,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+licenses(["notice"])
+
 load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_proto_library",

--- a/src/istio/utils/BUILD
+++ b/src/istio/utils/BUILD
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-licenses(["notice"])
-
 package(default_visibility = ["//visibility:public"])
 
 load(
@@ -21,6 +19,8 @@ load(
     "envoy_cc_library",
     "envoy_cc_test",
 )
+
+licenses(["notice"])
 
 envoy_cc_library(
     name = "attribute_names_lib",
@@ -31,5 +31,4 @@ envoy_cc_library(
         "attribute_names.h",
     ],
     repository = "@envoy",
-    visibility = ["//visibility:public"],
 )

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -22,6 +22,8 @@ load(
     "envoy_cc_test_library",
 )
 
+licenses(["notice"])
+
 envoy_cc_test(
     name = "istio_http_integration_test_with_envoy_jwt_filter",
     size = "large",


### PR DESCRIPTION
Add license notice to every package.
Move `load` first in every `BUILD` file.
Remove per-package visibility restrictions.

Dis-ambiguate optional return in a method.