### PR TITLE
Allow local modification of envoy.bazelrc

### DIFF
--- a/envoy.bazelrc
+++ b/envoy.bazelrc
@@ -223,18 +223,18 @@ build:compile-time-options --@envoy//source/extensions/filters/http/kill_request
 
 common:fips-common --test_tag_filters=-nofips
 common:fips-common --build_tag_filters=-nofips
-common:fips-common --//bazel:fips=True
+common:fips-common --@envoy//bazel:fips=True
 
 # BoringSSL FIPS
 common:boringssl-fips --config=fips-common
-common:boringssl-fips --//bazel:ssl=@boringssl_fips//:ssl
-common:boringssl-fips --//bazel:crypto=@boringssl_fips//:crypto
+common:boringssl-fips --@envoy//bazel:ssl=@boringssl_fips//:ssl
+common:boringssl-fips --@envoy//bazel:crypto=@boringssl_fips//:crypto
 
 # AWS-LC FIPS
 common:aws-lc-fips --config=fips-common
-common:aws-lc-fips --//bazel:ssl=@aws_lc//:ssl
-common:aws-lc-fips --//bazel:crypto=@aws_lc//:crypto
-common:aws-lc-fips --//bazel:http3=False
+common:aws-lc-fips --@envoy//bazel:ssl=@aws_lc//:ssl
+common:aws-lc-fips --@envoy//bazel:crypto=@aws_lc//:crypto
+common:aws-lc-fips --@envoy//bazel:http3=False
 
 
 #############################################################################

--- a/scripts/update_envoy.sh
+++ b/scripts/update_envoy.sh
@@ -68,18 +68,14 @@ curl -sSL "https://raw.githubusercontent.com/${ENVOY_ORG}/${ENVOY_REPO}/${LATEST
 # On conflict, take upstream version (consistent with previous behavior)
 OLD_BAZELRC=$(mktemp)
 NEW_BAZELRC=$(mktemp)
-MERGED_BAZELRC=$(mktemp)
 
 curl -sSL "https://raw.githubusercontent.com/${ENVOY_ORG}/${ENVOY_REPO}/${OLD_SHA}/.bazelrc" > "${OLD_BAZELRC}"
 curl -sSL "https://raw.githubusercontent.com/${ENVOY_ORG}/${ENVOY_REPO}/${LATEST_SHA}/.bazelrc" > "${NEW_BAZELRC}"
 
 # Attempt merge; on conflict, use upstream version
-if git merge-file -p envoy.bazelrc "${OLD_BAZELRC}" "${NEW_BAZELRC}" > "${MERGED_BAZELRC}" 2>/dev/null; then
-  mv "${MERGED_BAZELRC}" envoy.bazelrc
-else
+if ! git merge-file envoy.bazelrc "${OLD_BAZELRC}" "${NEW_BAZELRC}" 2>/dev/null; then
   # Conflicts exist - resolve by taking upstream (theirs)
-  git merge-file -p --theirs envoy.bazelrc "${OLD_BAZELRC}" "${NEW_BAZELRC}" > "${MERGED_BAZELRC}"
-  mv "${MERGED_BAZELRC}" envoy.bazelrc
+  git merge-file --theirs envoy.bazelrc "${OLD_BAZELRC}" "${NEW_BAZELRC}"
 fi
 
 rm -f "${OLD_BAZELRC}" "${NEW_BAZELRC}"


### PR DESCRIPTION
## Description

This PR updates the `update_envoy.sh` script to preserve local modifications to `envoy.bazelrc` while still applying upstream changes from Envoy.

This addresses the issue where PR #6840 was automatically overwritten by the `update_envoy.sh` automation, which previously performed a direct file replacement.

## Changes

The script now performs a three-way merge of `envoy.bazelrc`:
- **Base**: Previous upstream version (from old `ENVOY_SHA`)
- **Local**: Current `envoy.bazelrc` with Istio-specific modifications
- **Upstream**: New upstream version (from new `ENVOY_SHA`)

This allows:
- ✅ Local modifications (like the `@envoy//` prefix fixes from #6840) to be preserved across updates
- ✅ Upstream changes to be automatically applied
- ✅ Conflicts to be auto-resolved by taking the upstream version (preserving existing behavior)

## Behavior

**When upstream doesn't modify a line**: Local changes are preserved

**When upstream modifies the same line**: Upstream version wins (same as before)

This maintains backward compatibility while enabling selective local customization of bazel settings.

---

Fixes the automation issue that overwrote #6840