### PR TITLE
Use cluster metadata for destination_service_name

### DIFF
--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1234,8 +1234,11 @@ private:
       tags_.push_back({context_.destination_service_name_, service_host_name.empty()
                                                                ? context_.unknown_
                                                                : pool_.add(service_host_name)});
-      tags_.push_back({context_.destination_service_namespace_,
-                       !service_namespace.empty() ? pool_.add(service_namespace) : context_.unknown_});
+      tags_.push_back({context_.destination_service_namespace_, !service_namespace.empty()
+                                                                    ? pool_.add(service_namespace)
+                                                                    : (peer ?
+                                                                        pool_.add(peer->namespace_name_)
+                                                                        : context_.unknown_)});
       tags_.push_back({context_.destination_cluster_, peer && !peer->cluster_name_.empty()
                                                           ? pool_.add(peer->cluster_name_)
                                                           : context_.unknown_});

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1234,11 +1234,10 @@ private:
       tags_.push_back({context_.destination_service_name_, service_host_name.empty()
                                                                ? context_.unknown_
                                                                : pool_.add(service_host_name)});
-      tags_.push_back({context_.destination_service_namespace_, !service_namespace.empty()
-                                                                    ? pool_.add(service_namespace)
-                                                                    : (peer ?
-                                                                        pool_.add(peer->namespace_name_)
-                                                                        : context_.unknown_)});
+      tags_.push_back({context_.destination_service_namespace_,
+                       !service_namespace.empty()
+                           ? pool_.add(service_namespace)
+                           : (peer ? pool_.add(peer->namespace_name_) : context_.unknown_)});
       tags_.push_back({context_.destination_cluster_, peer && !peer->cluster_name_.empty()
                                                           ? pool_.add(peer->cluster_name_)
                                                           : context_.unknown_});

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1011,6 +1011,7 @@ private:
     // Compute destination service with client-side fallbacks.
     absl::string_view service_host;
     absl::string_view service_host_name;
+    absl::string_view service_namespace;
     if (!config_->disable_host_header_fallback_) {
       const auto* headers = info.getRequestHeaders();
       if (headers && headers->Host()) {
@@ -1045,6 +1046,10 @@ private:
                   service_host = host_it->second.string_value();
                 }
                 const auto& name_it = service.find("name");
+                const auto& namespace_it = service.find("namespace");
+                if (namespace_it != service.end()) {
+                  service_namespace = namespace_it->second.string_value();
+                }
                 if (name_it != service.end()) {
                   service_host_name = name_it->second.string_value();
                 } else {
@@ -1230,7 +1235,7 @@ private:
                                                                ? context_.unknown_
                                                                : pool_.add(service_host_name)});
       tags_.push_back({context_.destination_service_namespace_,
-                       !peer_namespace.empty() ? pool_.add(peer_namespace) : context_.unknown_});
+                       !service_namespace.empty() ? pool_.add(service_namespace) : context_.unknown_});
       tags_.push_back({context_.destination_cluster_, peer && !peer->cluster_name_.empty()
                                                           ? pool_.add(peer->cluster_name_)
                                                           : context_.unknown_});

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1234,10 +1234,11 @@ private:
       tags_.push_back({context_.destination_service_name_, service_host_name.empty()
                                                                ? context_.unknown_
                                                                : pool_.add(service_host_name)});
-      tags_.push_back({context_.destination_service_namespace_,
-                       !service_namespace.empty()
-                           ? pool_.add(service_namespace)
-                           : (peer ? pool_.add(peer->namespace_name_) : context_.unknown_)});
+      tags_.push_back(
+          {context_.destination_service_namespace_,
+           !service_namespace.empty()
+               ? pool_.add(service_namespace)
+               : (!peer_namespace.empty() ? pool_.add(peer_namespace) : context_.unknown_)});
       tags_.push_back({context_.destination_cluster_, peer && !peer->cluster_name_.empty()
                                                           ? pool_.add(peer->cluster_name_)
                                                           : context_.unknown_});

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -56,5 +56,6 @@ func init() {
 		"TestTCPMetadataExchangeWithConnectionTermination",
 		"TestOtelPayload",
 		"TestTCPMetadataNotFoundReporting",
+		"TestStatsDestinationServiceNamespacePrecedence",
 	}...)
 }

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -112,19 +112,6 @@ var TestCases = []struct {
 		},
 		ElideServerMetadata: true,
 	},
