### PR TITLE
Enable envoy.resource_monitors.cpu_utilization

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -202,6 +202,7 @@ ENVOY_EXTENSIONS = {
     # Resource monitors
     #
 
+    "envoy.resource_monitors.cpu_utilization":          "//source/extensions/resource_monitors/cpu_utilization:config",
     "envoy.resource_monitors.fixed_heap":               "//source/extensions/resource_monitors/fixed_heap:config",
     "envoy.resource_monitors.injected_resource":        "//source/extensions/resource_monitors/injected_resource:config",
     "envoy.resource_monitors.downstream_connections":   "//source/extensions/resource_monitors/downstream_connections:config",


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables `envoy.resource_monitors.cpu_utilization`.
This is required in order to support load shedding in k8s environments: https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/overload_manager/overload_manager#loadshedding-in-k8s-environment.

**Special notes for your reviewer**:
Should also enable additional resource monitors that may be helpful, e.g. `envoy.resource_monitors.cgroup_memory`?
