### PR TITLE
Detect HTTP/3 support from Bazel config to skip QUIC tests

### DIFF
--- a/test/envoye2e/basic_flow/basic_test.go
+++ b/test/envoye2e/basic_flow/basic_test.go
@@ -22,6 +22,7 @@ import (
 
 	"istio.io/proxy/test/envoye2e"
 	"istio.io/proxy/test/envoye2e/driver"
+	"istio.io/proxy/test/envoye2e/env"
 )
 
 var ProtocolOptions = []struct {
@@ -32,10 +33,15 @@ var ProtocolOptions = []struct {
 		Name: "h2",
 		Quic: false,
 	},
-	{
-		Name: "quic",
-		Quic: true,
-	},
+}
+
+func init() {
+	if env.IsHTTP3Enabled() {
+		ProtocolOptions = append(ProtocolOptions, struct {
+			Name string
+			Quic bool
+		}{Name: "quic", Quic: true})
+	}
 }
 
 func TestBasicTCPFlow(t *testing.T) {

--- a/test/envoye2e/env/utils.go
+++ b/test/envoye2e/env/utils.go
@@ -75,6 +75,22 @@ func GetDefaultEnvoyBinOrDie() string {
 	return GetBazelBinOrDie()
 }
 
+func IsHTTP3Enabled() bool {
+	buildArgs := os.Getenv("BAZEL_BUILD_ARGS")
+	args := []string{"cquery", "@envoy//bazel:http3",
+		"--output=starlark",
+		"--starlark:expr=providers(target)[\"@@bazel_skylib//rules:common_settings.bzl%BuildSettingInfo\"].value",
+	}
+	if buildArgs != "" {
+		args = append(args, strings.Split(buildArgs, " ")...)
+	}
+	out, err := exec.Command("bazel", args...).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "True"
+}
+
 func SkipTSanASan(t *testing.T) {
 	if os.Getenv("TSAN") != "" || os.Getenv("ASAN") != "" {
 		t.Skip("https://github.com/istio/istio/issues/21273")


### PR DESCRIPTION
QUIC test variants (TestBasicCONNECT/quic, TestPassthroughCONNECT/quic) fail when HTTP/3 is disabled (e.g. OpenSSL builds). Query the @envoy//bazel:http3 build flag via `bazel cquery` at test init time to automatically exclude them.

