### PR TITLE
Exclude incompatible contrib extensions from OpenSSL builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,12 +43,17 @@ ISTIO_EXTENSIONS = [
     "//source/extensions/filters/network/peer_metadata",
 ]
 
+load("@envoy_build_config//:extensions_build_config.bzl", "OPENSSL_INCOMPATIBLE_CONTRIB_DEPS")
+
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
     deps = ISTIO_EXTENSIONS + [
         "@envoy//source/exe:envoy_main_entry_lib",
-    ],
+    ] + select({
+        "@envoy//bazel:using_openssl": [],
+        "//conditions:default": OPENSSL_INCOMPATIBLE_CONTRIB_DEPS,
+    }),
 )
 
 pkg_tar(

--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -538,12 +538,17 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.network.postgres_proxy",
     "envoy.filters.network.sip_proxy",
     "envoy.filters.sip.router",
-    "envoy.tls.key_providers.cryptomb",
-    "envoy.tls.key_providers.qat",
     "envoy.network.connection_balance.dlb",
     "envoy.load_balancing_policies.peak_ewma",
     "envoy.filters.http.peak_ewma",
 ]
+
+OPENSSL_INCOMPATIBLE_CONTRIB_EXTENSIONS = [
+    "envoy.tls.key_providers.cryptomb",
+    "envoy.tls.key_providers.qat",
+]
+
+OPENSSL_INCOMPATIBLE_CONTRIB_DEPS = ["@envoy" + v + "_envoy_extension" for k, v in ENVOY_CONTRIB_EXTENSIONS.items() if k in OPENSSL_INCOMPATIBLE_CONTRIB_EXTENSIONS]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +
                   [(k,v) for k, v in ENVOY_CONTRIB_EXTENSIONS.items() if k in ISTIO_ENABLED_CONTRIB_EXTENSIONS])


### PR DESCRIPTION
Move cryptomb and qat out of ISTIO_ENABLED_CONTRIB_EXTENSIONS and into a new OPENSSL_INCOMPATIBLE_CONTRIB_EXTENSIONS list. These extensions are conditionally included via select() in the root BUILD, so they are linked only when *not* building with `--config=openssl`.
