### PR TITLE
ambient: Fix destination principal with WDS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,16 @@ to find out how you can help.
 ## Prerequisites
 
 To make sure you're ready to build Envoy, clone and follow the upstream Envoy [build instructions](https://github.com/envoyproxy/envoy/blob/main/bazel/README.md). Be sure to copy clang.bazelrc into this directory after running the setup_clang script. Confirm that your environment is ready to go by running `bazel build --config=clang --define=wasm=disabled :envoy` (in this directory).
+
+## How to use a devcontainer
+
+1. Change the image in .devcontainer.json to `build-tools-proxy` instead of `build-tools`
+2. Open the directory in a container with the Remote - Containers extension
+3. Install the following extensions:
+    - [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd)
+    - [bazel-stack-vscode-cc](https://marketplace.visualstudio.com/items?itemName=StackBuild.bazel-stack-vscode-cc)
+4. Update clangd and reload the container
+5. Edit the new `bsv.cc.compdb.targets` workspace setting and set it to `//:envoy_tar`
+6. Execute `Bazel/C++: Generate Compilation Database` within vscode
+
+Note: if you have a remote bazel cache or something mounted in your build container for your normal proxy builds, you'll need to configure that in the devcontainer with runArgs.

--- a/extensions/common/metadata_object.h
+++ b/extensions/common/metadata_object.h
@@ -71,11 +71,12 @@ struct WorkloadMetadataObject : public Envoy::StreamInfo::FilterState::Object,
                                   absl::string_view namespace_name, absl::string_view workload_name,
                                   absl::string_view canonical_name,
                                   absl::string_view canonical_revision, absl::string_view app_name,
-                                  absl::string_view app_version, const WorkloadType workload_type)
+                                  absl::string_view app_version, const WorkloadType workload_type,
+                                  absl::string_view identity)
       : instance_name_(instance_name), cluster_name_(cluster_name), namespace_name_(namespace_name),
         workload_name_(workload_name), canonical_name_(canonical_name),
         canonical_revision_(canonical_revision), app_name_(app_name), app_version_(app_version),
-        workload_type_(workload_type) {}
+        workload_type_(workload_type), identity_(identity) {}
 
   static WorkloadMetadataObject fromBaggage(absl::string_view baggage_header_value);
 
@@ -94,6 +95,7 @@ struct WorkloadMetadataObject : public Envoy::StreamInfo::FilterState::Object,
   const std::string app_name_;
   const std::string app_version_;
   const WorkloadType workload_type_;
+  const std::string identity_;
 };
 
 // Convert metadata object to flatbuffer.

--- a/extensions/common/metadata_object_test.cc
+++ b/extensions/common/metadata_object_test.cc
@@ -24,25 +24,25 @@ using ::testing::NiceMock;
 
 TEST(WorkloadMetadataObjectTest, Hash) {
   WorkloadMetadataObject obj1("foo-pod-12345", "my-cluster", "default", "foo", "foo", "latest",
-                              "foo-app", "v1", WorkloadType::Deployment);
+                              "foo-app", "v1", WorkloadType::Deployment, "");
   WorkloadMetadataObject obj2("foo-pod-12345", "my-cluster", "default", "bar", "baz", "first",
-                              "foo-app", "v1", WorkloadType::Job);
+                              "foo-app", "v1", WorkloadType::Job, "");
 
   EXPECT_EQ(obj1.hash().value(), obj2.hash().value());
 }
 
 TEST(WorkloadMetadataObjectTest, Baggage) {
   WorkloadMetadataObject deploy("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                "v1alpha3", "foo-app", "v1", WorkloadType::Deployment);
+                                "v1alpha3", "foo-app", "v1", WorkloadType::Deployment, "");
 
   WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                             "v1alpha3", "foo-app", "v1", WorkloadType::Pod);
