### PR TITLE
Update Envoy

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,8 +10,8 @@ import %workspace%/envoy.bazelrc
 # The 3GB limit causes memory pressure during large downloads which breaks gRPC remote cache connections
 # Also increase direct buffer memory for large file transfers
 # See: https://github.com/istio/proxy/pull/6726
-startup --host_jvm_args=-Xmx4g
-startup --host_jvm_args=-XX:MaxDirectMemorySize=4g
+startup --host_jvm_args=-Xmx5g
+startup --host_jvm_args=-XX:MaxDirectMemorySize=5g
 
 # Overrides workspace_status_command
 build --workspace_status_command=bazel/bazel_get_workspace_status

--- a/.bazelrc
+++ b/.bazelrc
@@ -10,8 +10,8 @@ import %workspace%/envoy.bazelrc
 # The 3GB limit causes memory pressure during large downloads which breaks gRPC remote cache connections
 # Also increase direct buffer memory for large file transfers
 # See: https://github.com/istio/proxy/pull/6726
-startup --host_jvm_args=-Xmx5g
-startup --host_jvm_args=-XX:MaxDirectMemorySize=5g
+startup --host_jvm_args=-Xmx4608m
+startup --host_jvm_args=-XX:MaxDirectMemorySize=4608m
 
 # Overrides workspace_status_command
 build --workspace_status_command=bazel/bazel_get_workspace_status

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,10 +22,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # 1. Determine SHA256 `wget https://github.com/envoyproxy/envoy/archive/$COMMIT.tar.gz && sha256sum $COMMIT.tar.gz`
 # 2. Update .bazelversion, envoy.bazelrc and .bazelrc if needed.
 #
-# Commit date: 2026-06-30
-ENVOY_SHA = "4f1e006e2db1c4263924993bc1dae3ed9e3b886a"
+# Commit date: 2026-07-20
+ENVOY_SHA = "4e9f5e4564518f46cdf05ea26745d317775857dc"
 
-ENVOY_SHA256 = "0c261fd289aa7ff8b3b0691163e83f5ae56010f8827320b3a388b654d8c708ce"
+ENVOY_SHA256 = "e63e7639df6a04ab11d61abe6d6c5ed94bcea1035cca7ccf259c4650522e1b6a"
 
 ENVOY_ORG = "envoyproxy"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a replacement for #7167 that bumps Envoy version, but to work around build failures this PR also bumps Bazel JVM heap size.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