-	{
-		Name:         "Default",
-		ClientConfig: "testdata/stats/client_config.yaml",
-		ServerConfig: "testdata/stats/server_config.yaml",
-		ClientStats: map[string]driver.StatMatcher{
-			"istio_requests_total": &driver.ExactStat{Metric: "client_request_total_cluster_metadata_precedence_service_namespace.yaml.tmpl"},
-		},
-		ServerStats: map[string]driver.StatMatcher{
-			"istio_requests_total": &driver.ExactStat{Metric: "testdata/metric/server_request_total.yaml.tmpl"},
-			"istio_build":          &driver.ExactStat{Metric: "testdata/metric/istio_build.yaml"},
-		},
-		TestParallel: true,
-	},
 }
 
 func enableStats(t *testing.T, vars map[string]string) {

--- a/testdata/bootstrap/client_cluster_metadata_precedence.yaml.tmpl
+++ b/testdata/bootstrap/client_cluster_metadata_precedence.yaml.tmpl
@@ -1,0 +1,82 @@
+node:
+  id: client
+  cluster: test-cluster
+  metadata: { {{ .Vars.ClientMetadata | fill }} }
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: {{ .Ports.ClientAdmin }}
+{{ .Vars.StatsConfig }}
+dynamic_resources:
+  ads_config:
+    api_type: DELTA_GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+static_resources:
+  clusters:
+  - connect_timeout: 5s
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: {{ .Ports.XDSPort }}
+    http2_protocol_options: {}
+    name: xds_cluster
+  - name: server-outbound-cluster
+    connect_timeout: 5s
+    type: STATIC
+    http2_protocol_options: {}
+    {{- if ne .Vars.ElideServerMetadata "true" }}
+    metadata:
+      filter_metadata:
+        istio:
+          services:
+            - host: server.default.svc.cluster.local
+              name: server
+              namespace: server
+    {{- end }}
+    load_assignment:
+      cluster_name: server-outbound-cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.2
+                port_value: {{ .Ports.ServerPort }}
+          {{- if eq .Vars.EnableEndpointMetadata "true" }}
+          metadata:
+            filter_metadata:
+              istio:
+                workload: ratings-v1;default;ratings;version-1;server-cluster
+          {{- end }}
+{{ .Vars.ClientTLSContext | indent 4 }}
+{{ .Vars.ClientStaticCluster | indent 2 }}
+bootstrap_extensions:
+- name: envoy.bootstrap.internal_listener
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener
+{{- if eq .Vars.EnableMetadataDiscovery "true" }}
+- name: metadata_discovery
+  typed_config:
+    "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+    type_url: type.googleapis.com/istio.workload.BootstrapExtension
+    value:
+      config_source:
+        ads: {}
+{{- end }}

--- a/testdata/metric/client_request_total_cluster_metadata_precedence.yaml.tmpl
+++ b/testdata/metric/client_request_total_cluster_metadata_precedence.yaml.tmpl
@@ -1,0 +1,60 @@
+name: istio_requests_total
+type: COUNTER
+metric:
+- counter:
+    value: {{ .Vars.RequestCount }}
+  label:
+  - name: reporter
+    value: source
+  - name: source_workload
+    value: productpage-v1
+  - name: source_canonical_service
+    value: productpage-v1
+  - name: source_canonical_revision
+    value: version-1
+  - name: source_workload_namespace
+    value: default
+  - name: source_principal
+    value: unknown
+  - name: source_app
+    value: productpage
+  - name: source_version
+    value: v1
+  - name: source_cluster
+    value: client-cluster
+  - name: destination_workload
+    value: ratings-v1
+  - name: destination_workload_namespace
+    value: default
+  - name: destination_principal
+    value: unknown
+  - name: destination_app
+    value: ratings
+  - name: destination_version
+    value: v1
+  - name: destination_service
+    value: server.default.svc.cluster.local
+  - name: destination_canonical_service
+    value: ratings
+  - name: destination_canonical_revision
+    value: version-1
+  - name: destination_service_name
+    value: server
+  - name: destination_service_namespace
+    value: server
+  - name: destination_cluster
+    value: server-cluster
+  - name: request_protocol
+    {{- if .Vars.GrpcResponseStatus }}
+    value: grpc
+    {{- else }}
+    value: http
+    {{- end }}
+  - name: response_code
+    value: "200"
+  - name: grpc_response_status
+    value: "{{ .Vars.GrpcResponseStatus }}"
+  - name: response_flags
+    value: "-"
+  - name: connection_security_policy
+    value: unknown


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes istio/istio#49842

**Special notes for your reviewer**:
~I'm setting the field to unknown right now just to confirm that we're retrieving the namespace from metadata correctly. Before we merge, it should probably fall back to peer metadata~ The only two tests that were failing were for clusters with no metadata; we're good to go here.
