### PR TITLE
unify the naming and type with Envoy

### DIFF
--- a/extensions/common/metadata_object.cc
+++ b/extensions/common/metadata_object.cc
@@ -448,7 +448,7 @@ std::optional<absl::string_view> WorkloadMetadataObject::field(absl::string_view
       return locality_zone_;
     }
   }
-  return absl::nullopt;
+  return std::nullopt;
 }
 
 WorkloadMetadataObject::FieldType

--- a/extensions/common/metadata_object.cc
+++ b/extensions/common/metadata_object.cc
@@ -68,7 +68,7 @@ static absl::flat_hash_map<absl::string_view, WorkloadType> ALL_WORKLOAD_TOKENS 
     {CronJobSuffix, WorkloadType::CronJob},
 };
 
-absl::optional<absl::string_view> toSuffix(WorkloadType workload_type) {
+std::optional<absl::string_view> toSuffix(WorkloadType workload_type) {
   switch (workload_type) {
   case WorkloadType::Deployment:
     return DeploymentSuffix;
@@ -228,16 +228,16 @@ WorkloadMetadataObject::serializeAsPairs() const {
   return parts;
 }
 
-absl::optional<std::string> WorkloadMetadataObject::serializeAsString() const {
+std::optional<std::string> WorkloadMetadataObject::serializeAsString() const {
   const auto parts = serializeAsPairs();
   return absl::StrJoin(parts, ",", absl::PairFormatter("="));
 }
 
-absl::optional<uint64_t> WorkloadMetadataObject::hash() const {
+std::optional<uint64_t> WorkloadMetadataObject::hash() const {
   return Envoy::HashUtil::xxHash64(*serializeAsString());
 }
 
-absl::optional<std::string> WorkloadMetadataObject::owner() const {
+std::optional<std::string> WorkloadMetadataObject::owner() const {
   const auto suffix = toSuffix(workload_type_);
   if (suffix) {
     return absl::StrCat(OwnerPrefix, namespace_name_, "/", *suffix, "s/", workload_name_);
@@ -267,8 +267,8 @@ WorkloadType parseOwner(absl::string_view owner, absl::string_view workload) {
   return WorkloadType::Unknown;
 }
 
-google::protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataObject& obj) {
-  google::protobuf::Struct metadata;
+Envoy::Protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataObject& obj) {
+  Envoy::Protobuf::Struct metadata;
   if (!obj.instance_name_.empty()) {
     (*metadata.mutable_fields())[InstanceMetadataField].set_string_value(obj.instance_name_);
   }
@@ -316,20 +316,20 @@ google::protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataO
 
 // Convert struct to a metadata object.
 std::unique_ptr<WorkloadMetadataObject>
-convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata) {
+convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata) {
   return convertStructToWorkloadMetadata(metadata, {});
 }
 
 std::unique_ptr<WorkloadMetadataObject>
-convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata,
+convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels) {
   return convertStructToWorkloadMetadata(metadata, additional_labels, {});
 }
 
 std::unique_ptr<WorkloadMetadataObject>
-convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata,
+convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels,
-                                const absl::optional<envoy::config::core::v3::Locality> locality) {
+                                const std::optional<envoy::config::core::v3::Locality> locality) {
   absl::string_view instance, namespace_name, owner, workload, cluster, identity, canonical_name,
       canonical_revision, app_name, app_version, region, zone;
   std::vector<std::pair<std::string, std::string>> labels;
@@ -393,22 +393,22 @@ convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata,
   return obj;
 }
 
-absl::optional<WorkloadMetadataObject>
+std::optional<WorkloadMetadataObject>
 convertEndpointMetadata(const std::string& endpoint_encoding) {
   std::vector<absl::string_view> parts = absl::StrSplit(endpoint_encoding, ';');
   if (parts.size() < 5) {
     return {};
   }
-  return absl::make_optional<WorkloadMetadataObject>("", parts[4], parts[1], parts[0], parts[2],
-                                                     parts[3], "", "", WorkloadType::Unknown, "",
-                                                     "", "");
+  return std::make_optional<WorkloadMetadataObject>("", parts[4], parts[1], parts[0], parts[2],
+                                                    parts[3], "", "", WorkloadType::Unknown, "", "",
+                                                    "");
 }
 
-std::string serializeToStringDeterministic(const google::protobuf::Struct& metadata) {
+std::string serializeToStringDeterministic(const Envoy::Protobuf::Struct& metadata) {
   std::string out;
   {
-    google::protobuf::io::StringOutputStream md(&out);
-    google::protobuf::io::CodedOutputStream mcs(&md);
+    Envoy::Protobuf::io::StringOutputStream md(&out);
+    Envoy::Protobuf::io::CodedOutputStream mcs(&md);
     mcs.SetSerializationDeterministic(true);
     if (!metadata.SerializeToCodedStream(&mcs)) {
       out.clear();
@@ -417,8 +417,7 @@ std::string serializeToStringDeterministic(const google::protobuf::Struct& metad
   return out;
 }
 
-absl::optional<absl::string_view>
-WorkloadMetadataObject::field(absl::string_view field_name) const {
+std::optional<absl::string_view> WorkloadMetadataObject::field(absl::string_view field_name) const {
   const auto it = ALL_METADATA_FIELDS.find(field_name);
   if (it != ALL_METADATA_FIELDS.end()) {
     switch (it->second) {

--- a/extensions/common/metadata_object.h
+++ b/extensions/common/metadata_object.h
@@ -134,16 +134,16 @@ public:
         workload_type_(workload_type), identity_(identity), locality_region_(region),
         locality_zone_(zone) {}
 
-  absl::optional<uint64_t> hash() const override;
+  std::optional<uint64_t> hash() const override;
   Envoy::ProtobufTypes::MessagePtr serializeAsProto() const override;
   std::vector<std::pair<absl::string_view, absl::string_view>> serializeAsPairs() const;
-  absl::optional<std::string> serializeAsString() const override;
-  absl::optional<std::string> owner() const;
+  std::optional<std::string> serializeAsString() const override;
+  std::optional<std::string> owner() const;
   std::string identity() const;
   bool hasFieldSupport() const override { return true; }
   using Envoy::StreamInfo::FilterState::Object::FieldType;
   FieldType getField(absl::string_view) const override;
-  absl::optional<absl::string_view> field(absl::string_view field_name) const;
+  std::optional<absl::string_view> field(absl::string_view field_name) const;
   void setLabels(std::vector<std::pair<std::string, std::string>> labels) { labels_ = labels; }
   std::vector<std::pair<std::string, std::string>> getLabels() const { return labels_; }
   std::string baggage() const;
@@ -170,30 +170,29 @@ WorkloadType fromSuffix(absl::string_view suffix);
 WorkloadType parseOwner(absl::string_view owner, absl::string_view workload);
 
 // Convert a metadata object to a struct.
-google::protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataObject& obj);
+Envoy::Protobuf::Struct convertWorkloadMetadataToStruct(const WorkloadMetadataObject& obj);
 
 // Convert struct to a metadata object.
 std::unique_ptr<WorkloadMetadataObject>
-convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata);
+convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata);
 
 std::unique_ptr<WorkloadMetadataObject>
-convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata,
+convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels);
 
 std::unique_ptr<WorkloadMetadataObject>
-convertStructToWorkloadMetadata(const google::protobuf::Struct& metadata,
+convertStructToWorkloadMetadata(const Envoy::Protobuf::Struct& metadata,
                                 const absl::flat_hash_set<std::string>& additional_labels,
-                                const absl::optional<envoy::config::core::v3::Locality> locality);
+                                const std::optional<envoy::config::core::v3::Locality> locality);
 
 // Convert endpoint metadata string to a metadata object.
 // Telemetry metadata is compressed into a semicolon separated string:
 // workload-name;namespace;canonical-service-name;canonical-service-revision;cluster-id.
 // Telemetry metadata is stored as a string under "istio", "workload" field
 // path.
-absl::optional<WorkloadMetadataObject>
-convertEndpointMetadata(const std::string& endpoint_encoding);
+std::optional<WorkloadMetadataObject> convertEndpointMetadata(const std::string& endpoint_encoding);
 
-std::string serializeToStringDeterministic(const google::protobuf::Struct& metadata);
+std::string serializeToStringDeterministic(const Envoy::Protobuf::Struct& metadata);
 
 // Convert from baggage encoding.
 std::unique_ptr<WorkloadMetadataObject> convertBaggageToWorkloadMetadata(absl::string_view baggage);

--- a/extensions/common/metadata_object_test.cc
+++ b/extensions/common/metadata_object_test.cc
@@ -210,10 +210,10 @@ TEST(WorkloadMetadataObjectTest, ConvertFromEmpty) {
 }
 
 TEST(WorkloadMetadataObjectTest, ConvertFromEndpointMetadata) {
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata(""));
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata("a;b"));
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata("a;;;b"));
-  EXPECT_EQ(absl::nullopt, convertEndpointMetadata("a;b;c;d"));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata(""));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;b"));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;;;b"));
+  EXPECT_EQ(std::nullopt, convertEndpointMetadata("a;b;c;d"));
   auto obj = convertEndpointMetadata("foo-pod;default;foo-service;v1;my-cluster");
   ASSERT_TRUE(obj.has_value());
   EXPECT_EQ(obj->serializeAsString(), "workload=foo-pod,cluster=my-cluster,"

--- a/extensions/common/metadata_object_test.cc
+++ b/extensions/common/metadata_object_test.cc
@@ -203,7 +203,7 @@ TEST(WorkloadMetadataObjectTest, Conversion) {
 }
 
 TEST(WorkloadMetadataObjectTest, ConvertFromEmpty) {
-  google::protobuf::Struct node;
+  Envoy::Protobuf::Struct node;
   auto obj = convertStructToWorkloadMetadata(node);
   EXPECT_EQ(obj->serializeAsString(), "");
   checkStructConversion(*obj);

--- a/source/extensions/common/hashable_string/hashable_string_test.cc
+++ b/source/extensions/common/hashable_string/hashable_string_test.cc
@@ -32,7 +32,7 @@ namespace {
 TEST(HashableStringTest, TestHashableStringIsHashable) {
   using ::envoy::extensions::filters::common::set_filter_state::v3::FilterStateValue;
   using ::Envoy::Extensions::Filters::Common::SetFilterState::Config;
-  using ::google::protobuf::RepeatedPtrField;
+  using ::Envoy::Protobuf::RepeatedPtrField;
 
   NiceMock<Envoy::Server::Configuration::MockGenericFactoryContext> context;
   Envoy::Http::TestRequestHeaderMapImpl header_map;

--- a/source/extensions/filters/http/alpn/alpn_test.cc
+++ b/source/extensions/filters/http/alpn/alpn_test.cc
@@ -85,7 +85,7 @@ TEST_F(AlpnFilterTest, OverrideAlpnUseDownstreamProtocol) {
   ON_CALL(cluster_manager_, getThreadLocalCluster(_)).WillByDefault(Return(fake_cluster_.get()));
   ON_CALL(*fake_cluster_, info()).WillByDefault(Return(cluster_info_));
   ON_CALL(*cluster_info_, upstreamHttpProtocol(_))
-      .WillByDefault([](absl::optional<Http::Protocol> protocol) -> std::vector<Http::Protocol> {
+      .WillByDefault([](std::optional<Http::Protocol> protocol) -> std::vector<Http::Protocol> {
         return {protocol.value()};
       });
 
@@ -119,7 +119,7 @@ TEST_F(AlpnFilterTest, OverrideAlpn) {
   ON_CALL(cluster_manager_, getThreadLocalCluster(_)).WillByDefault(Return(fake_cluster_.get()));
   ON_CALL(*fake_cluster_, info()).WillByDefault(Return(cluster_info_));
   ON_CALL(*cluster_info_, upstreamHttpProtocol(_))
-      .WillByDefault([](absl::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
+      .WillByDefault([](std::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
         return {Http::Protocol::Http2};
       });
 
@@ -152,7 +152,7 @@ TEST_F(AlpnFilterTest, EmptyOverrideAlpn) {
   ON_CALL(cluster_manager_, getThreadLocalCluster(_)).WillByDefault(Return(fake_cluster_.get()));
   ON_CALL(*fake_cluster_, info()).WillByDefault(Return(cluster_info_));
   ON_CALL(*cluster_info_, upstreamHttpProtocol(_))
-      .WillByDefault([](absl::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
+      .WillByDefault([](std::optional<Http::Protocol>) -> std::vector<Http::Protocol> {
         return {Http::Protocol::Http2};
       });
 

--- a/source/extensions/filters/http/istio_stats/istio_stats.cc
+++ b/source/extensions/filters/http/istio_stats/istio_stats.cc
@@ -54,7 +54,7 @@ namespace {
 
 constexpr absl::string_view NamespaceKey = "/ns/";
 
-absl::optional<absl::string_view> getNamespace(absl::string_view principal) {
+std::optional<absl::string_view> getNamespace(absl::string_view principal) {
   // The namespace is a substring in principal with format:
   // "<DOMAIN>/ns/<NAMESPACE>/sa/<SERVICE-ACCOUNT>". '/' is not allowed to
   // appear in actual content except as delimiter between tokens.
@@ -87,7 +87,7 @@ absl::string_view extractMapString(const Protobuf::Struct& metadata, const std::
   return extractString(it->second.struct_value(), key);
 }
 
-absl::optional<Istio::Common::WorkloadMetadataObject>
+std::optional<Istio::Common::WorkloadMetadataObject>
 extractEndpointMetadata(const StreamInfo::StreamInfo& info) {
   auto upstream_info = info.upstreamInfo();
   auto upstream_host = upstream_info ? upstream_info->upstreamHost() : nullptr;
@@ -391,7 +391,7 @@ struct MetricOverrides : public Logger::Loggable<Logger::Id::filter> {
   // Initial transformation: metrics dropped.
   absl::flat_hash_set<Stats::StatName> drop_;
   // Second transformation: tags changed.
-  using TagOverrides = absl::flat_hash_map<Stats::StatName, absl::optional<uint32_t>>;
+  using TagOverrides = absl::flat_hash_map<Stats::StatName, std::optional<uint32_t>>;
   absl::flat_hash_map<Stats::StatName, TagOverrides> tag_overrides_;
   // Third transformation: tags added.
   using TagAdditions = std::vector<std::pair<Stats::StatName, uint32_t>>;
@@ -426,7 +426,7 @@ struct MetricOverrides : public Logger::Loggable<Logger::Id::filter> {
     }
     return out;
   }
-  absl::optional<uint32_t> getOrCreateExpression(const std::string& expr, bool int_expr) {
+  std::optional<uint32_t> getOrCreateExpression(const std::string& expr, bool int_expr) {
     const auto& it = expression_ids_.find(expr);
     if (it != expression_ids_.end()) {
       return {it->second};
@@ -973,7 +973,7 @@ private:
   void populatePeerInfo(const StreamInfo::StreamInfo& info,
                         const StreamInfo::FilterState& filter_state) {
     // Compute peer info with client-side fallbacks.
-    absl::optional<Istio::Common::WorkloadMetadataObject> peer;
+    std::optional<Istio::Common::WorkloadMetadataObject> peer;
     auto object = peerInfo(config_->reporter(), filter_state);
     if (object) {
       peer.emplace(object.value());
@@ -1256,7 +1256,7 @@ private:
   bool peer_read_{false};
   uint64_t bytes_sent_{0};
   uint64_t bytes_received_{0};
-  absl::optional<bool> mutual_tls_;
+  std::optional<bool> mutual_tls_;
   bool is_grpc_{false};
   uint64_t request_message_count_{0};
   uint64_t response_message_count_{0};

--- a/source/extensions/filters/http/peer_metadata/filter.cc
+++ b/source/extensions/filters/http/peer_metadata/filter.cc
@@ -37,8 +37,8 @@ public:
       : downstream_(downstream),
         metadata_provider_(Extensions::Common::WorkloadDiscovery::GetProvider(factory_context)),
         local_info_(factory_context.localInfo()) {}
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
 
 private:
   const bool downstream_;
@@ -46,8 +46,8 @@ private:
   const LocalInfo::LocalInfo& local_info_;
 };
 
-absl::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& info,
-                                                   Http::HeaderMap& headers, Context&) const {
+std::optional<PeerInfo> XDSMethod::derivePeerInfo(const StreamInfo::StreamInfo& info,
+                                                  Http::HeaderMap& headers, Context&) const {
   if (!metadata_provider_) {
     return {};
   }
@@ -123,8 +123,8 @@ MXMethod::MXMethod(bool downstream, const absl::flat_hash_set<std::string> addit
   tls_.set([](Event::Dispatcher&) { return std::make_shared<MXCache>(); });
 }
 
-absl::optional<PeerInfo> MXMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
-                                                  Http::HeaderMap& headers, Context& ctx) const {
+std::optional<PeerInfo> MXMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
+                                                 Http::HeaderMap& headers, Context& ctx) const {
   const auto peer_id_header = headers.get(Headers::get().ExchangeMetadataHeaderId);
   if (downstream_) {
     ctx.request_peer_id_received_ = !peer_id_header.empty();
@@ -148,7 +148,7 @@ void MXMethod::remove(Http::HeaderMap& headers) const {
   headers.remove(Headers::get().ExchangeMetadataHeader);
 }
 
-absl::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view value) const {
+std::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_view value) const {
   // This code is copied from:
   // https://github.com/istio/proxy/blob/release-1.18/extensions/metadata_exchange/plugin.cc#L116
   auto& cache = tls_->cache_;
@@ -159,7 +159,7 @@ absl::optional<PeerInfo> MXMethod::lookup(absl::string_view id, absl::string_vie
     }
   }
   const auto bytes = Base64::decodeWithoutPadding(value);
-  google::protobuf::Struct metadata;
+  Envoy::Protobuf::Struct metadata;
   if (!metadata.ParseFromString(bytes)) {
     return {};
   }
@@ -179,14 +179,14 @@ public:
   UpstreamFilterStateMethod(
       const io::istio::http::peer_metadata::Config_UpstreamFilterState& config)
       : peer_metadata_key_(config.peer_metadata_key()) {}
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
 
 private:
   std::string peer_metadata_key_;
 };
 
-absl::optional<PeerInfo>
+std::optional<PeerInfo>
 UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Http::HeaderMap&,
                                           Context&) const {
   const auto upstream = info.upstreamInfo();
@@ -206,7 +206,7 @@ UpstreamFilterStateMethod::derivePeerInfo(const StreamInfo::StreamInfo& info, Ht
     return {};
   }
 
-  google::protobuf::Struct obj;
+  Envoy::Protobuf::Struct obj;
   if (!obj.ParseFromString(absl::string_view(cel_state->value()))) {
     return {};
   }
@@ -233,7 +233,7 @@ std::string MXPropagationMethod::computeValue(
   const auto obj = Istio::Common::convertStructToWorkloadMetadata(
       factory_context.localInfo().node().metadata(), additional_labels,
       factory_context.localInfo().node().locality());
-  const google::protobuf::Struct metadata = Istio::Common::convertWorkloadMetadataToStruct(*obj);
+  const Envoy::Protobuf::Struct metadata = Istio::Common::convertWorkloadMetadataToStruct(*obj);
   const std::string metadata_bytes = Istio::Common::serializeToStringDeterministic(metadata);
   return Base64::encode(metadata_bytes.data(), metadata_bytes.size());
 }
@@ -271,9 +271,9 @@ void BaggagePropagationMethod::inject(const StreamInfo::StreamInfo&, Http::Heade
 
 BaggageDiscoveryMethod::BaggageDiscoveryMethod() {}
 
-absl::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
-                                                                Http::HeaderMap& headers,
-                                                                Context&) const {
+std::optional<PeerInfo> BaggageDiscoveryMethod::derivePeerInfo(const StreamInfo::StreamInfo&,
+                                                               Http::HeaderMap& headers,
+                                                               Context&) const {
   const auto baggage_header = headers.get(Headers::get().Baggage);
   if (baggage_header.empty()) {
     return {};

--- a/source/extensions/filters/http/peer_metadata/filter.h
+++ b/source/extensions/filters/http/peer_metadata/filter.h
@@ -50,8 +50,8 @@ struct Context {
 class DiscoveryMethod {
 public:
   virtual ~DiscoveryMethod() = default;
-  virtual absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                                  Context&) const PURE;
+  virtual std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                                 Context&) const PURE;
   virtual void remove(Http::HeaderMap&) const {}
 };
 
@@ -61,12 +61,12 @@ class MXMethod : public DiscoveryMethod {
 public:
   MXMethod(bool downstream, const absl::flat_hash_set<std::string> additional_labels,
            Server::Configuration::ServerFactoryContext& factory_context);
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
   void remove(Http::HeaderMap&) const override;
 
 private:
-  absl::optional<PeerInfo> lookup(absl::string_view id, absl::string_view value) const;
+  std::optional<PeerInfo> lookup(absl::string_view id, absl::string_view value) const;
   const bool downstream_;
   struct MXCache : public ThreadLocal::ThreadLocalObject {
     absl::flat_hash_map<std::string, PeerInfo> cache_;
@@ -116,8 +116,8 @@ private:
 class BaggageDiscoveryMethod : public DiscoveryMethod, public Logger::Loggable<Logger::Id::filter> {
 public:
   BaggageDiscoveryMethod();
-  absl::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
-                                          Context&) const override;
+  std::optional<PeerInfo> derivePeerInfo(const StreamInfo::StreamInfo&, Http::HeaderMap&,
+                                         Context&) const override;
 };
 
 class FilterConfig : public Logger::Loggable<Logger::Id::filter> {

--- a/source/extensions/filters/http/peer_metadata/filter_test.cc
+++ b/source/extensions/filters/http/peer_metadata/filter_test.cc
@@ -561,7 +561,7 @@ TEST_F(PeerMetadataTest, UpstreamMXPropagationWithNodeLocality) {
   const std::string encoded_metadata = std::string(mx_header[0]->value().getStringView());
   const std::string metadata_bytes = Base64::decode(encoded_metadata);
 
-  google::protobuf::Struct metadata;
+  Envoy::Protobuf::Struct metadata;
   ASSERT_TRUE(metadata.ParseFromString(metadata_bytes));
   // Check that locality fields are present
   ASSERT_TRUE(metadata.fields().contains("REGION"));
@@ -682,7 +682,7 @@ TEST_F(PeerMetadataTest, CelExpressionCompatibility) {
   ASSERT_NE(proto, nullptr);
 
   // Verify the protobuf contains expected data
-  const auto* struct_proto = dynamic_cast<const google::protobuf::Struct*>(proto.get());
+  const auto* struct_proto = dynamic_cast<const Envoy::Protobuf::Struct*>(proto.get());
   ASSERT_NE(struct_proto, nullptr);
   EXPECT_EQ("production", extractString(*struct_proto, "namespace"));
   EXPECT_EQ("bar", extractString(*struct_proto, "workload"));
@@ -1313,7 +1313,7 @@ TEST_F(PeerMetadataTest, BaggagePropagationWithNodeLocality) {
 // Test MX discovery preserves locality from incoming headers
 TEST_F(PeerMetadataTest, MXDiscoveryPreservesLocality) {
   // Create test MX header with locality
-  google::protobuf::Struct test_metadata;
+  Envoy::Protobuf::Struct test_metadata;
   (*test_metadata.mutable_fields())[Istio::Common::NamespaceMetadataField].set_string_value(
       "mx-locality-ns");
   (*test_metadata.mutable_fields())[Istio::Common::ClusterMetadataField].set_string_value(

--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange.h
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange.h
@@ -134,7 +134,7 @@ private:
   void tryReadInitialProxyHeader(Buffer::Instance& data);
 
   // Tries to read data after initial proxy header. This is currently in the
-  // form of google::protobuf::any which encapsulates google::protobuf::struct.
+  // form of Envoy::Protobuf::any which encapsulates Envoy::Protobuf::struct.
   void tryReadProxyData(Buffer::Instance& data);
 
   // Helper function to share the metadata with other filters.
@@ -161,7 +161,7 @@ private:
   const std::string ExchangeMetadataHeader = "x-envoy-peer-metadata";
   const std::string ExchangeMetadataHeaderId = "x-envoy-peer-metadata-id";
 
-  // Type url of google::protobuf::struct.
+  // Type url of Envoy::Protobuf::struct.
   const std::string StructTypeUrl = "type.googleapis.com/google.protobuf.Struct";
 
   // Captures the state machine of what is going on in the filter.

--- a/source/extensions/filters/network/metadata_exchange/metadata_exchange_test.cc
+++ b/source/extensions/filters/network/metadata_exchange/metadata_exchange_test.cc
@@ -26,7 +26,7 @@
 #include "test/mocks/protobuf/mocks.h"
 #include "test/mocks/server/server_factory_context.h"
 
-using ::google::protobuf::util::MessageDifferencer;
+using ::Envoy::Protobuf::util::MessageDifferencer;
 using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;

--- a/source/extensions/filters/network/peer_metadata/peer_metadata.cc
+++ b/source/extensions/filters/network/peer_metadata/peer_metadata.cc
@@ -93,7 +93,7 @@ Network::FilterStatus Filter::onWrite(Buffer::Instance& buffer, bool) {
     // for peer metadata anymore, if the upstream sent it, we'd have it by
     // now. So we can check if the peer metadata is available or not, and if
     // no peer metadata available, we can give up waiting for it.
-    std::optional<google::protobuf::Any> peer_metadata = discoverPeerMetadata();
+    std::optional<Envoy::Protobuf::Any> peer_metadata = discoverPeerMetadata();
     if (peer_metadata) {
       propagatePeerMetadata(*peer_metadata);
     } else {
@@ -137,7 +137,7 @@ bool Filter::disableDiscovery() const {
 //
 // NOTE: It's safe to call this function during any step of processing - it
 // will not do anything if the filter is not in the right state.
-std::optional<google::protobuf::Any> Filter::discoverPeerMetadata() {
+std::optional<Envoy::Protobuf::Any> Filter::discoverPeerMetadata() {
   ENVOY_LOG(trace, "Trying to discover peer metadata from filter state set by TCP Proxy");
   ASSERT(write_callbacks_);
 
@@ -177,13 +177,13 @@ std::optional<google::protobuf::Any> Filter::discoverPeerMetadata() {
       ::Istio::Common::convertBaggageToWorkloadMetadata(baggage[0]->value().getStringView(),
                                                         identity);
 
-  google::protobuf::Struct data = convertWorkloadMetadataToStruct(*metadata);
-  google::protobuf::Any wrapped;
+  Envoy::Protobuf::Struct data = convertWorkloadMetadataToStruct(*metadata);
+  Envoy::Protobuf::Any wrapped;
   wrapped.PackFrom(data);
   return wrapped;
 }
 
-void Filter::propagatePeerMetadata(const google::protobuf::Any& peer_metadata) {
+void Filter::propagatePeerMetadata(const Envoy::Protobuf::Any& peer_metadata) {
   ENVOY_LOG(trace, "Sending peer metadata downstream with the data stream");
   ASSERT(write_callbacks_);
 
@@ -347,14 +347,14 @@ bool UpstreamFilter::consumePeerMetadata(Buffer::Instance& buffer, bool end_stre
   std::string_view data{static_cast<const char*>(buffer.linearize(peer_metadata_size)),
                         peer_metadata_size};
   data = data.substr(sizeof(PeerMetadataHeader));
-  google::protobuf::Any any;
+  Envoy::Protobuf::Any any;
   if (!any.ParseFromArray(data.data(), data.size())) {
     ENVOY_LOG(trace, "Failed to parse peer metadata proto from the data stream");
     populateNoPeerMetadata();
     return true;
   }
 
-  google::protobuf::Struct peer_metadata;
+  Envoy::Protobuf::Struct peer_metadata;
   if (!any.UnpackTo(&peer_metadata)) {
     ENVOY_LOG(trace, "Failed to unpack peer metadata struct");
     populateNoPeerMetadata();

--- a/source/extensions/filters/network/peer_metadata/peer_metadata.h
+++ b/source/extensions/filters/network/peer_metadata/peer_metadata.h
@@ -153,8 +153,8 @@ public:
 private:
   void populateBaggage();
   bool disableDiscovery() const;
-  std::optional<google::protobuf::Any> discoverPeerMetadata();
-  void propagatePeerMetadata(const google::protobuf::Any& peer_metadata);
+  std::optional<Envoy::Protobuf::Any> discoverPeerMetadata();
+  void propagatePeerMetadata(const Envoy::Protobuf::Any& peer_metadata);
   void propagateNoPeerMetadata();
 
   PeerMetadataState state_ = PeerMetadataState::WaitingForData;

--- a/source/extensions/filters/network/peer_metadata/peer_metadata_test.cc
+++ b/source/extensions/filters/network/peer_metadata/peer_metadata_test.cc
@@ -63,7 +63,7 @@ bool parsePeerMetadataHeader(const std::string& data, PeerMetadataHeader& header
 }
 
 bool parsePeerMetadata(const std::string& data, PeerMetadataHeader& header,
-                       google::protobuf::Any& any) {
+                       Envoy::Protobuf::Any& any) {
   if (!parsePeerMetadataHeader(data, header)) {
     return false;
   }
@@ -111,7 +111,7 @@ public:
   }
 
   void disablePeerDiscovery() {
-    google::protobuf::Struct metadata;
+    Envoy::Protobuf::Struct metadata;
     auto fields = metadata.mutable_fields();
     (*fields)[FilterNames::get().DisableDiscoveryField].set_bool_value(true);
     (*stream_info_.metadata_.mutable_filter_metadata())[FilterNames::get().Name].MergeFrom(
@@ -194,12 +194,12 @@ TEST_F(PeerMetadataFilterTest, TestPeerMetadataDiscoveredAndPropagated) {
   EXPECT_FALSE(injected.empty());
 
   PeerMetadataHeader header;
-  google::protobuf::Any any;
+  Envoy::Protobuf::Any any;
   EXPECT_TRUE(parsePeerMetadata(injected, header, any));
   EXPECT_EQ(header.magic, PeerMetadataHeader::magic_number);
   EXPECT_GT(header.data_size, 0);
 
-  google::protobuf::Struct metadata;
+  Envoy::Protobuf::Struct metadata;
   EXPECT_TRUE(any.UnpackTo(&metadata));
 
   std::unique_ptr<Istio::Common::WorkloadMetadataObject> workload =
@@ -321,8 +321,8 @@ std::string encodePeerMetadataHeaderOnly(const PeerMetadataHeader& header) {
 std::string encodeMetadataOnly(std::string_view baggage, std::string_view identity) {
   std::unique_ptr<::Istio::Common::WorkloadMetadataObject> metadata =
       ::Istio::Common::convertBaggageToWorkloadMetadata(baggage, identity);
-  google::protobuf::Struct data = convertWorkloadMetadataToStruct(*metadata);
-  google::protobuf::Any wrapped;
+  Envoy::Protobuf::Struct data = convertWorkloadMetadataToStruct(*metadata);
+  Envoy::Protobuf::Any wrapped;
   wrapped.PackFrom(data);
   return wrapped.SerializeAsString();
 }
@@ -363,7 +363,7 @@ public:
       return std::nullopt;
     }
 
-    google::protobuf::Struct obj;
+    Envoy::Protobuf::Struct obj;
     if (!obj.ParseFromString(std::string_view(cel_state->value()))) {
       return std::nullopt;
     }
@@ -441,7 +441,7 @@ TEST_F(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
   initialize();
   setUpstreamHost(makeInternalListenerHost("connect_originate"));
 
-  google::protobuf::Struct metadata;
+  Envoy::Protobuf::Struct metadata;
   auto fields = metadata.mutable_fields();
   (*fields)[FilterNames::get().DisableDiscoveryField].set_bool_value(true);
   (*hostMetadata().mutable_filter_metadata())[FilterNames::get().Name].MergeFrom(metadata);
@@ -462,7 +462,7 @@ TEST_F(PeerMetadataUpstreamFilterTest, TestPeerMetadataNotConsumedWhenDisabledVi
   initialize();
   setUpstreamHost(makeInternalListenerHost("connect_originate"));
 
-  google::protobuf::Struct metadata;
+  Envoy::Protobuf::Struct metadata;
   auto fields = metadata.mutable_fields();
   (*fields)[FilterNames::get().DisableDiscoveryField].set_bool_value(true);
   (*clusterMetadata().mutable_filter_metadata())[FilterNames::get().Name].MergeFrom(metadata);


### PR DESCRIPTION
**What this PR does / why we need it**:

This is purely naming change PR and without touching any logic.

1. absl::optional -> std::optional because the absl plan to deprecate the absl::optional and Envoy did part change.
2. google::protobuf::* -> Envoy::Protobuf::* because Envoy try to avoid directly google:: protobuf* namespace usage.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
