### PR TITLE
[release-1.28] Disable contrib/dlb until download issue is fixed

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -518,7 +518,8 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.sip.router",
     "envoy.tls.key_providers.cryptomb",
     "envoy.tls.key_providers.qat",
-    "envoy.network.connection_balance.dlb",
+    # FIXME: https://github.com/istio/istio/issues/60485
+    # "envoy.network.connection_balance.dlb",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +


### PR DESCRIPTION
**What this PR does / why we need it**:
manual cherry-pick of https://github.com/istio/proxy/pull/7078 to release-1.29, the auto cherrypick conflicted. unblocks proxy builds on 1.28 (e.g. https://github.com/istio/proxy/pull/7077). Backport of https://github.com/istio/proxy/pull/7078

Once https://github.com/istio/istio/issues/60485 is fixed we should enable again

