### PR TITLE
Enable kill_request filter in the proxy build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,6 +45,9 @@ build:macos --define tcmalloc=disabled
 # Build with embedded V8-based WebAssembly runtime.
 build --define wasm=v8
 
+# Enable kill_request filter (disabled by default in Envoy via enabled_default = False).
+build --@envoy//source/extensions/filters/http/kill_request:enabled
+
 # Build Proxy-WASM plugins as native extensions.
 build --copt -DNULL_PLUGIN
 

--- a/test/envoye2e/basic_flow/extensions_test.go
+++ b/test/envoye2e/basic_flow/extensions_test.go
@@ -61,8 +61,6 @@ var excludedExtensions = map[string]string{
 	// WASM runtimes gated behind envoy_select_wasm_wamr / envoy_select_wasm_wasmtime
 	"envoy.wasm.runtime.wamr":     "requires wasm_wamr build flag",
 	"envoy.wasm.runtime.wasmtime": "requires wasm_wasmtime build flag",
-	// Extra extension requiring ENVOY_HAS_EXTRA_EXTENSIONS=true at build time
-	"envoy.filters.http.kill_request": "extra extension, not built by default",
 	// Registers as ProactiveResourceMonitorFactory, not included in /server_info extension listing
 	"envoy.resource_monitors.downstream_connections": "proactive resource monitor, not in /server_info",
 }


### PR DESCRIPTION
The `kill_request` extension has `enabled_default = False` in its Envoy BUILD file, so listing it in `extensions_build_config.bzl` alone is not enough — it compiles as an empty target. Add the Bazel flag to `.bazelrc` so the filter is actually included in the binary.
