### PR TITLE
Remove unnecessary line from bazel file

### DIFF
--- a/bazel/extension_config/extensions_build_config.bzl
+++ b/bazel/extension_config/extensions_build_config.bzl
@@ -1,5 +1,3 @@
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
-
 ENVOY_EXTENSIONS = {
     #
     # Access loggers


### PR DESCRIPTION
`dicts` is not used anywhere.
