### PR TITLE
build: fix proto use since they are duplicated in istio/api

### DIFF
--- a/source/extensions/filters/http/alpn/BUILD
+++ b/source/extensions/filters/http/alpn/BUILD
@@ -20,7 +20,6 @@ load(
     "envoy_cc_library",
     "envoy_cc_test",
     "envoy_extension_package",
-    "envoy_proto_library",
 )
 
 envoy_extension_package()
@@ -84,7 +83,12 @@ envoy_cc_test(
     ],
 )
 
-envoy_proto_library(
+cc_proto_library(
+    name = "config_cc_proto",
+    deps = ["config"],
+)
+
+proto_library(
     name = "config",
     srcs = ["config.proto"],
 )

--- a/source/extensions/filters/http/istio_stats/BUILD
+++ b/source/extensions/filters/http/istio_stats/BUILD
@@ -19,7 +19,6 @@ load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_extension",
     "envoy_extension_package",
-    "envoy_proto_library",
 )
 
 envoy_extension_package()
@@ -39,23 +38,32 @@ envoy_cc_extension(
         "@com_google_cel_cpp//eval/public:cel_expr_builder_factory",
         "@com_google_cel_cpp//parser",
         "@envoy//envoy/registry",
+        "@envoy//envoy/server:factory_context_interface",
         "@envoy//envoy/server:filter_config_interface",
+        "@envoy//envoy/singleton:manager_interface",
         "@envoy//envoy/stream_info:filter_state_interface",
         "@envoy//source/common/grpc:common_lib",
         "@envoy//source/common/http:header_map_lib",
+        "@envoy//source/common/http:header_utility_lib",
         "@envoy//source/common/network:utility_lib",
         "@envoy//source/common/stream_info:utility_lib",
         "@envoy//source/extensions/filters/common/expr:cel_state_lib",
         "@envoy//source/extensions/filters/common/expr:context_lib",
         "@envoy//source/extensions/filters/common/expr:evaluator_lib",
-        "@envoy//source/extensions/filters/http/common:factory_base_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
         "@envoy//source/extensions/filters/http/grpc_stats:config",
-        "@envoy//source/extensions/filters/network/common:factory_base_lib",
     ],
 )
 
-envoy_proto_library(
+cc_proto_library(
+    name = "config_cc_proto",
+    deps = ["config"],
+)
+
+proto_library(
     name = "config",
     srcs = ["config.proto"],
+    deps = [
+        "@com_google_protobuf//:duration_proto",
+    ],
 )

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1219,11 +1219,12 @@ private:
 
 } // namespace
 
-Http::FilterFactoryCb IstioStatsFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const stats::PluginConfig& proto_config, const std::string&,
+absl::StatusOr<Http::FilterFactoryCb> IstioStatsFilterConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message& proto_config, const std::string&,
     Server::Configuration::FactoryContext& factory_context) {
   factory_context.api().customStatNamespaces().registerStatNamespace(CustomStatNamespace);
-  ConfigSharedPtr config = std::make_shared<Config>(proto_config, factory_context);
+  ConfigSharedPtr config = std::make_shared<Config>(
+      dynamic_cast<const stats::PluginConfig&>(proto_config), factory_context);
   config->recordVersion();
   return [config](Http::FilterChainFactoryCallbacks& callbacks) {
     auto filter = std::make_shared<IstioStatsFilter>(config);
@@ -1237,11 +1238,11 @@ Http::FilterFactoryCb IstioStatsFilterConfigFactory::createFilterFactoryFromProt
 REGISTER_FACTORY(IstioStatsFilterConfigFactory,
                  Server::Configuration::NamedHttpFilterConfigFactory);
 
-Network::FilterFactoryCb IstioStatsNetworkFilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const stats::PluginConfig& proto_config,
-    Server::Configuration::FactoryContext& factory_context) {
+Network::FilterFactoryCb IstioStatsNetworkFilterConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message& proto_config, Server::Configuration::FactoryContext& factory_context) {
   factory_context.api().customStatNamespaces().registerStatNamespace(CustomStatNamespace);
-  ConfigSharedPtr config = std::make_shared<Config>(proto_config, factory_context);
+  ConfigSharedPtr config = std::make_shared<Config>(
+      dynamic_cast<const stats::PluginConfig&>(proto_config), factory_context);
   config->recordVersion();
   return [config](Network::FilterManager& filter_manager) {
     filter_manager.addReadFilter(std::make_shared<IstioStatsFilter>(config));

--- a/source/extensions/filters/http/istio_stats/istio_stats.h
+++ b/source/extensions/filters/http/istio_stats/istio_stats.h
@@ -17,34 +17,37 @@
 #include "envoy/server/filter_config.h"
 #include "envoy/stream_info/filter_state.h"
 #include "source/extensions/filters/http/istio_stats/config.pb.h"
-#include "source/extensions/filters/http/istio_stats/config.pb.validate.h"
-#include "source/extensions/filters/http/common/factory_base.h"
-#include "source/extensions/filters/network/common/factory_base.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace IstioStats {
 
-class IstioStatsFilterConfigFactory : public Common::FactoryBase<stats::PluginConfig> {
+class IstioStatsFilterConfigFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
-  IstioStatsFilterConfigFactory() : FactoryBase("envoy.filters.http.istio_stats") {}
+  std::string name() const override { return "envoy.filters.http.istio_stats"; }
 
-private:
-  Http::FilterFactoryCb
-  createFilterFactoryFromProtoTyped(const stats::PluginConfig& proto_config, const std::string&,
-                                    Server::Configuration::FactoryContext&) override;
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<stats::PluginConfig>();
+  }
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config, const std::string&,
+                               Server::Configuration::FactoryContext&) override;
 };
 
 class IstioStatsNetworkFilterConfigFactory
-    : public NetworkFilters::Common::FactoryBase<stats::PluginConfig> {
+    : public Server::Configuration::NamedNetworkFilterConfigFactory {
 public:
-  IstioStatsNetworkFilterConfigFactory() : FactoryBase("envoy.filters.network.istio_stats") {}
+  std::string name() const override { return "envoy.filters.network.istio_stats"; }
 
-private:
-  Network::FilterFactoryCb createFilterFactoryFromProtoTyped(
-      const stats::PluginConfig& proto_config,
-      Server::Configuration::FactoryContext& factory_context) override;
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<stats::PluginConfig>();
+  }
+
+  Network::FilterFactoryCb
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config,
+                               Server::Configuration::FactoryContext& factory_context) override;
 };
 
 } // namespace IstioStats

