### PR TITLE
Add client-side weighted round robin to LB config

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -414,14 +414,15 @@ ENVOY_EXTENSIONS = {
     #
     # Load balancing policies for upstream
     #
-    "envoy.load_balancing_policies.least_request":     "//source/extensions/load_balancing_policies/least_request:config",
-    "envoy.load_balancing_policies.random":            "//source/extensions/load_balancing_policies/random:config",
-    "envoy.load_balancing_policies.round_robin":       "//source/extensions/load_balancing_policies/round_robin:config",
-    "envoy.load_balancing_policies.maglev":            "//source/extensions/load_balancing_policies/maglev:config",
-    "envoy.load_balancing_policies.ring_hash":         "//source/extensions/load_balancing_policies/ring_hash:config",
-    "envoy.load_balancing_policies.subset":            "//source/extensions/load_balancing_policies/subset:config",
-    "envoy.load_balancing_policies.cluster_provided":  "//source/extensions/load_balancing_policies/cluster_provided:config",
-    "envoy.load_balancing_policies.override_host":     "//source/extensions/load_balancing_policies/override_host:config",
+    "envoy.load_balancing_policies.least_request":                     "//source/extensions/load_balancing_policies/least_request:config",
+    "envoy.load_balancing_policies.random":                            "//source/extensions/load_balancing_policies/random:config",
+    "envoy.load_balancing_policies.round_robin":                       "//source/extensions/load_balancing_policies/round_robin:config",
+    "envoy.load_balancing_policies.maglev":                            "//source/extensions/load_balancing_policies/maglev:config",
+    "envoy.load_balancing_policies.ring_hash":                         "//source/extensions/load_balancing_policies/ring_hash:config",
+    "envoy.load_balancing_policies.subset":                            "//source/extensions/load_balancing_policies/subset:config",
+    "envoy.load_balancing_policies.cluster_provided":                  "//source/extensions/load_balancing_policies/cluster_provided:config",
+    "envoy.load_balancing_policies.override_host":                     "//source/extensions/load_balancing_policies/override_host:config",
+    "envoy.load_balancing_policies.client_side_weighted_round_robin":  "//source/extensions/load_balancing_policies/client_side_weighted_round_robin:config",
 
     #
     # HTTP Early Header Mutation


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Envoy’s client_side_weighted_round_robin load balancing policy to Istio proxy’s extension build config so it is included with the other upstream LB policy extensions.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
