### PR TITLE
[release-1.29] Disable contrib/dlb until download issue is fixed

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -524,7 +524,8 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.sip.router",
     "envoy.tls.key_providers.cryptomb",
     # "envoy.tls.key_providers.qat",
-    "envoy.network.connection_balance.dlb",
+    # FIXME: https://github.com/istio/istio/issues/60485
+    # "envoy.network.connection_balance.dlb",
     "envoy.load_balancing_policies.peak_ewma",
     "envoy.filters.http.peak_ewma",
 ]


### PR DESCRIPTION
manual cherry-pick of #7078 to release-1.29, the auto cherrypick conflicted. unblocks proxy builds on 1.29 (e.g. #7077). Backport of #7078