### PR TITLE
network filter: set identiy from PROXY TLV header

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -39,7 +39,7 @@ envoy_cc_binary(
         "//source/extensions/filters/http/alpn:config_lib",
         "//source/extensions/filters/http/istio_stats",
         "//source/extensions/filters/http/peer_metadata:filter_lib",
-        "//source/extensions/filters/network/istio_tlv_authn:config_lib", # Very experimental: ambient/sandwich
+        "//source/extensions/filters/network/istio_tlv_authn:config_lib",  # Very experimental: ambient/sandwich
         "//source/extensions/filters/network/metadata_exchange:config_lib",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],

--- a/BUILD
+++ b/BUILD
@@ -39,6 +39,7 @@ envoy_cc_binary(
         "//source/extensions/filters/http/alpn:config_lib",
         "//source/extensions/filters/http/istio_stats",
         "//source/extensions/filters/http/peer_metadata:filter_lib",
+        "//source/extensions/filters/network/istio_tlv_authn:config_lib", # Very experimental: ambient/sandwich
         "//source/extensions/filters/network/metadata_exchange:config_lib",
         "@envoy//source/exe:envoy_main_entry_lib",
     ],

--- a/source/extensions/filters/network/istio_tlv_authn/BUILD
+++ b/source/extensions/filters/network/istio_tlv_authn/BUILD
@@ -32,7 +32,6 @@ envoy_cc_extension(
     repository = "@envoy",
     deps = [
         ":config_cc_proto",
-        "@envoy//source/common/router:string_accessor_lib",
         "@envoy//envoy/common:hashable_interface",
         "@envoy//envoy/network:filter_interface",
         "@envoy//envoy/registry",
@@ -40,6 +39,7 @@ envoy_cc_extension(
         "@envoy//envoy/stream_info:filter_state_interface",
         "@envoy//source/common/common:hash_lib",
         "@envoy//source/common/network:proxy_protocol_filter_state_lib",
+        "@envoy//source/common/router:string_accessor_lib",
         "@envoy//source/extensions/filters/network/common:factory_base_lib",
     ],
 )
@@ -48,4 +48,3 @@ envoy_proto_library(
     name = "config",
     srcs = ["config.proto"],
 )
-

--- a/source/extensions/filters/network/istio_tlv_authn/BUILD
+++ b/source/extensions/filters/network/istio_tlv_authn/BUILD
@@ -1,0 +1,51 @@
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_cc_test",
+    "envoy_extension_package",
+    "envoy_proto_library",
+)
+
+envoy_extension_package()
+
+envoy_cc_extension(
+    name = "config_lib",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":config_cc_proto",
+        "@envoy//source/common/router:string_accessor_lib",
+        "@envoy//envoy/common:hashable_interface",
+        "@envoy//envoy/network:filter_interface",
+        "@envoy//envoy/registry",
+        "@envoy//envoy/server:filter_config_interface",
+        "@envoy//envoy/stream_info:filter_state_interface",
+        "@envoy//source/common/common:hash_lib",
+        "@envoy//source/common/network:proxy_protocol_filter_state_lib",
+        "@envoy//source/extensions/filters/network/common:factory_base_lib",
+    ],
+)
+
+envoy_proto_library(
+    name = "config",
+    srcs = ["config.proto"],
+)
+

--- a/source/extensions/filters/network/istio_tlv_authn/config.cc
+++ b/source/extensions/filters/network/istio_tlv_authn/config.cc
@@ -1,0 +1,94 @@
+/* Copyright Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "source/extensions/filters/network/istio_tlv_authn/config.h"
+
+#include "envoy/registry/registry.h"
+#include "source/common/common/hash.h"
+#include "source/common/network/proxy_protocol_filter_state.h"
+#include "source/extensions/filters/network/common/factory_base.h"
+#include "source/extensions/filters/network/istio_tlv_authn/config.pb.h"
+#include "source/extensions/filters/network/istio_tlv_authn/config.pb.validate.h"
+#include "source/common/router/string_accessor_impl.h"
+
+
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace IstioAuthn {
+
+// Copied from filter_objects.h to avoid duplicate REGISTER_FACTORY from include
+constexpr absl::string_view PeerPrincipalKey = "io.istio.peer_principal";
+
+void IstioTLVAuthnFilter::onEvent(Network::ConnectionEvent event) {
+  switch (event) {
+  case Network::ConnectionEvent::Connected:
+    // TLS handshake success triggers this event.
+    populate();
+    break;
+  default:
+    break;
+  }
+}
+
+void IstioTLVAuthnFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) {
+  read_callbacks_ = &callbacks;
+  read_callbacks_->connection().addConnectionCallbacks(*this);
+}
+
+const uint8_t principalTlvType = 0xD0;
+
+void IstioTLVAuthnFilter::populate() const {
+  Network::Connection& conn = read_callbacks_->connection();
+  const auto* proxy_proto = conn.streamInfo().filterState()->getDataReadOnly<Network::ProxyProtocolFilterState>(Network::ProxyProtocolFilterState::key());
+  const auto& tlv_vector = proxy_proto->value().tlv_vector_;
+
+  auto tlv = std::find_if(tlv_vector.begin(), tlv_vector.end(), [](const Network::ProxyProtocolTLV& tlv) {
+    return tlv.type == principalTlvType;
+  });
+  if (tlv == tlv_vector.end()) {
+    return;
+  }
+
+  ENVOY_LOG(debug, "istio_tlv_authn: setting io.istio.peer_principal from PROXY Protocol TLV");
+  std::string id(tlv->value.begin(), tlv->value.end()); 
+  auto peer_principal = std::make_shared<Router::StringAccessorImpl>(id);
+  conn.streamInfo().filterState()->setData(PeerPrincipalKey , peer_principal,
+                                           StreamInfo::FilterState::StateType::ReadOnly,
+                                           StreamInfo::FilterState::LifeSpan::Connection,
+                                           shared_);
+}
+
+class IstioTLVAuthnConfigFactory : public Common::FactoryBase<io::istio::network::tlv_authn::Config> {
+public:
+  IstioTLVAuthnConfigFactory () : FactoryBase("io.istio.network.tlv_authn") {}
+
+private:
+  Network::FilterFactoryCb
+  createFilterFactoryFromProtoTyped(const io::istio::network::tlv_authn::Config& config,
+                                    Server::Configuration::FactoryContext&) override {
+    return [shared = config.shared()](Network::FilterManager& filter_manager) -> void {
+      filter_manager.addReadFilter(std::make_shared<IstioTLVAuthnFilter>(shared));
+    };
+  }
+};
+
+REGISTER_FACTORY(IstioTLVAuthnConfigFactory, Server::Configuration::NamedNetworkFilterConfigFactory);
+
+} // namespace IstioAuthn
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/istio_tlv_authn/config.h
+++ b/source/extensions/filters/network/istio_tlv_authn/config.h
@@ -25,10 +25,9 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace IstioAuthn {
 
-class IstioTLVAuthnFilter : 
-  public Network::ReadFilter, 
-  public Network::ConnectionCallbacks,
-  public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+class IstioTLVAuthnFilter : public Network::ReadFilter,
+                            public Network::ConnectionCallbacks,
+                            public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
 public:
   IstioTLVAuthnFilter(bool shared)
       : shared_(shared ? StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce

--- a/source/extensions/filters/network/istio_tlv_authn/config.h
+++ b/source/extensions/filters/network/istio_tlv_authn/config.h
@@ -1,0 +1,58 @@
+/* Copyright Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "envoy/common/hashable.h"
+#include "envoy/network/filter.h"
+#include "envoy/server/filter_config.h"
+#include "envoy/stream_info/filter_state.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace IstioAuthn {
+
+class IstioTLVAuthnFilter : 
+  public Network::ReadFilter, 
+  public Network::ConnectionCallbacks,
+  public Envoy::Logger::Loggable<Envoy::Logger::Id::filter> {
+public:
+  IstioTLVAuthnFilter(bool shared)
+      : shared_(shared ? StreamInfo::StreamSharingMayImpactPooling::SharedWithUpstreamConnectionOnce
+                       : StreamInfo::StreamSharingMayImpactPooling::None) {}
+
+  // Network::ConnectionCallbacks
+  void onEvent(Network::ConnectionEvent event) override;
+  void onAboveWriteBufferHighWatermark() override {}
+  void onBelowWriteBufferLowWatermark() override {}
+
+  // Network::ReadFilter
+  Network::FilterStatus onData(Buffer::Instance&, bool) override {
+    return Network::FilterStatus::Continue;
+  }
+  Network::FilterStatus onNewConnection() override { return Network::FilterStatus::Continue; }
+  void initializeReadFilterCallbacks(Network::ReadFilterCallbacks& callbacks) override;
+
+private:
+  void populate() const;
+  const StreamInfo::StreamSharingMayImpactPooling shared_;
+  Network::ReadFilterCallbacks* read_callbacks_{nullptr};
+};
+
+} // namespace IstioAuthn
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/istio_tlv_authn/config.proto
+++ b/source/extensions/filters/network/istio_tlv_authn/config.proto
@@ -1,0 +1,25 @@
+/* Copyright Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package io.istio.network.tlv_authn;
+
+message Config {
+  // TODO needed for our use?
+  // Share the filter state with the upstream connections. This is meant to be
+  // used in the tunnel listeners.
+  bool shared = 1;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the most basic filter for propagating identity from the sandwich 

// TODO link the zTunnel PR here that sets the TLV header

**Which issue this PR fixes** 

First step towards https://github.com/istio/istio/issues/48362

**Special notes for your reviewer**:

This uses 0xD0 as the key for the spiffe string. We could support multiple formats here, e.g.

0xD0 -> SPIFFE string directly into peer_principal
0XD1 -> A JWT that also sets some metadata

