### PR TITLE
build: fix breakage in core proto rules

### DIFF
--- a/source/extensions/filters/http/peer_metadata/BUILD
+++ b/source/extensions/filters/http/peer_metadata/BUILD
@@ -19,6 +19,7 @@ load(
     "@envoy//bazel:envoy_build_system.bzl",
     "envoy_cc_library",
     "envoy_cc_test",
+    "envoy_proto_library",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -46,12 +47,7 @@ envoy_cc_library(
     ],
 )
 
-cc_proto_library(
-    name = "config_cc_proto",
-    deps = ["config"],
-)
-
-proto_library(
+envoy_proto_library(
     name = "config",
     srcs = ["config.proto"],
 )


### PR DESCRIPTION
Change-Id: I755ea813ecf6e0e76ac0e236fec501f0448ff9e3

**What this PR does / why we need it**:
Proto rules are being moved to a library. This shims the problem when bazel upgrades.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
