### PR TITLE
use tcmalloc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,9 +23,6 @@ build:remote-ci --action_env=PATH=/usr/local/google-cloud-sdk/bin:/usr/sbin:/usr
 # See: https://github.com/envoyproxy/envoy/pull/6519
 build --define path_normalization_by_default=true
 
-# Heap profiler is supported only with gperf tcmalloc, not google tcmalloc.
-# See: https://github.com/istio/istio/issues/28233
-build:linux --define tcmalloc=gperftools
 build:macos --define tcmalloc=disabled
 
 # Build with embedded V8-based WebAssembly runtime.


### PR DESCRIPTION
Change-Id: Ifeb9f5315a9c0ef1e0f38580e5132cd468d7a79b

Heap profiling is supported by tcmalloc now: https://www.envoyproxy.io/docs/envoy/latest/faq/debugging/how_to_dump_heap_profile_of_envoy