### PR TITLE
Disable spammy logs in release

### DIFF
--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -134,7 +134,7 @@ do
       fi
       ;;
     "debug")
-      CONFIG_PARAMS="--config=debug"
+      CONFIG_PARAMS=""
       BINARY_BASE_NAME="${BASE_BINARY_NAME}-debug"
       # shellcheck disable=SC2086
       BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/${ARCH_NAME}-dbg/bin"

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -134,7 +134,7 @@ do
       fi
       ;;
     "debug")
-      CONFIG_PARAMS=""
+      CONFIG_PARAMS="-c dbg"
       BINARY_BASE_NAME="${BASE_BINARY_NAME}-debug"
       # shellcheck disable=SC2086
       BAZEL_OUT="$(bazel info ${BAZEL_BUILD_ARGS} output_path)/${ARCH_NAME}-dbg/bin"


### PR DESCRIPTION
The `debug` flag does not impact the result of the build, but it does turn on ~every logging option in bazel resulting in 200k lines of logs each run

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