--- a/source/extensions/filters/http/peer_metadata/BUILD
+++ b/source/extensions/filters/http/peer_metadata/BUILD
@@ -20,7 +20,6 @@ load(
     "envoy_cc_extension",
     "envoy_cc_test",
     "envoy_extension_package",
-    "envoy_proto_library",
 )
 
 envoy_extension_package()
@@ -50,7 +49,12 @@ envoy_cc_extension(
     ],
 )
 
-envoy_proto_library(
+cc_proto_library(
+    name = "config_cc_proto",
+    deps = ["config"],
+)
+
+proto_library(
     name = "config",
     srcs = ["config.proto"],
 )

--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -353,10 +353,11 @@ Http::FilterHeadersStatus Filter::encodeHeaders(Http::ResponseHeaderMap& headers
   return Http::FilterHeadersStatus::Continue;
 }
 
-Http::FilterFactoryCb FilterConfigFactory::createFilterFactoryFromProtoTyped(
-    const io::istio::http::peer_metadata::Config& config, const std::string&,
+absl::StatusOr<Http::FilterFactoryCb> FilterConfigFactory::createFilterFactoryFromProto(
+    const Protobuf::Message& config, const std::string&,
     Server::Configuration::FactoryContext& factory_context) {
-  auto filter_config = std::make_shared<FilterConfig>(config, factory_context);
+  auto filter_config = std::make_shared<FilterConfig>(
+      dynamic_cast<const io::istio::http::peer_metadata::Config&>(config), factory_context);
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) {
     auto filter = std::make_shared<Filter>(filter_config);
     callbacks.addStreamFilter(filter);

--- a/source/extensions/filters/http/peer_metadata/filter.h
+++ b/source/extensions/filters/http/peer_metadata/filter.h
@@ -17,7 +17,6 @@
 #include "source/extensions/filters/http/common/factory_base.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 #include "source/extensions/filters/http/peer_metadata/config.pb.h"
-#include "source/extensions/filters/http/peer_metadata/config.pb.validate.h"
 #include "source/extensions/common/workload_discovery/api.h"
 #include "source/common/singleton/const_singleton.h"
 #include "extensions/common/context.h"
@@ -142,15 +141,17 @@ private:
   Context ctx_;
 };
 
-class FilterConfigFactory : public Common::FactoryBase<io::istio::http::peer_metadata::Config> {
+class FilterConfigFactory : public Server::Configuration::NamedHttpFilterConfigFactory {
 public:
-  FilterConfigFactory() : FactoryBase("envoy.filters.http.peer_metadata") {}
+  std::string name() const override { return "envoy.filters.http.peer_metadata"; }
 
-private:
-  Http::FilterFactoryCb
-  createFilterFactoryFromProtoTyped(const io::istio::http::peer_metadata::Config&,
-                                    const std::string&,
-                                    Server::Configuration::FactoryContext&) override;
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<io::istio::http::peer_metadata::Config>();
+  }
+
+  absl::StatusOr<Http::FilterFactoryCb>
+  createFilterFactoryFromProto(const Protobuf::Message& proto_config, const std::string&,
+                               Server::Configuration::FactoryContext&) override;
 };
 
 } // namespace PeerMetadata


### PR DESCRIPTION
Change-Id: I4d3bfb95e512c17820231a54d0a1764552b9a6c7

Use simple proto library for protos in istio/api because the tooling there does not create validation code.
