### PR TITLE
Include cgroup_memory resource monitor

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -205,6 +205,7 @@ ENVOY_EXTENSIONS = {
 
     "envoy.resource_monitors.cpu_utilization":          "//source/extensions/resource_monitors/cpu_utilization:config",
     "envoy.resource_monitors.fixed_heap":               "//source/extensions/resource_monitors/fixed_heap:config",
+    "envoy.resource_monitors.cgroup_memory":            "//source/extensions/resource_monitors/cgroup_memory:config",
     "envoy.resource_monitors.injected_resource":        "//source/extensions/resource_monitors/injected_resource:config",
     "envoy.resource_monitors.downstream_connections":   "//source/extensions/resource_monitors/downstream_connections:config",
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Via https://github.com/envoyproxy/envoy/issues/38718 a cgroup aware memory resource monitor was added to Envoy.
This allows to dynamically adapt overload mechanisms relative to the available container memory:

* https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/overload_manager/overload_manager#overload-actions
* https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/overload_manager/overload_manager#loadshedding-in-k8s-environment

**Special notes for your reviewer**:
@bpalermo already suggested adding this in his MR https://github.com/istio/proxy/pull/6318#issue-3091367722





