### PR TITLE
skip proto_util_speed_test on macm1

### DIFF
--- a/extensions/common/BUILD
+++ b/extensions/common/BUILD
@@ -123,22 +123,29 @@ envoy_cc_test(
     ],
 )
 
+# TODO: fix this build on mac m1?
 envoy_extension_cc_benchmark_binary(
     name = "proto_util_speed_test",
-    srcs = ["proto_util_speed_test.cc"],
+    srcs = select({
+        "@envoy//bazel:linux": ["proto_util_speed_test.cc"],
+        "//conditions:default": [],
+    }),
     extension_names = ["envoy.wasm.runtime.null"],
     external_deps = [
         "benchmark",
     ],
     repository = "@envoy",
-    deps = [
-        ":metadata_object_lib",
-        ":node_info_fb_cc",
-        ":proto_util",
-        "@envoy//source/common/stream_info:filter_state_lib",
-        "@envoy//source/extensions/filters/common/expr:cel_state_lib",
-        "@envoy//test/test_common:status_utility_lib",
-    ],
+    deps = select({
+        "@envoy//bazel:linux": [
+            ":metadata_object_lib",
+            ":node_info_fb_cc",
+            ":proto_util",
+            "@envoy//source/common/stream_info:filter_state_lib",
+            "@envoy//source/extensions/filters/common/expr:cel_state_lib",
+            "@envoy//test/test_common:status_utility_lib",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 flatbuffer_library_public(


### PR DESCRIPTION
get rid of the following error:
```console
ERROR: /Users/zirain/Codes/istio.io/proxy/extensions/common/BUILD:126:36: Linking extensions/common/proto_util_speed_test failed: (Exit 1): cc_wrapper.sh failed: error executing command (from target //extensions/common:proto_util_speed_test) external/local_config_cc/cc_wrapper.sh @bazel-out/darwin_arm64-fastbuild/bin/extensions/common/proto_util_speed_test-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld: warning: ignoring duplicate libraries: '-lc++', '-lm', '-lpthread'
Undefined symbols for architecture arm64:
  "cel::base_internal::MessageTypeName(unsigned long)", referenced from:
      cel::base_internal::LegacyStructType::name() const in libdata.a[23](struct_type.o)
  "cel::base_internal::LegacyMapValueGet(unsigned long, cel::ValueFactory&, cel::Handle<cel::Value> const&)", referenced from:
      cel::base_internal::LegacyMapValue::FindImpl(cel::ValueFactory&, cel::Handle<cel::Value> const&) const in libdata.a[39](map_value.o)
  "cel::base_internal::LegacyMapValueHas(unsigned long, cel::Handle<cel::Value> const&)", referenced from:
      cel::base_internal::LegacyMapValue::HasImpl(cel::ValueFactory&, cel::Handle<cel::Value> const&) const in libdata.a[39](map_value.o)
  "cel::base_internal::LegacyListValueGet(unsigned long, cel::ValueFactory&, unsigned long)", referenced from:
      cel::base_internal::LegacyListValue::GetImpl(cel::ValueFactory&, unsigned long) const in libdata.a[37](list_value.o)
      cel::base_internal::(anonymous namespace)::LegacyListValueIterator::Next() in libdata.a[37](list_value.o)
  "cel::base_internal::LegacyMapValueSize(unsigned long)", referenced from:
      cel::base_internal::LegacyMapValue::Size() const in libdata.a[39](map_value.o)
  "cel::base_internal::MessageValueEquals(unsigned long, unsigned long, cel::Value const&)", referenced from:
      cel::base_internal::LegacyStructValue::Equals(cel::ValueFactory&, cel::Value const&) const in libdata.a[45](struct_value.o)
  "cel::base_internal::LegacyListValueSize(unsigned long)", referenced from:
      cel::base_internal::LegacyListValue::Size() const in libdata.a[37](list_value.o)
      cel::base_internal::(anonymous namespace)::LegacyListValueIterator::LegacyListValueIterator(cel::ValueFactory&, unsigned long) in libdata.a[37](list_value.o)
  "cel::base_internal::LegacyMapValueEmpty(unsigned long)", referenced from:
      cel::base_internal::LegacyMapValue::IsEmpty() const in libdata.a[39](map_value.o)
      cel::base_internal::(anonymous namespace)::LegacyMapValueIterator::HasNext() in libdata.a[39](map_value.o)
  "cel::base_internal::MessageValueQualify(unsigned long, unsigned long, cel::ValueFactory&, absl::lts_20230802::Span<std::__1::variant<cel::FieldSpecifier, cel::AttributeQualifier> const>, bool)", referenced from:
      cel::base_internal::LegacyStructValue::Qualify(cel::ValueFactory&, absl::lts_20230802::Span<std::__1::variant<cel::FieldSpecifier, cel::AttributeQualifier> const>, bool) const in libdata.a[45](struct_value.o)
  "cel::base_internal::LegacyListValueAnyOf(cel::ValueFactory&, unsigned long, absl::lts_20230802::FunctionRef<absl::lts_20230802::StatusOr<bool> (cel::Handle<cel::Value> const&)>)", referenced from:
      cel::base_internal::LegacyListValue::AnyOf(cel::ValueFactory&, absl::lts_20230802::FunctionRef<absl::lts_20230802::StatusOr<bool> (cel::Handle<cel::Value> const&)>) const in libdata.a[37](list_value.o)
  "cel::base_internal::LegacyListValueEmpty(unsigned long)", referenced from:
      cel::base_internal::LegacyListValue::IsEmpty() const in libdata.a[37](list_value.o)
  "cel::base_internal::MessageTypeFieldCount(unsigned long)", referenced from:
      cel::base_internal::LegacyStructType::field_count() const in libdata.a[23](struct_type.o)
  "cel::base_internal::LegacyMapValueListKeys(unsigned long, cel::ValueFactory&)", referenced from:
      cel::base_internal::LegacyMapValue::ListKeys(cel::ValueFactory&) const in libdata.a[39](map_value.o)
      cel::base_internal::(anonymous namespace)::LegacyMapValueIterator::OnNext() in libdata.a[39](map_value.o)
  "cel::base_internal::MessageValueFieldCount(unsigned long, unsigned long)", referenced from:
      cel::base_internal::LegacyStructValue::field_count() const in libdata.a[45](struct_value.o)
  "cel::base_internal::MessageValueListFields(unsigned long, unsigned long)", referenced from:
      cel::base_internal::LegacyStructValueFieldIterator::LegacyStructValueFieldIterator(cel::ValueFactory&, unsigned long, unsigned long) in libdata.a[45](struct_value.o)
  "cel::base_internal::LegacyListValueContains(cel::ValueFactory&, unsigned long, cel::Handle<cel::Value> const&)", referenced from:
      cel::base_internal::LegacyListValue::Contains(cel::ValueFactory&, cel::Handle<cel::Value> const&) const in libdata.a[37](list_value.o)
  "cel::base_internal::MessageValueGetFieldByName(unsigned long, unsigned long, cel::ValueFactory&, std::__1::basic_string_view<char, std::__1::char_traits<char>>, bool)", referenced from:
      cel::base_internal::LegacyStructValue::GetFieldByName(cel::ValueFactory&, std::__1::basic_string_view<char, std::__1::char_traits<char>>) const in libdata.a[45](struct_value.o)
      cel::base_internal::LegacyStructValue::GetWrappedFieldByName(cel::ValueFactory&, std::__1::basic_string_view<char, std::__1::char_traits<char>>) const in libdata.a[45](struct_value.o)
      cel::base_internal::LegacyStructValueFieldIterator::Next() in libdata.a[45](struct_value.o)
  "cel::base_internal::MessageValueHasFieldByName(unsigned long, unsigned long, std::__1::basic_string_view<char, std::__1::char_traits<char>>)", referenced from:
      cel::base_internal::LegacyStructValue::HasFieldByName(cel::TypeManager&, std::__1::basic_string_view<char, std::__1::char_traits<char>>) const in libdata.a[45](struct_value.o)
  "cel::base_internal::MessageValueGetFieldByNumber(unsigned long, unsigned long, cel::ValueFactory&, long long, bool)", referenced from:
      cel::base_internal::LegacyStructValue::GetFieldByNumber(cel::ValueFactory&, long long) const in libdata.a[45](struct_value.o)
  "cel::base_internal::MessageValueHasFieldByNumber(unsigned long, unsigned long, long long)", referenced from:
      cel::base_internal::LegacyStructValue::HasFieldByNumber(cel::TypeManager&, long long) const in libdata.a[45](struct_value.o)
ld: symbol(s) not found for architecture arm64
```