### PR TITLE
Use remote cache

### DIFF
--- a/prow/proxy-common.inc
+++ b/prow/proxy-common.inc
@@ -69,17 +69,19 @@ CREDS="google_default_credentials"
 # Use GCP service account when available.
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   echo "Using legacy GOOGLE_APPLICATION_CREDENTIALS. Move to workload identity!" >&2
-  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-  CREDS="google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" CREDS="google_credentials=${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
 
 BAZEL_BUILD_RBE_JOBS="${BAZEL_BUILD_RBE_JOBS:-200}"
-if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
-  if [[ "${BAZEL_BUILD_RBE_JOBS}" -gt 0 ]]; then
-    echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (execute)"
-    export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --${CREDS} --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
-  elif [[ -n "${BAZEL_BUILD_RBE_CACHE}" ]]; then
+if [[ "${BAZEL_BUILD_RBE_JOBS}" -gt 0 && -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
+  echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (execute)"
+  export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --${CREDS} --config=remote-clang-libc++ --config=remote-ci --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --jobs=${BAZEL_BUILD_RBE_JOBS}"
+elif [[ -n "${BAZEL_BUILD_RBE_CACHE}" ]]; then
+  if [[ -n "${BAZEL_BUILD_RBE_INSTANCE}" ]]; then
     echo "Using RBE: ${BAZEL_BUILD_RBE_INSTANCE} (cache)"
     export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --${CREDS} --remote_instance_name=${BAZEL_BUILD_RBE_INSTANCE} --remote_cache=${BAZEL_BUILD_RBE_CACHE}"
+  else
+    echo "Using remote cache: ${BAZEL_BUILD_RBE_CACHE}"
+    export BAZEL_BUILD_ARGS="${BAZEL_BUILD_ARGS} --remote_cache=${BAZEL_BUILD_RBE_CACHE}"
   fi
 fi

--- a/scripts/release-binary.sh
+++ b/scripts/release-binary.sh
@@ -173,7 +173,10 @@ do
   if [ -n "${DST}" ]; then
     # Copy it to the bucket.
     echo "Copying ${BINARY_NAME} ${SHA256_NAME} to ${DST}/"
-    gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DWP_NAME}" "${DST}/"
+    # only do this if AWS_CONTAINER_CREDENTIALS_FULL_URI is not set, otherwise we will get an error from gsutil
+    if [ -z "${AWS_CONTAINER_CREDENTIALS_FULL_URI}" ]; then
+        gsutil cp "${BINARY_NAME}" "${SHA256_NAME}" "${DWP_NAME}" "${DST}/"
+    fi
 
     R2_DST="${DST/gs:\/\//s3:\/\/}"
     ENDPOINT="$(echo "${CF_CREDENTIALS}" | jq -r '.endpoint' | tr -d '\n')"


### PR DESCRIPTION
This allows us to use a remote cache that is just a storage/cache endpoint by setting `BAZEL_BUILD_RBE_CACHE` to the url of the cache and `BAZEL_BUILD_RBE_INSTANCE=""`