### PR TITLE
Fix IPv4/IPv6 address encoding for big-endian architectures s390x

### DIFF
--- a/source/extensions/common/workload_discovery/api.cc
+++ b/source/extensions/common/workload_discovery/api.cc
@@ -94,14 +94,13 @@ public:
       if (const auto ipv4 = address->ip()->ipv4(); ipv4) {
         uint32_t value = ipv4->address();
         std::array<uint8_t, 4> output;
-        absl::little_endian::Store32(&output, value);
+        memcpy(output.data(), &value, 4);
         return tls_->get(std::string(output.begin(), output.end()));
       } else if (const auto ipv6 = address->ip()->ipv6(); ipv6) {
-        const uint64_t high = absl::Uint128High64(ipv6->address());
-        const uint64_t low = absl::Uint128Low64(ipv6->address());
+        const auto* sa = reinterpret_cast<const sockaddr_in6*>(address->sockAddr());
         std::array<uint8_t, 16> output;
-        absl::little_endian::Store64(&output, low);
-        absl::little_endian::Store64(&output[8], high);
+        static_assert(sizeof(sa->sin6_addr.s6_addr) == 16);
+        memcpy(output.data(), sa->sin6_addr.s6_addr, 16);
         return tls_->get(std::string(output.begin(), output.end()));
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
On big-endian architectures (s390x), the workload metadata IP address lookup fails silently because absl::little_endian::Store32/Store64 encodes IP address bytes in little-endian order, which does not match how the xDS server stores addresses in workload.addresses (network byte order / big-endian). This causes GetMetadata() to always return empty results on s390x, breaking workload identity resolution and telemetry metadata labels.

The fix replaces absl::little_endian encoding with memcpy() which copies raw bytes as-is in network byte order correct and consistent across all architectures. For IPv6, replaces the fragile absl::uint128 High64/Low64 decomposition with a direct copy from sockaddr_in6.sin6_addr.s6_addr which is always 16 bytes in network byte order.

It fixes workload metadata lookup on s390x, which was causing waypoint proxy to emit incomplete telemetry on s390x platform.