### PR TITLE
Add metadata fallback for client sidecar reporters

### DIFF
--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1113,7 +1113,7 @@ private:
       }
       if (peer_san.empty()) {
         std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
-        const auto* endpoint_object = peerInfo(config_->reporter(), filter_state);
+        const auto endpoint_object = peerInfo(config_->reporter(), filter_state);
         if (endpoint_object) {
           peer_san = endpoint_object->identity_;
         }

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1076,7 +1076,7 @@ private:
       }
     }
 
-    absl::string_view peer_san;
+    std::string peer_san;
     absl::string_view local_san;
     switch (config_->reporter()) {
     case Reporter::ServerSidecar:

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1115,7 +1115,7 @@ private:
         std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
         const auto endpoint_object = peerInfo(config_->reporter(), filter_state);
         if (endpoint_object) {
-          peer_san = endpoint_object->identity_;
+          peer_san = endpoint_object.value().identity_;
         }
       }
       // This won't work for sidecar/ingress -> ambient becuase of the CONNECT

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -1111,17 +1111,17 @@ private:
       if (ssl_info && !ssl_info->uriSanPeerCertificate().empty()) {
         peer_san = ssl_info->uriSanPeerCertificate()[0];
       }
-      // This won't work for sidecar/ingress -> ambient becuase of the CONNECT
-      // tunnel.
-      if (ssl_info && !ssl_info->uriSanLocalCertificate().empty()) {
-        local_san = ssl_info->uriSanLocalCertificate()[0];
-      }
       if (peer_san.empty()) {
         std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
         const auto* endpoint_object = peerInfo(config_->reporter(), filter_state);
         if (endpoint_object) {
           peer_san = endpoint_object->identity_;
         }
+      }
+      // This won't work for sidecar/ingress -> ambient becuase of the CONNECT
+      // tunnel.
+      if (ssl_info && !ssl_info->uriSanLocalCertificate().empty()) {
+        local_san = ssl_info->uriSanLocalCertificate()[0];
       }
       break;
     }

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -538,6 +538,7 @@ struct Config : public Logger::Loggable<Logger::Id::filter> {
     default:
       break;
     }
+
     if (proto_config.metrics_size() > 0 || proto_config.definitions_size() > 0) {
       metric_overrides_ = std::make_unique<MetricOverrides>(context_, scope()->symbolTable());
       for (const auto& definition : proto_config.definitions()) {
@@ -1110,8 +1111,17 @@ private:
       if (ssl_info && !ssl_info->uriSanPeerCertificate().empty()) {
         peer_san = ssl_info->uriSanPeerCertificate()[0];
       }
+      // This won't work for sidecar/ingress -> ambient becuase of the CONNECT
+      // tunnel.
       if (ssl_info && !ssl_info->uriSanLocalCertificate().empty()) {
         local_san = ssl_info->uriSanLocalCertificate()[0];
+      }
+      if (peer_san.empty()) {
+        std::optional<Istio::Common::WorkloadMetadataObject> endpoint_peer;
+        const auto* endpoint_object = peerInfo(config_->reporter(), filter_state);
+        if (endpoint_object) {
+          peer_san = endpoint_object->identity_;
+        }
       }
       break;
     }

--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -80,6 +80,7 @@ absl::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo&
       }
     }
   }
+  ENVOY_LOG_MISC(debug, "Peer address: {}", peer_address->asString());
   return metadata_provider_->GetMetadata(peer_address);
 }
 

--- a/test/envoye2e/inventory.go
+++ b/test/envoye2e/inventory.go
@@ -60,5 +60,6 @@ func init() {
 		"TestStatsDestinationServiceNamespacePrecedence",
 		"TestAdditionalLabels",
 		"TestTCPMXAdditionalLabels",
+		"TestStatsClientSidecarCONNECT",
 	}...)
 }

--- a/test/envoye2e/stats_plugin/stats_test.go
+++ b/test/envoye2e/stats_plugin/stats_test.go
@@ -662,6 +662,84 @@ func TestStatsServerWaypointProxy(t *testing.T) {
 	}
 }
 
+func TestStatsClientSidecarCONNECT(t *testing.T) {
+	params := driver.NewTestParams(t, map[string]string{
+		"RequestCount":            "10",
+		"EnableDelta":             "true",
+		"EnableMetadataDiscovery": "true",
+		"StatsFilterServerConfig": driver.LoadTestJSON("testdata/stats/server_config.yaml"),
+		"StatsFilterClientConfig": driver.LoadTestJSON("testdata/stats/client_config.yaml"),
+	}, envoye2e.ProxyE2ETests)
+	params.Vars["ServerClusterName"] = "internal_outbound"
+	params.Vars["ServerInternalAddress"] = "internal_inbound"
+	params.Vars["ClientMetadata"] = params.LoadTestData("testdata/client_node_metadata.json.tmpl")
+	params.Vars["ServerMetadata"] = params.LoadTestData("testdata/server_waypoint_proxy_node_metadata.json.tmpl")
+	params.Vars["ServerHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_waypoint.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stats_inbound.yaml.tmpl")
+	params.Vars["EnableTunnelEndpointMetadata"] = "true"
+	params.Vars["EnableOriginalDstPortOverride"] = "true"
+	params.Vars["ClientHTTPFilters"] = driver.LoadTestData("testdata/filters/mx_native_outbound.yaml.tmpl") + "\n" +
+		driver.LoadTestData("testdata/filters/stats_outbound.yaml.tmpl")
+
+	if err := (&driver.Scenario{
+		Steps: []driver.Step{
+			&driver.XDS{},
+			&driver.Update{
+				Node: "client", Version: "0",
+				Clusters: []string{
+					driver.LoadTestData("testdata/cluster/internal_outbound.yaml.tmpl"),
+					driver.LoadTestData("testdata/cluster/original_dst.yaml.tmpl"),
+				},
+				Listeners: []string{
+					driver.LoadTestData("testdata/listener/client.yaml.tmpl"),
+					driver.LoadTestData("testdata/listener/internal_outbound.yaml.tmpl"),
+				},
+				Secrets: []string{
+					driver.LoadTestData("testdata/secret/client.yaml.tmpl"),
+				},
+			},
+			&driver.Update{
+				Node: "server", Version: "0",
+				Clusters: []string{
+					driver.LoadTestData("testdata/cluster/internal_inbound.yaml.tmpl"),
+				},
+				Listeners: []string{
+					driver.LoadTestData("testdata/listener/terminate_connect.yaml.tmpl"),
+					driver.LoadTestData("testdata/listener/server.yaml.tmpl"),
+				},
+				Secrets: []string{
+					driver.LoadTestData("testdata/secret/server.yaml.tmpl"),
+				},
+			},
+			&driver.UpdateWorkloadMetadata{Workloads: []driver.WorkloadMetadata{{
+				Address:  "127.0.0.1",
+				Metadata: ProductPageMetadata,
+			}, {
+				Address:  "127.0.0.2", // We're going to pretend our server is a mesh service
+				Metadata: BackendMetadata,
+			}}},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/client.yaml.tmpl")},
+			&driver.Envoy{Bootstrap: params.LoadTestData("testdata/bootstrap/server.yaml.tmpl")},
+			&driver.Sleep{Duration: 1 * time.Second},
+			&driver.Repeat{
+				N: 10,
+				Step: &driver.HTTPCall{
+					Port:         params.Ports.ClientPort,
+					ResponseCode: 200,
+				},
+			},
+			&driver.Stats{
+				AdminPort: params.Ports.ClientAdmin,
+				Matchers: map[string]driver.StatMatcher{
+					"istio_requests_total": &driver.ExactStat{Metric: "testdata/metric/client_sidecar_connect_request_total.yaml.tmpl"},
+				},
+			},
+		},
+	}).Run(params); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestStatsServerWaypointProxyCONNECT(t *testing.T) {
 	t.Run("full metadata", func(t *testing.T) {
 		runStatsServerWaypointProxyCONNECT(t, BackendMetadata, "testdata/metric/server_waypoint_proxy_connect_request_total.yaml.tmpl")

--- a/testdata/cluster/internal_outbound.yaml.tmpl
+++ b/testdata/cluster/internal_outbound.yaml.tmpl
@@ -1,4 +1,11 @@
 name: internal_outbound
+metadata:
+  filter_metadata:
+    istio:
+      services:
+        - host: server.default.svc.cluster.local
+          name: server
+          namespace: default
 load_assignment:
   cluster_name: internal_outbound
   endpoints:
@@ -12,6 +19,8 @@ load_assignment:
         filter_metadata:
           envoy.filters.listener.original_dst:
             local: 127.0.0.2:{{ .Ports.ServerPort }}
+          istio:
+            workload: ratings-v1;default;ratings;version-1;server-cluster
 {{- end }}
 transport_socket:
   name: envoy.transport_sockets.internal_upstream

--- a/testdata/filters/mx_native_outbound.yaml.tmpl
+++ b/testdata/filters/mx_native_outbound.yaml.tmpl
@@ -5,5 +5,6 @@
     value:
       upstream_discovery:
       - istio_headers: {}
+      - workload_discovery: {}
       upstream_propagation:
       - istio_headers: {}

--- a/testdata/metric/client_sidecar_connect_request_total.yaml.tmpl
+++ b/testdata/metric/client_sidecar_connect_request_total.yaml.tmpl
@@ -1,0 +1,60 @@
+name: istio_requests_total
+type: COUNTER
+metric:
+- counter:
+    value: {{ .Vars.RequestCount }}
+  label:
+  - name: reporter
+    value: source
+  - name: source_workload
+    value: productpage-v1
+  - name: source_canonical_service
+    value: productpage-v1
+  - name: source_canonical_revision
+    value: version-1
+  - name: source_workload_namespace
+    value: default
+  - name: source_principal
+    value: unknown
+  - name: source_app
+    value: productpage
+  - name: source_version
+    value: v1
+  - name: source_cluster
+    value: client-cluster
+  - name: destination_workload
+    value: ratings-v1
+  - name: destination_workload_namespace
+    value: default
+  - name: destination_principal
+    value: spiffe://cluster.global/ns/default/sa/ratings
+  - name: destination_app
+    value: ratings
+  - name: destination_version
+    value: version-1
+  - name: destination_service
+    value: server.default.svc.cluster.local
+  - name: destination_canonical_service
+    value: ratings
+  - name: destination_canonical_revision
+    value: version-1
+  - name: destination_service_name
+    value: server
+  - name: destination_service_namespace
+    value: default
+  - name: destination_cluster
+    value: ratings-cluster
+  - name: request_protocol
+    {{- if .Vars.GrpcResponseStatus }}
+    value: grpc
+    {{- else }}
+    value: http
+    {{- end }}
+  - name: response_code
+    value: "200"
+  - name: grpc_response_status
+    value: "{{ .Vars.GrpcResponseStatus }}"
+  - name: response_flags
+    value: "-"
+  - name: connection_security_policy
+    value: unknown # Because we can't verify the source principal (dumb reason)


### PR DESCRIPTION
**What this PR does / why we need it**:  Companion to istio/istio#54383. Use MX fallback if there's no ssl context for the upstream connection (there won't be when we're doing CONNECT encap due to the extra internal listener in between).  Note that this doesn't help with the source principal; we may be able to set some filter state in the connect_encap listener and have stats read it before we flush, but I'd need to try it out.