### PR TITLE
[release-1.27] Disable contrib/dlb until download issue is fixed

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -516,7 +516,8 @@ ISTIO_ENABLED_CONTRIB_EXTENSIONS = [
     "envoy.filters.sip.router",
     "envoy.tls.key_providers.cryptomb",
     "envoy.tls.key_providers.qat",
-    "envoy.network.connection_balance.dlb",
+    # FIXME: https://github.com/istio/istio/issues/60485
+    # "envoy.network.connection_balance.dlb",
 ]
 
 EXTENSIONS = dict([(k,v) for k,v in ENVOY_EXTENSIONS.items() if not k in ISTIO_DISABLED_EXTENSIONS] +


### PR DESCRIPTION
Commented out 'envoy.network.connection_balance.dlb' and added a FIXME note regarding an issue.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
