### PR TITLE
CI: Add bazel extra args variable to prow scripts

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -31,7 +31,8 @@ GOPATH=/home/prow/go
 ROOT=/go/src
 
 # Configure available resources and disable IPv6 tests.
-export BAZEL_BUILD_ARGS="--verbose_failures --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
+BAZEL_BUILD_ARGS="${BAZEL_BUILD_EXTRA_ARGS:-} --verbose_failures --test_env=ENVOY_IP_TEST_VERSIONS=v4only --test_output=errors"
+export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS# }"
 
 # Override envoy.
 if [[ "${ENVOY_REPOSITORY:-}" && "${ENVOY_PREFIX:-}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:  Add BAZEL_BUILD_EXTRA_ARGS as a prow build customization point. In at least one use case, this is used to configure a bazel remote cache:

Per https://github.com/envoyproxy/envoy/blob/97bc67a06a3908821c933b437f9268886383d210/ci/README.md?plain=1#L129-L141
> To leverage a bazel remote cache:
> * add bazel options like --remote_cache and/or --remote_cache_header to a .bazelrc file, such as user.bazelrc. For
> example
> `build:my-remote-cache --remote_cache=grpcs://remotecache.googleapis.com`
> `build:my-remote-cache --remote_cache_header=Authorization="Bearer <token>"`
> * specify the config in the BAZEL_BUILD_EXTRA_OPTIONS environment variable. Run
> `export BAZEL_BUILD_EXTRA_OPTIONS=--config=my-remote-cache

So in a prow job spec:

```
  spec:
    containers:
      - name: build-container
        image: ...
        args:
        - ./prow/proxy-presubmit.sh
        env:
        - name: BAZEL_BUILD_EXTRA_ARGS
          value: >-
            --config=remote-cache
```

**Fixes**: N/A

**Special notes for your reviewer**: This PR does not include .bazelrc changes, since this public repo's CI seems tuned for  GCP remote execution. In organizations not using GCP, the bazel remote cache is an easy way to reduce CI build times.
