### PR TITLE
Allow versionless cluster name match in stats

### DIFF
--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1027,6 +1027,7 @@ private:
       if (cluster_info && cluster_info.value()) {
         const auto& cluster_name = cluster_info.value()->name();
         if (cluster_name == "BlackHoleCluster" || cluster_name == "PassthroughCluster" ||
+            cluster_name == "InboundPassthroughCluster" ||
             cluster_name == "InboundPassthroughClusterIpv4" ||
             cluster_name == "InboundPassthroughClusterIpv6") {
           service_host_name = cluster_name;


### PR DESCRIPTION
For https://github.com/istio/istio/pull/51503, but also required even if
we don't change; for inbound HBONE we need to add initial support for
passthrough (https://github.com/istio/istio/issues/51336). I don't want
to start with legacy hacks on new code, so that will for sure use InboundPassthroughCluster
