### PR TITLE
Enable QAT key provider

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -507,7 +507,7 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.network.sip_proxy",
     "envoy.filters.sip.router",
     "envoy.tls.key_providers.cryptomb",
-    # "envoy.tls.key_providers.qat", # TODO enable this later
+    "envoy.tls.key_providers.qat",
     "envoy.network.connection_balance.dlb",
 ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The qat key provider was disabled due to CI breaking https://github.com/istio/proxy/pull/5411#issuecomment-2017030825, now the build issue was fixed by https://github.com/envoyproxy/envoy/pull/33143, so enable it again.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #5411

**Special notes for your reviewer**:
