### PR TITLE
Ambient Telemetry: implement "waypoint single" approach 

### DIFF
--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -91,6 +91,7 @@ std::string_view ProtocolString(Protocol protocol);
 
 // RequestInfo represents the information collected from filter stream
 // callbacks. This is used to fill metrics and logs.
+// TODO: do we want to include waypoint specific variables and maintain source and dest as the workloads?
 struct RequestInfo {
   // Start timestamp in nanoseconds.
   int64_t start_time;

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -89,6 +89,8 @@ std::string_view AuthenticationPolicyString(ServiceAuthenticationPolicy policy);
 std::string_view TCPConnectionStateString(TCPConnectionState state);
 std::string_view ProtocolString(Protocol protocol);
 
+// RequestInfo represents the information collected from filter stream
+// callbacks. This is used to fill metrics and logs.
 struct RequestInfo {
   // Start timestamp in nanoseconds.
   int64_t start_time;

--- a/extensions/common/context.h
+++ b/extensions/common/context.h
@@ -89,9 +89,6 @@ std::string_view AuthenticationPolicyString(ServiceAuthenticationPolicy policy);
 std::string_view TCPConnectionStateString(TCPConnectionState state);
 std::string_view ProtocolString(Protocol protocol);
 
-// RequestInfo represents the information collected from filter stream
-// callbacks. This is used to fill metrics and logs.
-// TODO: do we want to include waypoint specific variables and maintain source and dest as the workloads?
 struct RequestInfo {
   // Start timestamp in nanoseconds.
   int64_t start_time;

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -170,7 +170,7 @@ struct Context : public Singleton::Instance {
         destination_service_namespace_(pool_.add("destination_service_namespace")),
         destination_canonical_service_(pool_.add("destination_canonical_service")),
         destination_canonical_revision_(pool_.add("destination_canonical_revision")),
-        destination_cluster_(pool_.add("destination_cluster")), 
+        destination_cluster_(pool_.add("destination_cluster")),
         request_protocol_(pool_.add("request_protocol")),
         response_flags_(pool_.add("response_flags")),
         connection_security_policy_(pool_.add("connection_security_policy")),
@@ -1136,7 +1136,6 @@ private:
       switch (config_->reporter()) {
       case Reporter::ServerGateway: {
         std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
-        // INFO: "wasm.upstream_peer" is the filter state returned
         const auto* endpoint_object = peerInfo(Reporter::ClientSidecar, filter_state);
         if (endpoint_object) {
           endpoint_peer.emplace(Istio::Common::convertFlatNodeToWorkloadMetadata(*endpoint_object));
@@ -1148,8 +1147,7 @@ private:
                          endpoint_peer && !endpoint_peer->namespace_name_.empty()
                              ? pool_.add(endpoint_peer->namespace_name_)
                              : context_.unknown_});
-        tags_.push_back({context_.destination_principal_,
-                         !peer_san.empty() ? pool_.add(peer_san) : context_.unknown_});
+        tags_.push_back({context_.destination_principal_, !local_san.empty() ? pool_.add(local_san) : context_.unknown_});
         // Endpoint encoding does not have app and version.
         tags_.push_back(
             {context_.destination_app_, endpoint_peer && !endpoint_peer->app_name_.empty()

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -185,9 +185,8 @@ struct Context : public Singleton::Instance {
         cluster_name_(pool_.add(extractString(node.metadata(), "CLUSTER_ID"))),
         app_name_(pool_.add(extractMapString(node.metadata(), "LABELS", "app"))),
         app_version_(pool_.add(extractMapString(node.metadata(), "LABELS", "version"))),
-        waypoint_(pool_.add("waypoint")),
-        istio_build_(pool_.add("istio_build")), component_(pool_.add("component")),
-        proxy_(pool_.add("proxy")), tag_(pool_.add("tag")),
+        waypoint_(pool_.add("waypoint")), istio_build_(pool_.add("istio_build")),
+        component_(pool_.add("component")), proxy_(pool_.add("proxy")), tag_(pool_.add("tag")),
         istio_version_(pool_.add(extractString(node.metadata(), "ISTIO_VERSION"))) {
     all_metrics_ = {
         {"requests_total", requests_total_},
@@ -1147,7 +1146,8 @@ private:
                          endpoint_peer && !endpoint_peer->namespace_name_.empty()
                              ? pool_.add(endpoint_peer->namespace_name_)
                              : context_.unknown_});
-        tags_.push_back({context_.destination_principal_, !local_san.empty() ? pool_.add(local_san) : context_.unknown_});
+        tags_.push_back({context_.destination_principal_,
+                         !local_san.empty() ? pool_.add(local_san) : context_.unknown_});
         // Endpoint encoding does not have app and version.
         tags_.push_back(
             {context_.destination_app_, endpoint_peer && !endpoint_peer->app_name_.empty()

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -5,7 +5,7 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: destination
+    value: waypoint
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service
@@ -29,9 +29,9 @@ metric:
   - name: destination_principal
     value: spiffe://cluster.local/ns/default/sa/server
   - name: destination_app
-    value: unknown
+    value: ratings
   - name: destination_version
-    value: unknown
+    value: version-1
   - name: destination_service
     value: server.default.svc.cluster.local
   - name: destination_canonical_service

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -5,11 +5,11 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: destination # waypoint
+    value: waypoint
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service
-    value: unknown
+    value: productpage-v1
   - name: source_canonical_revision
     value: latest
   - name: source_workload_namespace
@@ -17,11 +17,11 @@ metric:
   - name: source_principal
     value: spiffe://cluster.local/ns/default/sa/client
   - name: source_app
-    value: unknown
+    value: productpage-v1
   - name: source_version
-    value: unknown
+    value: latest
   - name: source_cluster
-    value: unknown
+    value: client
   - name: destination_workload
     value: ratings-v1
   - name: destination_workload_namespace
@@ -29,9 +29,9 @@ metric:
   - name: destination_principal
     value: spiffe://cluster.local/ns/default/sa/server
   - name: destination_app
-    value: unknown
+    value: ratings
   - name: destination_version
-    value: unknown
+    value: version-1
   - name: destination_service
     value: server.default.svc.cluster.local
   - name: destination_canonical_service

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -5,7 +5,7 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: destination
+    value: destination # waypoint
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -5,11 +5,11 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: waypoint
+    value: destination
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service
-    value: productpage-v1
+    value: unknown
   - name: source_canonical_revision
     value: latest
   - name: source_workload_namespace
@@ -17,11 +17,11 @@ metric:
   - name: source_principal
     value: spiffe://cluster.local/ns/default/sa/client
   - name: source_app
-    value: productpage-v1
+    value: unknown
   - name: source_version
-    value: latest
+    value: unknown
   - name: source_cluster
-    value: Kubernetes
+    value: unknown
   - name: destination_workload
     value: ratings-v1
   - name: destination_workload_namespace
@@ -29,9 +29,9 @@ metric:
   - name: destination_principal
     value: spiffe://cluster.local/ns/default/sa/server
   - name: destination_app
-    value: ratings
+    value: unknown
   - name: destination_version
-    value: version-1
+    value: unknown
   - name: destination_service
     value: server.default.svc.cluster.local
   - name: destination_canonical_service

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -21,7 +21,7 @@ metric:
   - name: source_version
     value: latest
   - name: source_cluster
-    value: client
+    value: Kubernetes
   - name: destination_workload
     value: ratings-v1
   - name: destination_workload_namespace

--- a/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
@@ -5,7 +5,7 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: destination
+    value: waypoint
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service
@@ -29,9 +29,9 @@ metric:
   - name: destination_principal
     value: unknown
   - name: destination_app
-    value: unknown
+    value: ratings
   - name: destination_version
-    value: unknown
+    value: version-1
   - name: destination_service
     value: server.default.svc.cluster.local
   - name: destination_canonical_service

--- a/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
@@ -5,7 +5,7 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: destination #waypoint
+    value: waypoint
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service
@@ -27,7 +27,7 @@ metric:
   - name: destination_workload_namespace
     value: default
   - name: destination_principal
-    value: unknown # destination workload principal (ratings)
+    value: unknown
   - name: destination_app
     value: unknown
   - name: destination_version

--- a/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
@@ -5,7 +5,7 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: destination
+    value: destination #waypoint
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service
@@ -27,7 +27,7 @@ metric:
   - name: destination_workload_namespace
     value: default
   - name: destination_principal
-    value: unknown
+    value: unknown # destination workload principal (ratings)
   - name: destination_app
     value: unknown
   - name: destination_version

--- a/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
@@ -5,7 +5,7 @@ metric:
     value: {{ .Vars.RequestCount }}
   label:
   - name: reporter
-    value: waypoint
+    value: destination
   - name: source_workload
     value: productpage-v1
   - name: source_canonical_service


### PR DESCRIPTION
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Part of [#50225](https://github.com/istio/istio/issues/50225)

This fixes the destination workload unknown fields. The `destination_principal` still needs to be fixed.

Expected metric:
```
istio_requests_total{reporter="waypoint",source_workload="shell",source_canonical_service="shell",source_canonical_revision="latest",source_workload_namespace="default",source_principal="spiffe://cluster.local/ns/default/sa/shell",source_app="shell",source_version="latest",source_cluster="Kubernetes",destination_workload="echo",destination_workload_namespace="default",destination_principal="unknown",destination_app="echo",destination_version="latest",destination_service="echo-service.default.svc.cluster.local",destination_canonical_service="echo",destination_canonical_revision="latest",destination_service_name="echo-service",destination_service_namespace="default",destination_cluster="Kubernetes",request_protocol="http",response_code="200",grpc_response_status="",response_flags="-",connection_security_policy="mutual_tls"}
```
