### PR TITLE
Adding CEL Samplers

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -248,7 +248,8 @@ ENVOY_EXTENSIONS = {
     #
     # OpenTelemetry tracer samplers
     #
-
+    
+    "envoy.tracers.opentelemetry.samplers.cel":             "//source/extensions/tracers/opentelemetry/samplers/cel:config",
     "envoy.tracers.opentelemetry.samplers.always_on":       "//source/extensions/tracers/opentelemetry/samplers/always_on:config",
     "envoy.tracers.opentelemetry.samplers.dynatrace":       "//source/extensions/tracers/opentelemetry/samplers/dynatrace:config",
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will expose the CEL sampler for otel. We currently do not have a way to drop traces based on certain conditions in the service mesh. We would like to be able to make intelligent tracing decisions in the service mesh instead of having to make multiple changes to all micro services. 
  
**Which issue this PR fixes**  : fixes #57321

**Special notes for your reviewer**:
