### PR TITLE
stackdriver fake: use json

### DIFF
--- a/test/envoye2e/stackdriver_plugin/cmd/Makefile
+++ b/test/envoye2e/stackdriver_plugin/cmd/Makefile
@@ -18,12 +18,12 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 SD_PATH := $(dir $(MKFILE_PATH))
 IMG ?= gcr.io/istio-testing/fake-stackdriver
-TAG ?= 8.0
+TAG ?= 9.0
 
 all: build_and_push clean
 
 build_and_push:
-	cd $(SD_PATH) && GOOS=linux GOARCH=amd64 go build -o main-amd64 --ldflags '-extldflags -static -s -w' main.go
-	cd $(SD_PATH) && GOOS=linux GOARCH=arm64 go build -o main-arm64 --ldflags '-extldflags -static -s -w' main.go
+	cd $(SD_PATH) && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main-amd64 -ldflags '-extldflags -static -s -w' main.go
+	cd $(SD_PATH) && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o main-arm64 -ldflags '-extldflags -static -s -w' main.go
 	docker buildx build --platform=linux/arm64,linux/amd64 $(SD_PATH) -t $(IMG):$(TAG) --push
 	rm $(SD_PATH)/main-*

--- a/test/envoye2e/stackdriver_plugin/fake_stackdriver.go
+++ b/test/envoye2e/stackdriver_plugin/fake_stackdriver.go
@@ -30,8 +30,8 @@ import (
 	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	cloudtracev1 "cloud.google.com/go/trace/apiv1/tracepb"
 	cloudtracev2 "cloud.google.com/go/trace/apiv2/tracepb"
-	"github.com/golang/protobuf/jsonpb" // nolint: depguard // We need the deprecated module since the jsonpb replacement is not backwards compatible.
-	legacyproto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/jsonpb"            // nolint: depguard // We need the deprecated module since the jsonpb replacement is not backwards compatible.
+	legacyproto "github.com/golang/protobuf/proto" // nolint: staticcheck // We need to use the legacy one to use the legacy jsonpb
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/genproto/googleapis/api/metric"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
@@ -120,7 +120,7 @@ func (s *MetricServer) ListTimeSeries(context.Context, *monitoringpb.ListTimeSer
 
 // CreateTimeSeries implements CreateTimeSeries method.
 func (s *MetricServer) CreateTimeSeries(ctx context.Context, req *monitoringpb.CreateTimeSeriesRequest) (*empty.Empty, error) {
-	log.Printf("receive CreateTimeSeriesRequest %v", mustDumpToJson(req))
+	log.Printf("receive CreateTimeSeriesRequest %v", mustDumpToJSON(req))
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	s.listTSResp.TimeSeries = append(s.listTSResp.TimeSeries, req.TimeSeries...)
@@ -140,7 +140,7 @@ func (s *LoggingServer) DeleteLog(context.Context, *loggingpb.DeleteLogRequest) 
 
 // WriteLogEntries implements WriteLogEntries method.
 func (s *LoggingServer) WriteLogEntries(ctx context.Context, req *loggingpb.WriteLogEntriesRequest) (*loggingpb.WriteLogEntriesResponse, error) {
-	log.Printf("receive WriteLogEntriesRequest %v", mustDumpToJson(req))
+	log.Printf("receive WriteLogEntriesRequest %v", mustDumpToJSON(req))
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	for _, entry := range req.Entries {
@@ -283,7 +283,7 @@ func getID(id string) (uint64, error) {
 	return dec, nil
 }
 
-func mustDumpToJson(msg legacyproto.Message) string {
+func mustDumpToJSON(msg legacyproto.Message) string {
 	var m jsonpb.Marshaler
 	s, _ := m.MarshalToString(msg)
 	return s
@@ -291,7 +291,7 @@ func mustDumpToJson(msg legacyproto.Message) string {
 
 // BatchWriteSpans implements BatchWriteSpans method.
 func (s *TracesServer) BatchWriteSpans(ctx context.Context, req *cloudtracev2.BatchWriteSpansRequest) (*empty.Empty, error) {
-	log.Printf("receive BatchWriteSpansRequest %+v", mustDumpToJson(req))
+	log.Printf("receive BatchWriteSpansRequest %+v", mustDumpToJSON(req))
 	s.mux.Lock()
 	defer s.mux.Unlock()
 	for _, span := range req.Spans {


### PR DESCRIPTION
The `.String()` format is incomprehensible (by human or CLI) at this
size; JSON is much easier to grok. This only impacts test debug logging.