+                             "v1alpha3", "foo-app", "v1", WorkloadType::Pod, "");
 
   WorkloadMetadataObject cronjob("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                 "v1alpha3", "foo-app", "v1", WorkloadType::CronJob);
+                                 "v1alpha3", "foo-app", "v1", WorkloadType::CronJob, "");
 
   WorkloadMetadataObject job("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                             "v1alpha3", "foo-app", "v1", WorkloadType::Job);
+                             "v1alpha3", "foo-app", "v1", WorkloadType::Job, "");
 
   EXPECT_EQ(deploy.baggage(), absl::StrCat("k8s.deployment.name=foo,k8s.cluster.name=my-cluster,",
                                            "k8s.namespace.name=default,",

--- a/extensions/common/node_info.fbs
+++ b/extensions/common/node_info.fbs
@@ -45,6 +45,8 @@ table FlatNode {
   cluster_id:string;
   // instance ip addresses
   instance_ips:[string];
+  // identity of the proxy
+  identity:string;
 }
 
 root_type FlatNode;

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1147,7 +1147,7 @@ private:
                              ? pool_.add(endpoint_peer->namespace_name_)
                              : context_.unknown_});
         tags_.push_back({context_.destination_principal_,
-                         !local_san.empty() ? pool_.add(local_san) : context_.unknown_});
+                         endpoint_peer ? pool_.add(endpoint_peer->identity_) : context_.unknown_});
         // Endpoint encoding does not have app and version.
         tags_.push_back(
             {context_.destination_app_, endpoint_peer && !endpoint_peer->app_name_.empty()

--- a/source/extensions/filters/http/peer_metadata/filter_test.cc
+++ b/source/extensions/filters/http/peer_metadata/filter_test.cc
@@ -132,7 +132,8 @@ TEST_F(PeerMetadataTest, DownstreamXDSNone) {
 
 TEST_F(PeerMetadataTest, DownstreamXDS) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod);
+                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod,
+                                   "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
@@ -154,7 +155,8 @@ TEST_F(PeerMetadataTest, DownstreamXDS) {
 
 TEST_F(PeerMetadataTest, UpstreamXDS) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod);
+                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod,
+                                   "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
@@ -190,7 +192,8 @@ TEST_F(PeerMetadataTest, UpstreamXDSInternal) {
                             *host_metadata);
 
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod);
+                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod,
+                                   "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
@@ -259,7 +262,8 @@ TEST_F(PeerMetadataTest, DownstreamFallbackFirst) {
 
 TEST_F(PeerMetadataTest, DownstreamFallbackSecond) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "default", "foo", "foo-service",
-                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod);
+                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod,
+                                   "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
@@ -341,7 +345,8 @@ TEST_F(PeerMetadataTest, UpstreamFallbackFirst) {
 
 TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod);
+                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod,
+                                   "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {
@@ -363,7 +368,8 @@ TEST_F(PeerMetadataTest, UpstreamFallbackSecond) {
 
 TEST_F(PeerMetadataTest, UpstreamFallbackFirstXDS) {
   const WorkloadMetadataObject pod("pod-foo-1234", "my-cluster", "foo", "foo", "foo-service",
-                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod);
+                                   "v1alpha3", "foo-app", "v1", Istio::Common::WorkloadType::Pod,
+                                   "");
   EXPECT_CALL(*metadata_provider_, GetMetadata(_))
       .WillRepeatedly(Invoke([&](const Network::Address::InstanceConstSharedPtr& address)
                                  -> std::optional<WorkloadMetadataObject> {

--- a/test/envoye2e/driver/stats.go
+++ b/test/envoye2e/driver/stats.go
@@ -61,7 +61,7 @@ func (s *Stats) Run(p *Params) error {
 				log.Printf("matched metric %q", metric.GetName())
 				count++
 				continue
-			} else if _, ok := matcher.(*MissingStat); ok && err != nil {
+			} else if _, ok := matcher.(*MissingStat); ok {
 				return fmt.Errorf("found metric that should have been missing: %s", metric.GetName())
 			}
 			log.Printf("metric %q did not match: %v\n", metric.GetName(), err)

--- a/test/envoye2e/env/wasm.go
+++ b/test/envoye2e/env/wasm.go
@@ -50,7 +50,7 @@ func EnsureWasmFiles(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.WriteFile(file, content, 0666)
+		err = os.WriteFile(file, content, 0o666)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -638,6 +638,13 @@ workload_name: ratings-v1
 canonical_name: ratings
 canonical_revision: version-1
 uid: //v1/pod/default/ratings
+service_account: ratings
+trust_domain: cluster.global
+`
+
+const ProductPageMetadata = `
+workload_name: productpage-v1
+uid: //v1/pod/default/productpage
 `
 
 func TestStatsServerWaypointProxy(t *testing.T) {
@@ -684,11 +691,6 @@ func TestStatsServerWaypointProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
-const ProductPageMetadata = `
-workload_name: productpage-v1
-uid: //v1/pod/default/productpage
-`
 
 func TestStatsServerWaypointProxyCONNECT(t *testing.T) {
 	params := driver.NewTestParams(t, map[string]string{

--- a/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl
@@ -27,7 +27,7 @@ metric:
   - name: destination_workload_namespace
     value: default
   - name: destination_principal
-    value: spiffe://cluster.local/ns/default/sa/server
+    value: spiffe://cluster.global/ns/default/sa/ratings
   - name: destination_app
     value: ratings
   - name: destination_version

--- a/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
+++ b/testdata/metric/server_waypoint_proxy_request_total.yaml.tmpl
@@ -27,7 +27,7 @@ metric:
   - name: destination_workload_namespace
     value: default
   - name: destination_principal
-    value: unknown
+    value: spiffe://cluster.global/ns/default/sa/ratings
   - name: destination_app
     value: ratings
   - name: destination_version


### PR DESCRIPTION
Grab the service account and trust domain from WDS and use that to create the destination principal