### PR TITLE
build: use proto setters to handle cords

### DIFF
--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange.cc
@@ -197,7 +197,7 @@ void MetadataExchangeFilter::writeNodeMetadata() {
   }
   if (data.fields_size() > 0) {
     Envoy::ProtobufWkt::Any metadata_any_value;
-    *metadata_any_value.mutable_type_url() = StructTypeUrl;
+    metadata_any_value.set_type_url(StructTypeUrl);
     std::string serialized_data;
     serializeToStringDeterministic(data, &serialized_data);
     *metadata_any_value.mutable_value() = serialized_data;

--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange_test.cc
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange_test.cc
@@ -103,7 +103,7 @@ TEST_F(MetadataExchangeFilterTest, MetadataExchangeFound) {
   ::Envoy::Buffer::OwnedImpl data;
   MetadataExchangeInitialHeader initial_header;
   Envoy::ProtobufWkt::Any productpage_any_value;
-  *productpage_any_value.mutable_type_url() = "type.googleapis.com/google.protobuf.Struct";
+  productpage_any_value.set_type_url("type.googleapis.com/google.protobuf.Struct");
   *productpage_any_value.mutable_value() = productpage_value_.SerializeAsString();
   ConstructProxyHeaderData(data, productpage_any_value, &initial_header);
   ::Envoy::Buffer::OwnedImpl world{"world"};


### PR DESCRIPTION
Change-Id: I412f4c68458ea9cabd879206521519c3d3293824

Some protobuf libraries use cords instead of strings, so use the appropriate setter.