### PR TITLE
ambient: sync workload proto

### DIFF
--- a/source/extensions/common/workload_discovery/discovery.proto
+++ b/source/extensions/common/workload_discovery/discovery.proto
@@ -22,19 +22,28 @@ option go_package = "test/envoye2e/workloadapi";
  * https://github.com/istio/ztunnel/blob/e36680f1534fae3d158964500ae9185495ec5d7b/proto/workload.proto
  * with the following changes:
  *
- * 1) delete unused fields;
- * 2) change go_package;
- * 3) append bootstrap extension stub;
+ * 1) change go_package;
+ * 2) append bootstrap extension stub;
  */
 
 message Workload {
+  // UID represents a globally unique opaque identifier for this workload.
+  // For k8s resources, it is recommended to use the more readable format:
+  //
+  // cluster/group/kind/namespace/name/section-name
+  //
+  // As an example, a ServiceEntry with two WorkloadEntries inlined could become
+  // two Workloads with the following UIDs:
+  // - cluster1/networking.istio.io/v1alpha3/ServiceEntry/default/external-svc/endpoint1
+  // - cluster1/networking.istio.io/v1alpha3/ServiceEntry/default/external-svc/endpoint2
+  //
+  // For VMs and other workloads other formats are also supported; for example,
+  // a single UID string: "0ae5c03d-5fb3-4eb9-9de8-2bd4b51606ba"
   string uid = 20;
-
   // Name represents the name for the workload.
   // For Kubernetes, this is the pod name.
   // This is just for debugging and may be elided as an optimization.
   string name = 1;
-
   // Namespace represents the namespace for the workload.
   // This is just for debugging and may be elided as an optimization.
   string namespace = 2;
@@ -43,61 +52,87 @@ message Workload {
   // This should be globally unique.
   // This should not have a port number.
   // Each workload must have at least either an address or hostname; not both.
-  // TODO: support dual stack by making this repeated
-  // TODO: when this is repeated, update xds primary key from network/IP to network/UID
   repeated bytes addresses = 3;
 
-  reserved "hostname";
-  reserved 21;
+  // The hostname for the workload to be resolved by the ztunnel.
+  // DNS queries are sent on-demand by default.
+  // If the resolved DNS query has several endpoints, the request will be forwarded
+  // to the first response.
+  //
+  // At a minimum, each workload must have either an address or hostname. For example,
+  // a workload that backs a Kubernetes service will typically have only endpoints. A
+  // workload that backs a headless Kubernetes service, however, will have both
+  // addresses as well as a hostname used for direct access to the headless endpoint.
+  // TODO: support this field
+  string hostname = 21;
 
   // Network represents the network this workload is on. This may be elided for the default network.
   // A (network,address) pair makeup a unique key for a workload *at a point in time*.
   string network = 4;
 
-  reserved "tunnel_protocol";
-  reserved 5;
+  // Protocol that should be used to connect to this workload.
+  TunnelProtocol tunnel_protocol = 5;
 
   // The SPIFFE identity of the workload. The identity is joined to form spiffe://<trust_domain>/ns/<namespace>/sa/<service_account>.
   // TrustDomain of the workload. May be elided if this is the mesh wide default (typically cluster.local)
   string trust_domain = 6;
-
   // ServiceAccount of the workload. May be elided if this is "default"
   string service_account = 7;
 
-  reserved "waypoint";
-  reserved 8;
+  // If present, the waypoint proxy for this workload.
+  // All incoming requests must go through the waypoint.
+  GatewayAddress waypoint = 8;
 
-  reserved "network_gateway";
-  reserved 19;
+  // If present, East West network gateway this workload can be reached through.
+  // Requests from remote networks should traverse this gateway.
+  GatewayAddress network_gateway = 19;
 
-  reserved "node";
-  reserved 9;
+  // Name of the node the workload runs on
+  string node = 9;
 
   // CanonicalName for the workload. Used for telemetry.
   string canonical_name = 10;
-
   // CanonicalRevision for the workload. Used for telemetry.
   string canonical_revision = 11;
-
   // WorkloadType represents the type of the workload. Used for telemetry.
   WorkloadType workload_type = 12;
-
   // WorkloadName represents the name for the workload (of type WorkloadType). Used for telemetry.
   string workload_name = 13;
 
-  reserved "native_tunnel";
-  reserved 14;
+  // If set, this indicates a workload expects to directly receive tunnel traffic.
+  // In ztunnel, this means:
+  // * Requests *from* this workload do not need to be tunneled if they already are tunneled by the tunnel_protocol.
+  // * Requests *to* this workload, via the tunnel_protocol, do not need to be de-tunneled.
+  bool native_tunnel = 14;
 
-  reserved "virtual_ips";
-  reserved 15;
+  // If an application, such as a sandwiched waypoint proxy, supports directly
+  // receiving information from zTunnel they can set application_protocol.
+  ApplicationTunnel application_tunnel = 23;
 
-  reserved "authorization_policies";
-  reserved 16;
+  // The services for which this workload is an endpoint.
+  // The key is the NamespacedHostname string of the format namespace/hostname.
+  map<string, PortList> services = 22;
 
-  reserved "status";
-  reserved 17;
+  // A list of authorization policies applicable to this workload.
+  // NOTE: this *only* includes Selector based policies. Namespace and global polices
+  // are returned out of band.
+  // Authorization policies are only valid for workloads with `addresses` rather than `hostname`.
+  repeated string authorization_policies = 16;
 
+  WorkloadStatus status = 17;
+
+  // The cluster ID that the workload instance belongs to
   string cluster_id = 18;
+
+  // Reservations for deleted fields.
+  reserved 15;
+}
+
+enum WorkloadStatus {
+  // Workload is healthy and ready to serve traffic.
+  HEALTHY = 0;
+  // Workload is unhealthy and NOT ready to serve traffic.
+  UNHEALTHY = 1;
 }
 
 enum WorkloadType {
@@ -105,4 +140,80 @@ enum WorkloadType {
   CRONJOB = 1;
   POD = 2;
   JOB = 3;
+}
+
+// PorList represents the ports for a service
+message PortList {
+  repeated Port ports = 1;
+}
+
+message Port {
+  // Port the service is reached at (frontend).
+  uint32 service_port = 1;
+  // Port the service forwards to (backend).
+  uint32 target_port = 2;
+}
+
+// TunnelProtocol indicates the tunneling protocol for requests.
+enum TunnelProtocol {
+  // NONE means requests should be forwarded as-is, without tunneling.
+  NONE = 0;
+  // HBONE means requests should be tunneled over HTTP.
+  // This does not dictate HTTP/1.1 vs HTTP/2; ALPN should be used for that purpose.
+  HBONE = 1;
+  // Future options may include things like QUIC/HTTP3, etc.
+}
+
+// ApplicationProtocol specifies a workload  (application or gateway) can
+// consume tunnel information.
+message ApplicationTunnel {
+  enum Protocol {
+    // Bytes are copied from the inner stream without modification.
+    NONE = 0;
+
+    // Prepend PROXY protocol headers before copying bytes
+    // Standard PROXY source and destination information
+    // is included, along with potential extra TLV headers:
+    // 0xD0 - The SPIFFE identity of the source workload
+    // 0xD1 - The FQDN or Hostname of the targeted Service
+    PROXY = 1;
+  }
+
+  // A target natively handles this type of traffic.
+  Protocol protocol = 1;
+
+  // optional: if set, traffic should be sent to this port after the last zTunnel hop
+  uint32 port = 2;
+}
+
+// GatewayAddress represents the address of a gateway
+message GatewayAddress {
+  // address can either be a hostname (ex: gateway.example.com) or an IP (ex: 1.2.3.4).
+  oneof destination {
+    // TODO: add support for hostname lookup
+    NamespacedHostname hostname = 1;
+    NetworkAddress address = 2;
+  }
+  // port to reach the gateway at for mTLS HBONE connections
+  uint32 hbone_mtls_port = 3;
+  // port to reach the gateway at for single tls HBONE connections
+  // used for sending unauthenticated traffic originating outside the mesh to a waypoint-enabled destination
+  // A value of 0 = unset
+  uint32 hbone_single_tls_port = 4;
+}
+
+// NetworkAddress represents an address bound to a specific network.
+message NetworkAddress {
+  // Network represents the network this address is on.
+  string network = 1;
+  // Address presents the IP (v4 or v6).
+  bytes address = 2;
+}
+
+// NamespacedHostname represents a service bound to a specific namespace.
+message NamespacedHostname {
+  // The namespace the service is in.
+  string namespace = 1;
+  // hostname (ex: gateway.example.com)
+  string hostname = 2;
 }


### PR DESCRIPTION
reserving fields doesn't work; the proto engine will still spam logs
about usage of unknown fields

Fixes https://github.com/istio/istio/issues/46143
