### PR TITLE
Add null check to log message

### DIFF
--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -80,6 +80,9 @@ absl::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo&
       }
     }
   }
+  if (!peer_address) {
+    return {};
+  }
   ENVOY_LOG_MISC(debug, "Peer address: {}", peer_address->asString());
   return metadata_provider_->GetMetadata(peer_address);
 }


### PR DESCRIPTION
`peer_address` may be nil, so add a check: https://www.linkedin.com/in/ramvennam/