### PR TITLE
Update envoy to v1.33.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,10 +22,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
-# Commit date: 2025-08-19
-ENVOY_SHA = "ad701906d58e207ec94bc1acd14445456a9a909b"
+# Commit date: 2025-09-03
+ENVOY_SHA = "29a3107a28e29dc3a2510e326aa464943310da56"
 
-ENVOY_SHA256 = "3fe9d059c34d0216fb407595782548ee0370a31ca351f51be1b9ce71124cf70b"
+ENVOY_SHA256 = "6a478eaaa5f70c44825d391b073290495357ca036b8e19f8327c28ad1a421270"
 
 ENVOY_ORG = "envoyproxy"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
 Update envoy version to 1.33.8 ([repo: Release v1.33.8](https://github.com/envoyproxy/envoy/commit/29a3107a28e29dc3a2510e326aa464943310da56))